### PR TITLE
Fix deployment position info

### DIFF
--- a/src/versionbitsinfo.cpp
+++ b/src/versionbitsinfo.cpp
@@ -12,6 +12,10 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.gbt_force =*/ true,
     },
     {
+        /*.name =*/ "taproot_old",
+        /*.gbt_force =*/ true,
+    },
+    {
         /*.name =*/ "taproot",
         /*.gbt_force =*/ true,
     },


### PR DESCRIPTION
### Description
Version bit description was missing for index=2 (taproot) as previous taproot activation (that did not pass block threshold) is at deployment position too (for now). That resulted in few RPC calls failing (in particular, getblocktemplate).

