### PR TITLE
doc update instructions for running functional tests. Fixes #19

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -29,6 +29,9 @@ The ZMQ functional test requires a python ZMQ library. To install it:
 - on Unix, run `sudo apt-get install python3-zmq`
 - on mac OS, run `pip3 install pyzmq`
 
+##### Install SHA-3 wrapper (keccak) for Python
+`pip install pysha3`
+
 #### Running the tests
 
 Individual tests can be run by directly calling the test script, e.g.:

--- a/test/README.md
+++ b/test/README.md
@@ -30,7 +30,7 @@ The ZMQ functional test requires a python ZMQ library. To install it:
 - on mac OS, run `pip3 install pyzmq`
 
 ##### Install SHA-3 wrapper (keccak) for Python
-`pip install pysha3`
+`pip3 install pysha3`
 
 #### Running the tests
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -28,6 +28,8 @@ import socket
 import struct
 import time
 
+import sha3
+
 from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, assert_equal
 

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -28,8 +28,6 @@ import socket
 import struct
 import time
 
-import sha3
-
 from test_framework.siphash import siphash256
 from test_framework.util import hex_str_to_bytes, assert_equal
 


### PR DESCRIPTION
### Description
Most functional tests fail if you haven't installed the pysha3 python package locally which is a wrapper around the optimized Keccak Code Package

### Notes
This pull requests updates the documentation to make it easier for anyone who wants to run functional tests to do so with no problem.

### BTC/BGL PR reward address
1JgM4YQTwrn2CPpmHjUwxLx9qofBwz7QST
