### PR TITLE
Remove unused variables

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -39,7 +39,7 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
 
 
     // set reference point, paddings
-    int paddingRight            = 14;
+    // int paddingRight            = 14;
     int paddingTop              = 490;
     int titleVersionVSpace      = 17;
     int titleCopyrightVSpace    = 22;

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -40,7 +40,7 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
 
     // set reference point, paddings
     // int paddingRight            = 14;
-    int paddingTop              = 490;
+    // int paddingTop              = 490;
     int titleVersionVSpace      = 17;
     int titleCopyrightVSpace    = 22;
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -41,7 +41,7 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
     // set reference point, paddings
     // int paddingRight            = 14;
     // int paddingTop              = 490;
-    int titleVersionVSpace      = 17;
+    // int titleVersionVSpace      = 17;
     // int titleCopyrightVSpace    = 22;
 
     float fontFactor            = 1.0;

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -37,13 +37,6 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
     // no window decorations
     setWindowFlags(Qt::FramelessWindowHint);
 
-
-    // set reference point, paddings
-    // int paddingRight            = 14;
-    // int paddingTop              = 490;
-    // int titleVersionVSpace      = 17;
-    // int titleCopyrightVSpace    = 22;
-
     float fontFactor            = 1.0;
     float devicePixelRatio      = 1.0;
     devicePixelRatio = static_cast<QGuiApplication*>(QCoreApplication::instance())->devicePixelRatio();

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -42,7 +42,7 @@ SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) 
     // int paddingRight            = 14;
     // int paddingTop              = 490;
     int titleVersionVSpace      = 17;
-    int titleCopyrightVSpace    = 22;
+    // int titleCopyrightVSpace    = 22;
 
     float fontFactor            = 1.0;
     float devicePixelRatio      = 1.0;


### PR DESCRIPTION
### Description
Some warnings are raised when building the GUI wallet because there are variables that were declared but were never used. I noticed that the code that uses those variables was commented out and I assumed that it's important so I've also commented out the variable declarations.

### Notes
The following warnings were resolved:
- `warning: unused variable 'paddingRight' [-Wunused-variable]`
- `warning: unused variable 'paddingTop' [-Wunused-variable]`
- `warning: unused variable 'titleCopyrightVSpace' [-Wunused-variable]`
- `warning: unused variable 'titleVersionVSpace' [-Wunused-variable]`

### BTC/BGL PR reward address
if applicable, please type your reward wallet address here
