### PR TITLE
URL fixes, documentation improvements

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,8 +57,8 @@ test_script:
 - cmd: python test\util\rpcauth-test.py
 # Fee estimation test failing on appveyor with: WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted.
 # functional tests disabled for now. See
-# https://github.com/BGL/BGL/pull/18626#issuecomment-613396202
-# https://github.com/BGL/BGL/issues/18623
+# https://github.com/bitcoin/bitcoin/pull/18626#issuecomment-613396202
+# https://github.com/bitcoin/bitcoin/issues/18623
 # - cmd: python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --failfast --exclude feature_fee_estimation
 artifacts:
 #- path: BGL-%APPVEYOR_BUILD_VERSION%.zip

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,11 +4,6 @@ what is the goal of the pull request
 Pull requests without a rationale and clear improvement may be closed
 immediately.
 
-GUI-related pull requests should be opened against
-https://github.com/BGL-core/gui
-first. See CONTRIBUTING.md
--->
-
 ### Notes
 implementation details, hints for reviewers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,7 +417,7 @@ Rebased-From: <commit hash of the original commit>
 ```
 
 Have a look at [an example backport PR](
-https://github.com/BGL/BGL/pull/16189).
+https://github.com/bitcoin/bitcoin/pull/16189).
 
 Also see the [backport.py script](
 https://github.com/BGL-core/BGL-maintainer-tools#backport).

--- a/build_msvc/BGL_config.h
+++ b/build_msvc/BGL_config.h
@@ -244,7 +244,7 @@
 #define LT_OBJDIR ".libs/"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "https://github.com/BGL/BGL/issues"
+#define PACKAGE_BUGREPORT "https://github.com/BitgesellOfficial/bitgesell/issues"
 
 /* Define to the full name of this package. */
 #define PACKAGE_NAME "BGL Core"

--- a/build_msvc/BGL_config.h
+++ b/build_msvc/BGL_config.h
@@ -256,7 +256,7 @@
 #define PACKAGE_TARNAME "BGL"
 
 /* Define to the home page for this package. */
-#define PACKAGE_URL "https://BGLcore.org/"
+#define PACKAGE_URL "https://bitgesell.ca/"
 
 /* Define to the version of this package. */
 #define PACKAGE_VERSION "21.99.0"

--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -5,7 +5,7 @@ Introduction
 ---------------------
 Solution and project files to build the BGL Core applications `msbuild` or Visual Studio can be found in the build_msvc directory. The build has been tested with Visual Studio 2017 and 2019.
 
-Building with Visual Studio is an alternative to the Linux based [cross-compiler build](https://github.com/BGL/BGL/blob/master/doc/build-windows.md).
+Building with Visual Studio is an alternative to the Linux based [cross-compiler build](https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/build-windows.md).
 
 Quick Start
 ---------------------
@@ -19,7 +19,7 @@ msbuild /m BGL.sln /p:Platform=x64 /p:Configuration=Release /t:build
 
 Dependencies
 ---------------------
-A number of [open source libraries](https://github.com/BGL/BGL/blob/master/doc/dependencies.md) are required in order to be able to build BGL Core.
+A number of [open source libraries](https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/dependencies.md) are required in order to be able to build BGL Core.
 
 Options for installing the dependencies in a Visual Studio compatible manner are:
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ define(_CLIENT_VERSION_IS_RELEASE, true)
 define(_COPYRIGHT_YEAR, 2021)
 define(_COPYRIGHT_HOLDERS,[The %s developers])
 define(_COPYRIGHT_HOLDERS_SUBSTITUTION,[[BGL Core]])
-AC_INIT([BGL Core],m4_join([.], _CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MINOR, _CLIENT_VERSION_BUILD)m4_if(_CLIENT_VERSION_RC, [0], [], [rc]_CLIENT_VERSION_RC),[https://github.com/BGL/BGL/issues],[BGL],[https://BGLcore.org/])
+AC_INIT([BGL Core],m4_join([.], _CLIENT_VERSION_MAJOR, _CLIENT_VERSION_MINOR, _CLIENT_VERSION_BUILD)m4_if(_CLIENT_VERSION_RC, [0], [], [rc]_CLIENT_VERSION_RC),[https://github.com/BitgesellOfficial/bitgesell/issues],[BGL],[https://bitgesell.ca/])
 AC_CONFIG_SRCDIR([src/validation.cpp])
 AC_CONFIG_HEADERS([src/config/BGL-config.h])
 AC_CONFIG_AUX_DIR([build-aux])
@@ -167,7 +167,7 @@ AC_ARG_ENABLE([natpmp-default],
 AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
     [use_tests=$enableval],
-    [use_tests=no])
+    [use_tests=yes])
 
 AC_ARG_ENABLE(gui-tests,
     AS_HELP_STRING([--disable-gui-tests],[do not compile GUI tests (default is to compile if GUI and tests enabled)]),
@@ -343,7 +343,7 @@ AC_ARG_ENABLE([werror],
 AC_ARG_ENABLE([external-signer],
     [AS_HELP_STRING([--enable-external-signer],[compile external signer support (default is no, requires Boost::Process)])],
     [use_external_signer=$enableval],
-    [use_external_signer=no])
+    [use_external_signer=yes])
 
 AC_LANG_PUSH([C++])
 
@@ -480,7 +480,6 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-parameter],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-parameter"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wself-assign],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-self-assign"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
-  AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -167,7 +167,7 @@ AC_ARG_ENABLE([natpmp-default],
 AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
     [use_tests=$enableval],
-    [use_tests=yes])
+    [use_tests=no])
 
 AC_ARG_ENABLE(gui-tests,
     AS_HELP_STRING([--disable-gui-tests],[do not compile GUI tests (default is to compile if GUI and tests enabled)]),
@@ -343,7 +343,7 @@ AC_ARG_ENABLE([werror],
 AC_ARG_ENABLE([external-signer],
     [AS_HELP_STRING([--enable-external-signer],[compile external signer support (default is no, requires Boost::Process)])],
     [use_external_signer=$enableval],
-    [use_external_signer=yes])
+    [use_external_signer=no])
 
 AC_LANG_PUSH([C++])
 
@@ -480,6 +480,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-parameter],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-parameter"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wself-assign],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-self-assign"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
 fi
 

--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -33,7 +33,7 @@ def setup():
     if not os.path.isdir('gitian-builder'):
         subprocess.check_call(['git', 'clone', 'https://github.com/devrandom/gitian-builder.git'])
     if not os.path.isdir('BGL'):
-        subprocess.check_call(['git', 'clone', 'https://github.com/BGL/BGL.git'])
+        subprocess.check_call(['git', 'clone', 'https://github.com/BitgesellOfficial/bitgesell.git'])
     os.chdir('gitian-builder')
     make_image_prog = ['bin/make-base-vm', '--suite', 'focal', '--arch', 'amd64']
     if args.docker:
@@ -157,7 +157,7 @@ def main():
     parser = argparse.ArgumentParser(description='Script for running full Gitian builds.')
     parser.add_argument('-c', '--commit', action='store_true', dest='commit', help='Indicate that the version argument is for a commit or branch')
     parser.add_argument('-p', '--pull', action='store_true', dest='pull', help='Indicate that the version argument is the number of a github repository pull request')
-    parser.add_argument('-u', '--url', dest='url', default='https://github.com/BGL/BGL', help='Specify the URL of the repository. Default is %(default)s')
+    parser.add_argument('-u', '--url', dest='url', default='https://github.com/BitgesellOfficial/bitgesell', help='Specify the URL of the repository. Default is %(default)s')
     parser.add_argument('-v', '--verify', action='store_true', dest='verify', help='Verify the Gitian build')
     parser.add_argument('-b', '--build', action='store_true', dest='build', help='Do a Gitian build')
     parser.add_argument('-s', '--sign', action='store_true', dest='sign', help='Make signed binaries for Windows and MacOS')

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -41,7 +41,7 @@ packages:
 - "binutils-riscv64-linux-gnu"
 - "g++-8-riscv64-linux-gnu"
 remotes:
-- "url": "https://github.com/BGL/BGL.git"
+- "url": "https://github.com/BitgesellOfficial/bitgesell.git"
   "dir": "BGL"
 files: []
 script: |

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -28,7 +28,7 @@ packages:
 - "xorriso"
 - "libtinfo5"
 remotes:
-- "url": "https://github.com/BGL/BGL.git"
+- "url": "https://github.com/BitgesellOfficial/bitgesell.git"
   "dir": "BGL"
 files:
 - "Xcode-11.3.1-11C505-extracted-SDK-with-libcxx-headers.tar.gz"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -23,7 +23,7 @@ packages:
 - "ca-certificates"
 - "python3"
 remotes:
-- "url": "https://github.com/BGL/BGL.git"
+- "url": "https://github.com/BitgesellOfficial/bitgesell.git"
   "dir": "BGL"
 files: []
 script: |

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -220,7 +220,7 @@ EOF
 
 # The packaged config.guess and config.sub are ancient (2009) and can cause build issues.
 # Replace them with modern versions.
-# See https://github.com/BGL/BGL/issues/16064
+# See https://github.com/bitcoin/bitcoin/issues/16064
 CONFIG_GUESS_URL='https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'
 CONFIG_GUESS_HASH='2d1ff7bca773d2ec3c6217118129220fa72d8adda67c7d2bf79994b3129232c1'
 CONFIG_SUB_URL='https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=55eaf3e779455c4e5cc9f82efb5278be8f8f900b'

--- a/contrib/testgen/base58.py
+++ b/contrib/testgen/base58.py
@@ -4,7 +4,7 @@
 '''
 BGL base58 encoding and decoding.
 
-Based on https://BGLtalk.org/index.php?topic=1026.0 (public domain)
+Based on https://bitcointalk.org/index.php?topic=1026.0 (public domain)
 '''
 import hashlib
 
@@ -106,7 +106,7 @@ def get_bcaddress_version(strAddress):
     return ord(version)
 
 if __name__ == '__main__':
-    # Test case (from http://gitorious.org/BGL/python-base58.git)
+    # Test case (from http://gitorious.org/bitcoin/python-base58.git)
     assert get_bcaddress_version('15VjRaDX9zpbA8LVnbrCAFzrVzN7ixHNsC') is 0
     _ohai = 'o hai'.encode('ascii')
     _tmp = b58encode(_ohai)

--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -20,7 +20,7 @@
     alternative is to wrap the contents of `handle` inside `while True`.
 
     A blocking example using python 2.7 can be obtained from the git history:
-    https://github.com/BGL/BGL/blob/37a7fe9e440b83e2364d5498931253937abe9294/contrib/zmq/zmq_sub.py
+    https://github.com/bitcoin/bitcoin/blob/37a7fe9e440b83e2364d5498931253937abe9294/contrib/zmq/zmq_sub.py
 """
 
 import binascii

--- a/debian.minimal/copyright
+++ b/debian.minimal/copyright
@@ -1722,7 +1722,7 @@ Copyright: 2009-2019 The Bitcoin Core developers
 License:   __UNKNOWN__
  Please contribute if you find BGL Core useful. Visit
  <https://BGLcore.org> for further information about the software.
- The source code is available from <https://github.com/BGL/BGL>.
+ The source code is available from <https://github.com/BitgesellOfficial/bitgesell>.
  .
  This is experimental software.
  Distributed under the MIT software license, see the accompanying file COPYING

--- a/debian.minimal/copyright
+++ b/debian.minimal/copyright
@@ -1721,7 +1721,7 @@ Files:     doc/man/BGL-cli.1
 Copyright: 2009-2019 The Bitcoin Core developers
 License:   __UNKNOWN__
  Please contribute if you find BGL Core useful. Visit
- <https://BGLcore.org> for further information about the software.
+ <https://bitgesell.ca> for further information about the software.
  The source code is available from <https://github.com/BitgesellOfficial/bitgesell>.
  .
  This is experimental software.
@@ -2630,7 +2630,7 @@ Files:     contrib/verifybinaries/verify.sh
 Copyright: 2016 The Bitcoin Core developers Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php.
 License:   __UNKNOWN__
  This script attempts to download the signature file SHA256SUMS.asc from
- BGLcore.org and BGL.org and compares them.
+ bitgesell.ca and BGL.org and compares them.
  It first checks if the signature passes, and then downloads the files specified in
  the file, and checks if the hashes of these files match those that are specified
  in the signature file.

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -39,7 +39,7 @@ NO_ZMQ ?=
 NO_UPNP ?=
 NO_NATPMP ?=
 MULTIPROCESS ?=
-FALLBACK_DOWNLOAD_PATH ?= https://BGLcore.org/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://bitgesell.ca/depends-sources
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)

--- a/depends/README.md
+++ b/depends/README.md
@@ -75,7 +75,7 @@ For linux RISC-V 64-bit cross compilation (there are no packages for 32-bit):
 
     sudo apt-get install g++-riscv64-linux-gnu binutils-riscv64-linux-gnu
 
-RISC-V known issue: gcc-7.3.0 and gcc-7.3.1 result in a broken `test_BGL` executable (see https://github.com/BGL/BGL/pull/13543),
+RISC-V known issue: gcc-7.3.0 and gcc-7.3.1 result in a broken `test_BGL` executable (see https://github.com/bitcoin/bitcoin/pull/13543),
 this is apparently fixed in gcc-8.1.0.
 
 For linux S390X cross compilation:

--- a/doc/README.md
+++ b/doc/README.md
@@ -5,7 +5,7 @@ Setup
 ---------------------
 BGL Core is the original BGL client and it builds the backbone of the network. It downloads and, by default, stores the entire history of BGL transactions, which requires a few hundred gigabytes of disk space. Depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
-To download BGL Core, visit [BGLcore.org](https://BGLcore.org/en/download/).
+To download BGL Core, visit [bitgesell.ca](https://bitgesell.ca/en/download/).
 
 Running
 ---------------------
@@ -55,7 +55,7 @@ The BGL repo's [root README](/README.md) contains relevant information on the de
 - [Productivity Notes](productivity.md)
 - [Release Notes](release-notes.md)
 - [Release Process](release-process.md)
-- [Source Code Documentation (External Link)](https://doxygen.BGLcore.org/)
+- [Source Code Documentation (External Link)](https://doxygen.bitgesell.ca/)
 - [Translation Process](translation_process.md)
 - [Translation Strings Policy](translation_strings_policy.md)
 - [JSON-RPC Interface](JSON-RPC-interface.md)

--- a/doc/README_doxygen.md
+++ b/doc/README_doxygen.md
@@ -8,7 +8,7 @@ with no central authority: managing transactions and issuing money are carried o
 
 The software is a community-driven open source project, released under the MIT license.
 
-See https://github.com/BitgesellOfficial/bitgesell and https://BGLcore.org/ for further information about the project.
+See https://github.com/BitgesellOfficial/bitgesell and https://bitgesell.ca/ for further information about the project.
 
 \section Navigation
 Use <a href="modules.html"><code>Modules</code></a>, <a href="namespaces.html"><code>Namespaces</code></a>, <a href="classes.html"><code>Classes</code></a>, or <a href="files.html"><code>Files</code></a> at the top of the page to start navigating the code.

--- a/doc/README_doxygen.md
+++ b/doc/README_doxygen.md
@@ -8,7 +8,7 @@ with no central authority: managing transactions and issuing money are carried o
 
 The software is a community-driven open source project, released under the MIT license.
 
-See https://github.com/BGL/BGL and https://BGLcore.org/ for further information about the project.
+See https://github.com/BitgesellOfficial/bitgesell and https://BGLcore.org/ for further information about the project.
 
 \section Navigation
 Use <a href="modules.html"><code>Modules</code></a>, <a href="namespaces.html"><code>Namespaces</code></a>, <a href="classes.html"><code>Classes</code></a>, or <a href="files.html"><code>Files</code></a> at the top of the page to start navigating the code.

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -22,7 +22,7 @@ libtool
 pkg-config
 python37
 
-git clone https://github.com/BGL/BGL.git
+git clone https://github.com/BitgesellOfficial/bitgesell.git
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -106,7 +106,7 @@ The standard ulimit restrictions in OpenBSD are very strict:
     data(kbytes)         1572864
 
 This is, unfortunately, in some cases not enough to compile some `.cpp` files in the project,
-(see issue [#6658](https://github.com/BGL/BGL/issues/6658)).
+(see issue [#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
 If your user is in the `staff` group the limit can be raised with:
 
     ulimit -d 3000000

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -18,7 +18,7 @@ pkg_add automake # (select highest version, e.g. 1.16)
 pkg_add python # (select highest version, e.g. 3.8)
 pkg_add bash
 
-git clone https://github.com/BGL/BGL.git
+git clone https://github.com/BitgesellOfficial/bitgesell.git
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -71,7 +71,7 @@ brew install berkeley-db4
 
 1. Clone the BGL Core source code:
     ```shell
-    git clone https://github.com/BGL/BGL
+    git clone https://github.com/BitgesellOfficial/bitgesell
     cd BGL
     ```
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -302,7 +302,7 @@ Setup and Build Example: Arch Linux
 This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
 
     pacman -S git base-devel boost libevent python
-    git clone https://github.com/BGL/BGL.git
+    git clone https://github.com/BitgesellOfficial/bitgesell.git
     cd BGL/
     ./autogen.sh
     ./configure --disable-wallet --without-gui --without-miniupnpc

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -313,7 +313,7 @@ other input.
 
 Valgrind is a programming tool for memory debugging, memory leak detection, and
 profiling. The repo contains a Valgrind suppressions file
-([`valgrind.supp`](https://github.com/BGL/BGL/blob/master/contrib/valgrind.supp))
+([`valgrind.supp`](https://github.com/BitgesellOfficial/bitgesell/blob/master/contrib/valgrind.supp))
 which includes known Valgrind warnings in our dependencies that cannot be fixed
 in-tree. Example use:
 

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -434,7 +434,7 @@ Additional resources:
  * [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
  * [GCC Instrumentation Options](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html)
  * [Google Sanitizers Wiki](https://github.com/google/sanitizers/wiki)
- * [Issue #12691: Enable -fsanitize flags in Travis](https://github.com/BGL/BGL/issues/12691)
+ * [Issue #12691: Enable -fsanitize flags in Travis](https://github.com/bitcoin/bitcoin/issues/12691)
 
 Locking/mutex usage notes
 -------------------------
@@ -1080,13 +1080,13 @@ introduce accidental changes.
 
 Some good examples of scripted-diff:
 
-- [scripted-diff: Rename InitInterfaces to NodeContext](https://github.com/BGL/BGL/commit/301bd41a2e6765b185bd55f4c541f9e27aeea29d)
+- [scripted-diff: Rename InitInterfaces to NodeContext](https://github.com/bitcoin/bitcoin/commit/301bd41a2e6765b185bd55f4c541f9e27aeea29d)
 uses an elegant script to replace occurrences of multiple terms in all source files.
 
-- [scripted-diff: Remove g_connman, g_banman globals](https://github.com/BGL/BGL/commit/301bd41a2e6765b185bd55f4c541f9e27aeea29d)
+- [scripted-diff: Remove g_connman, g_banman globals](https://github.com/bitcoin/bitcoin/commit/301bd41a2e6765b185bd55f4c541f9e27aeea29d)
 replaces specific terms in a list of specific source files.
 
-- [scripted-diff: Replace fprintf with tfm::format](https://github.com/BGL/BGL/commit/fac03ec43a15ad547161e37e53ea82482cc508f9)
+- [scripted-diff: Replace fprintf with tfm::format](https://github.com/bitcoin/bitcoin/commit/fac03ec43a15ad547161e37e53ea82482cc508f9)
 does a global replacement but excludes certain directories.
 
 To find all previous uses of scripted diffs in the repository, do:

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1339,4 +1339,4 @@ communication:
 
   Note: This last convention isn't generally followed outside of
   [`src/interfaces/`](../src/interfaces/), though it did come up for discussion
-  before in [#14635](https://github.com/BGL/BGL/pull/14635).
+  before in [#14635](https://github.com/bitcoin/bitcoin/pull/14635).

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -24,7 +24,7 @@ improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -17,7 +17,7 @@ for the process.*
 
 BGL Core version *version* is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-*version*/>
+  <https://bitgesell.ca/bin/BGL-core-*version*/>
 
 This release includes new features, various bug fixes and performance
 improvements, as well as updated translations.
@@ -28,7 +28,7 @@ Please report bugs using the issue tracker at GitHub:
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitgesell.ca/en/list/announcements/join/>
 
 How to Upgrade
 ==============

--- a/doc/release-notes/release-notes-0.10.0.md
+++ b/doc/release-notes/release-notes-0.10.0.md
@@ -7,7 +7,7 @@ bug fixes.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 Upgrading and downgrading
 =========================
@@ -230,7 +230,7 @@ bindings such as [python-BGLlib](https://pypi.python.org/pypi/python-BGLlib) or
 alternative node implementations.
 
 This library is called `libBGLconsensus.so` (or, `.dll` for Windows).
-Its interface is defined in the C header [BGLconsensus.h](https://github.com/BGL/BGL/blob/0.10/src/script/BGLconsensus.h).
+Its interface is defined in the C header [BGLconsensus.h](https://github.com/BitgesellOfficial/bitgesell/blob/master/src/script/BGLconsensus.h).
 
 In its initial version the API includes two functions:
 

--- a/doc/release-notes/release-notes-0.10.0.md
+++ b/doc/release-notes/release-notes-0.10.0.md
@@ -1,6 +1,6 @@
-BGL Core version 0.10.0 is now available from:
+Bitcoin Core version 0.10.0 is now available from:
 
-  https://BGL.org/bin/0.10.0/
+  https://bitcoin.org/bin/0.10.0/
 
 This is a new major version release, bringing both new features and
 bug fixes.
@@ -17,15 +17,15 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrading warning
 ---------------------
 
 Because release 0.10.0 makes use of headers-first synchronization and parallel
 block download (see further), the block files and databases are not
-backwards-compatible with older versions of BGL Core or other software:
+backwards-compatible with older versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -50,7 +50,7 @@ Notable changes
 Faster synchronization
 ----------------------
 
-BGL Core now uses 'headers-first synchronization'. This means that we first
+Bitcoin Core now uses 'headers-first synchronization'. This means that we first
 ask peers for block headers (a total of 27 megabytes, as of December 2014) and
 validate those. In a second stage, when the headers have been discovered, we
 download the blocks. However, as we already know about the whole chain in
@@ -172,7 +172,7 @@ improved by making the signatures constant time and deterministic.
 
 This change is a result of switching signing to use libsecp256k1
 instead of OpenSSL. Libsecp256k1 is a cryptographic library
-optimized for the curve BGL uses which was created by BGL
+optimized for the curve Bitcoin uses which was created by Bitcoin
 Core developer Pieter Wuille.
 
 There exist attacks[1] against most ECC implementations where an
@@ -187,7 +187,7 @@ long time, but this functionality has still not made its
 way into a released version of OpenSSL. Libsecp256k1 achieves
 significantly stronger protection: As far as we're aware this is
 the only deployed implementation of constant time signing for
-the curve BGL uses and we have reason to believe that
+the curve Bitcoin uses and we have reason to believe that
 libsecp256k1 is better tested and more thoroughly reviewed
 than the implementation in OpenSSL.
 
@@ -222,21 +222,21 @@ addresses need to added to the wallet before the payment, though.
 Consensus library
 -----------------
 
-Starting from 0.10.0, the BGL Core distribution includes a consensus library.
+Starting from 0.10.0, the Bitcoin Core distribution includes a consensus library.
 
 The purpose of this library is to make the verification functionality that is
-critical to BGL's consensus available to other applications, e.g. to language
-bindings such as [python-BGLlib](https://pypi.python.org/pypi/python-BGLlib) or
+critical to Bitcoin's consensus available to other applications, e.g. to language
+bindings such as [python-bitcoinlib](https://pypi.python.org/pypi/python-bitcoinlib) or
 alternative node implementations.
 
-This library is called `libBGLconsensus.so` (or, `.dll` for Windows).
-Its interface is defined in the C header [BGLconsensus.h](https://github.com/BitgesellOfficial/bitgesell/blob/master/src/script/BGLconsensus.h).
+This library is called `libbitcoinconsensus.so` (or, `.dll` for Windows).
+Its interface is defined in the C header [bitcoinconsensus.h](https://github.com/bitcoin/bitcoin/blob/0.10/src/script/bitcoinconsensus.h).
 
 In its initial version the API includes two functions:
 
-- `BGLconsensus_verify_script` verifies a script. It returns whether the indicated input of the provided serialized transaction 
+- `bitcoinconsensus_verify_script` verifies a script. It returns whether the indicated input of the provided serialized transaction 
 correctly spends the passed scriptPubKey under additional constraints indicated by flags
-- `BGLconsensus_version` returns the API version, currently at an experimental `0`
+- `bitcoinconsensus_version` returns the API version, currently at an experimental `0`
 
 The functionality is planned to be extended to e.g. UTXO management in upcoming releases, but the interface
 for existing methods should remain stable.
@@ -247,25 +247,25 @@ Standard script rules relaxed for P2SH addresses
 The IsStandard() rules have been almost completely removed for P2SH
 redemption scripts, allowing applications to make use of any valid
 script type, such as "n-of-m OR y", hash-locked oracle addresses, etc.
-While the BGL protocol has always supported these types of script,
+While the Bitcoin protocol has always supported these types of script,
 actually using them on mainnet has been previously inconvenient as
-standard BGL Core nodes wouldn't relay them to miners, nor would
+standard Bitcoin Core nodes wouldn't relay them to miners, nor would
 most miners include them in blocks they mined.
 
-BGL-tx
+bitcoin-tx
 ----------
 
-It has been observed that many of the RPC functions offered by BGLd are
-"pure functions", and operate independently of the BGLd wallet. This
+It has been observed that many of the RPC functions offered by bitcoind are
+"pure functions", and operate independently of the bitcoind wallet. This
 included many of the RPC "raw transaction" API functions, such as
 createrawtransaction.
 
-BGL-tx is a newly introduced command line utility designed to enable easy
-manipulation of BGL transactions. A summary of its operation may be
-obtained via "BGL-tx --help" Transactions may be created or signed in a
+bitcoin-tx is a newly introduced command line utility designed to enable easy
+manipulation of bitcoin transactions. A summary of its operation may be
+obtained via "bitcoin-tx --help" Transactions may be created or signed in a
 manner similar to the RPC raw tx API. Transactions may be updated, deleting
 inputs or outputs, or appending new inputs and outputs. Custom scripts may be
-easily composed using a simple text notation, borrowed from the BGL test
+easily composed using a simple text notation, borrowed from the bitcoin test
 suite.
 
 This tool may be used for experimenting with new transaction types, signing
@@ -273,16 +273,16 @@ multi-party transactions, and many other uses. Long term, the goal is to
 deprecate and remove "pure function" RPC API calls, as those do not require a
 server round-trip to execute.
 
-Other utilities "BGL-key" and "BGL-script" have been proposed, making
+Other utilities "bitcoin-key" and "bitcoin-script" have been proposed, making
 key and script operations easily accessible via command line.
 
 Mining and relay policy enhancements
 ------------------------------------
 
-BGL Core's block templates are now for version 3 blocks only, and any mining
+Bitcoin Core's block templates are now for version 3 blocks only, and any mining
 software relying on its `getblocktemplate` must be updated in parallel to use
 libblkmaker either version 0.4.2 or any version from 0.5.1 onward.
-If you are solo mining, this will affect you the moment you upgrade BGL
+If you are solo mining, this will affect you the moment you upgrade Bitcoin
 Core, which must be done prior to BIP66 achieving its 951/1001 status.
 If you are mining with the stratum mining protocol: this does not affect you.
 If you are mining with the getblocktemplate protocol to a pool: this will affect
@@ -292,10 +292,10 @@ achieving its 951/1001 status.
 The `prioritisetransaction` RPC method has been added to enable miners to
 manipulate the priority of transactions on an individual basis.
 
-BGL Core now supports BIP 22 long polling, so mining software can be
+Bitcoin Core now supports BIP 22 long polling, so mining software can be
 notified immediately of new templates rather than having to poll periodically.
 
-Support for BIP 23 block proposals is now available in BGL Core's
+Support for BIP 23 block proposals is now available in Bitcoin Core's
 `getblocktemplate` method. This enables miners to check the basic validity of
 their next block before expending work on it, reducing risks of accidental
 hardforks or mining invalid blocks.
@@ -313,9 +313,9 @@ AllowFreeThreshold(), in which case they are relayed subject to the rate limiter
 BIP 66: strict DER encoding for signatures
 ------------------------------------------
 
-BGL Core 0.10 implements BIP 66, which introduces block version 3, and a new
+Bitcoin Core 0.10 implements BIP 66, which introduces block version 3, and a new
 consensus rule, which prohibits non-DER signatures. Such transactions have been
-non-standard since BGL v0.8.0 (released in February 2013), but were
+non-standard since Bitcoin v0.8.0 (released in February 2013), but were
 technically still permitted inside blocks.
 
 This change breaks the dependency on OpenSSL's signature parsing, and is
@@ -337,10 +337,10 @@ Detailed release notes follow. This overview includes changes that affect extern
 behavior, not code moves, refactors or string updates.
 
 RPC:
-- `f923c07` Support IPv6 lookup in BGL-cli even when IPv6 only bound on localhost
+- `f923c07` Support IPv6 lookup in bitcoin-cli even when IPv6 only bound on localhost
 - `b641c9c` Fix addnode "onetry": Connect with OpenNetworkConnection
 - `171ca77` estimatefee / estimatepriority RPC methods
-- `b750cf1` Remove cli functionality from BGLd
+- `b750cf1` Remove cli functionality from bitcoind
 - `f6984e8` Add "chain" to getmininginfo, improve help in getblockchaininfo
 - `99ddc6c` Add nLocalServices info to RPC getinfo
 - `cf0c47b` Remove getwork() RPC call
@@ -391,7 +391,7 @@ Command-line options:
 - `4278b1d` Clarify error message when invalid -rpcallowip
 - `6b407e4` -datadir is now allowed in config files
 - `bdd5b58` Add option `-sysperms` to disable 077 umask (create new files with system default umask)
-- `cbe39a3` Add "BGL-tx" command line utility and supporting modules
+- `cbe39a3` Add "bitcoin-tx" command line utility and supporting modules
 - `dbca89b` Trigger -alertnotify if network is upgrading without you
 - `ad96e7c` Make -reindex cope with out-of-order blocks
 - `16d5194` Skip reindexed blocks individually
@@ -465,7 +465,7 @@ P2P protocol and network code:
 - `35e408f` Regard connection failures as attempt for addrman
 - `a3a7317` Introduce 10 minute block download timeout
 - `3022e7d` Require sufficent priority for relay of free transactions
-- `58fda4d` Update seed IPs, based on BGL.sipa.be crawler data
+- `58fda4d` Update seed IPs, based on bitcoin.sipa.be crawler data
 - `18021d0` Remove bitnodes.io from dnsseeds.
 
 Validation:
@@ -492,13 +492,13 @@ Build system:
 - `9ce0774` build: Fix windows configure when using --with-qt-libdir
 - `ea96475` build: Add mention of --disable-wallet to bdb48 error messages
 - `1dec09b` depends: add shared dependency builder
-- `c101c76` build: Add --with-utils (BGL-cli and BGL-tx, default=yes). Help string consistency tweaks. Target sanity check fix
+- `c101c76` build: Add --with-utils (bitcoin-cli and bitcoin-tx, default=yes). Help string consistency tweaks. Target sanity check fix
 - `e432a5f` build: add option for reducing exports (v2)
 - `6134b43` Fixing condition 'sabotaging' MSVC build
 - `af0bd5e` osx: fix signing to make Gatekeeper happy (again)
 - `a7d1f03` build: fix dynamic boost check when --with-boost= is used
 - `d5fd094` build: fix qt test build when libprotobuf is in a non-standard path
-- `2cf5f16` Add libBGLconsensus library
+- `2cf5f16` Add libbitcoinconsensus library
 - `914868a` build: add a deterministic dmg signer 
 - `2d375fe` depends: bump openssl to 1.0.1k
 - `b7a4ecc` Build: Only check for boost when building code that requires it
@@ -522,7 +522,7 @@ Wallet:
 GUI:
 - `c21c74b` osx: Fix missing dock menu with qt5
 - `b90711c` Fix Transaction details shows wrong To:
-- `516053c` Make links in 'About BGL Core' clickable
+- `516053c` Make links in 'About Bitcoin Core' clickable
 - `bdc83e8` Ensure payment request network matches client network
 - `65f78a1` Add GUI view of peer information
 - `06a91d9` VerifyDB progress reporting
@@ -539,7 +539,7 @@ GUI:
 - `7007402` Implement SI-style (thin space) thoudands separator
 - `91cce17` Use fixed-point arithmetic in amount spinbox
 - `bdba2dd` Remove an obscure option no-one cares about
-- `bd0aa10` Replace the temporary file hack currently used to change BGL-Qt's dock icon (OS X) with a buffer-based solution
+- `bd0aa10` Replace the temporary file hack currently used to change Bitcoin-Qt's dock icon (OS X) with a buffer-based solution
 - `94e1b9e` Re-work overviewpage UI
 - `8bfdc9a` Better looking trayicon
 - `b197bf3` disable tray interactions when client model set to 0
@@ -585,8 +585,8 @@ Tests:
 - `4cac5db` script tests: value with trailing 0x00 is true
 - `89101c6` script test: test case for 5-byte bools
 - `d2d9dc0` script tests: add tests for CHECKMULTISIG limits
-- `d789386` Add "it works" test for BGL-tx
-- `df4d61e` Add BGL-tx tests
+- `d789386` Add "it works" test for bitcoin-tx
+- `df4d61e` Add bitcoin-tx tests
 - `aa41ac2` Test IsPushOnly() with invalid push
 - `6022b5d` Make `script_{valid,invalid}.json` validation flags configurable
 - `8138cbe` Add automatic script test generation, and actual checksig tests
@@ -598,7 +598,7 @@ Tests:
 - `2b62e17` Clearly separate PUSHDATA and numeric argument MINIMALDATA tests
 - `16d78bd` Add valid invert of invalid every numeric opcode tests
 - `f635269` tests: enable alertnotify test for Windows
-- `7a41614` tests: allow rpc-tests to get filenames for BGLd and BGL-cli from the environment
+- `7a41614` tests: allow rpc-tests to get filenames for bitcoind and bitcoin-cli from the environment
 - `5122ea7` tests: fix forknotify.py on windows
 - `fa7f8cd` tests: remove old pull-tester scripts
 - `7667850` tests: replace the old (unused since Travis) tests with new rpc test scripts
@@ -624,7 +624,7 @@ Tests:
 Miscellaneous:
 - `122549f` Fix incorrect checkpoint data for testnet3
 - `5bd02cf` Log used config file to debug.log on startup
-- `68ba85f` Updated Debian example BGL.conf with config from wiki + removed some cruft and updated comments
+- `68ba85f` Updated Debian example bitcoin.conf with config from wiki + removed some cruft and updated comments
 - `e5ee8f0` Remove -beta suffix
 - `38405ac` Add comment regarding experimental-use service bits
 - `be873f6` Issue warning if collecting RandSeed data failed
@@ -635,7 +635,7 @@ Miscellaneous:
 - `cd01a5e` Enable paranoid corruption checks in LevelDB >= 1.16
 - `9365937` Add comment about never updating nTimeOffset past 199 samples
 - `403c1bf` contrib: remove getwork-based pyminer (as getwork API call has been removed)
-- `0c3e101` contrib: Added systemd .service file in order to help distributions integrate BGLd
+- `0c3e101` contrib: Added systemd .service file in order to help distributions integrate bitcoind
 - `0a0878d` doc: Add new DNSseed policy
 - `2887bff` Update coding style and add .clang-format
 - `5cbda4f` Changed LevelDB cursors to use scoped pointers to ensure destruction when going out of scope
@@ -758,5 +758,5 @@ Thanks to everyone who contributed to this release:
 - Yoichi Hirai
 - Zak Wilcox
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
 

--- a/doc/release-notes/release-notes-0.10.1.md
+++ b/doc/release-notes/release-notes-0.10.1.md
@@ -7,7 +7,7 @@ updates. It is recommended to upgrade to this version.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 Upgrading and downgrading
 =========================

--- a/doc/release-notes/release-notes-0.10.1.md
+++ b/doc/release-notes/release-notes-0.10.1.md
@@ -1,13 +1,13 @@
-BGL Core version 0.10.1 is now available from:
+Bitcoin Core version 0.10.1 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.10.1/>
+  <https://bitcoin.org/bin/bitcoin-core-0.10.1/>
 
 This is a new minor version release, bringing bug fixes and translation 
 updates. It is recommended to upgrade to this version.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -17,15 +17,15 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 ------------------
 
 Because release 0.10.0 and later makes use of headers-first synchronization and
 parallel block download (see further), the block files and databases are not
-backwards-compatible with pre-0.10 versions of BGL Core or other software:
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -48,7 +48,7 @@ Notable changes
 
 This is a minor release and hence there are no notable changes.
 For the notable changes in 0.10, refer to the release notes for the
-0.10.0 release at https://github.com/BGL/BGL/blob/v0.10.0/doc/release-notes.md
+0.10.0 release at https://github.com/bitcoin/bitcoin/blob/v0.10.0/doc/release-notes.md
 
 0.10.1 Change log
 =================
@@ -140,4 +140,4 @@ And all those who contributed additional code review and/or security research:
 - Sergio Demian Lerner
 - Sharon Goldberg
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.10.2.md
+++ b/doc/release-notes/release-notes-0.10.2.md
@@ -7,7 +7,7 @@ updates. It is recommended to upgrade to this version.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 Upgrading and downgrading
 =========================

--- a/doc/release-notes/release-notes-0.10.2.md
+++ b/doc/release-notes/release-notes-0.10.2.md
@@ -1,13 +1,13 @@
-BGL Core version 0.10.2 is now available from:
+Bitcoin Core version 0.10.2 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.10.2/>
+  <https://bitcoin.org/bin/bitcoin-core-0.10.2/>
 
 This is a new minor version release, bringing minor bug fixes and translation 
 updates. It is recommended to upgrade to this version.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -17,15 +17,15 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 ------------------
 
 Because release 0.10.0 and later makes use of headers-first synchronization and
 parallel block download (see further), the block files and databases are not
-backwards-compatible with pre-0.10 versions of BGL Core or other software:
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -47,12 +47,12 @@ Notable changes
 ===============
 
 This fixes a serious problem on Windows with data directories that have non-ASCII
-characters (https://github.com/BGL/BGL/issues/6078).
+characters (https://github.com/bitcoin/bitcoin/issues/6078).
 
 For other platforms there are no notable changes.
 
 For the notable changes in 0.10, refer to the release notes
-at https://github.com/BGL/BGL/blob/v0.10.0/doc/release-notes.md
+at https://github.com/bitcoin/bitcoin/blob/v0.10.0/doc/release-notes.md
 
 0.10.2 Change log
 =================
@@ -83,4 +83,4 @@ And all those who contributed additional code review and/or security research:
 - Pieter Wuille
 - vayvanne
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.10.3.md
+++ b/doc/release-notes/release-notes-0.10.3.md
@@ -7,7 +7,7 @@ updates. It is recommended to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 Upgrading and downgrading
 =========================

--- a/doc/release-notes/release-notes-0.10.3.md
+++ b/doc/release-notes/release-notes-0.10.3.md
@@ -1,13 +1,13 @@
-BGL Core version 0.10.3 is now available from:
+Bitcoin Core version 0.10.3 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.10.3/>
+  <https://bitcoin.org/bin/bitcoin-core-0.10.3/>
 
 This is a new minor version release, bringing security fixes and translation 
 updates. It is recommended to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -17,15 +17,15 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 ------------------
 
 Because release 0.10.0 and later makes use of headers-first synchronization and
 parallel block download (see further), the block files and databases are not
-backwards-compatible with pre-0.10 versions of BGL Core or other software:
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -60,7 +60,7 @@ using distribution provided packages.
 Additionally, upnp has been disabled by default. This may result in a lower
 number of reachable nodes on IPv4, however this prevents future libupnpc
 vulnerabilities from being a structural risk to the network
-(see https://github.com/BGL/BGL/pull/6795).
+(see https://github.com/bitcoin/bitcoin/pull/6795).
 
 Test for LowS signatures before relaying
 -----------------------------------------
@@ -75,26 +75,26 @@ for nuisance malleability on SIGHASH_ALL P2PKH transactions. On the down-side
 it will block most transactions made by sufficiently out of date software.
 
 Unlike the other avenues to change txids on transactions this
-one was randomly violated by all deployed BGL software prior to
+one was randomly violated by all deployed bitcoin software prior to
 its discovery. So, while other malleability vectors where made
 non-standard as soon as they were discovered, this one has remained
 permitted. Even BIP62 did not propose applying this rule to
 old version transactions, but conforming implementations have become
 much more common since BIP62 was initially written.
 
-BGL Core has produced compatible signatures since a28fb70e in
+Bitcoin Core has produced compatible signatures since a28fb70e in
 September 2013, but this didn't make it into a release until 0.9
-in March 2014; BGLj has done so for a similar span of time.
-BGLjs and electrum have been more recently updated.
+in March 2014; Bitcoinj has done so for a similar span of time.
+Bitcoinjs and electrum have been more recently updated.
 
 This does not replace the need for BIP62 or similar, as miners can
 still cooperate to break transactions.  Nor does it replace the
 need for wallet software to handle malleability sanely[1]. This
 only eliminates the cheap and irritating DOS attack.
 
-[1] On the Malleability of BGL Transactions
+[1] On the Malleability of Bitcoin Transactions
 Marcin Andrychowicz, Stefan Dziembowski, Daniel Malinowski, Łukasz Mazurek
-http://fc15.ifca.ai/preproceedings/BGL/paper_9.pdf
+http://fc15.ifca.ai/preproceedings/bitcoin/paper_9.pdf
 
 Minimum relay fee default increase
 -----------------------------------
@@ -107,7 +107,7 @@ outrageous memory usage on nodes due to the mempool ballooning. This is a
 temporary measure, bridging the time until a dynamic method for determining
 this fee is merged (which will be in 0.12).
 
-(see https://github.com/BGL/BGL/pull/6793, as well as the 0.11.0
+(see https://github.com/bitcoin/bitcoin/pull/6793, as well as the 0.11.0
 release notes, in which this value was suggested)
 
 0.10.3 Change log
@@ -162,4 +162,4 @@ And all those who contributed additional code review and/or security research:
 - timothy on IRC for reporting the issue
 - Vulnerability in miniupnp discovered by Aleksandar Nikolic of Cisco Talos
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.10.4.md
+++ b/doc/release-notes/release-notes-0.10.4.md
@@ -8,7 +8,7 @@ recommended to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 Upgrading and downgrading
 =========================

--- a/doc/release-notes/release-notes-0.10.4.md
+++ b/doc/release-notes/release-notes-0.10.4.md
@@ -1,6 +1,6 @@
-BGL Core version 0.10.4 is now available from:
+Bitcoin Core version 0.10.4 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.10.4/>
+  <https://bitcoin.org/bin/bitcoin-core-0.10.4/>
 
 This is a new minor version release, bringing bug fixes, the BIP65
 (CLTV) consensus change, and relay policy preparation for BIP113. It is
@@ -8,7 +8,7 @@ recommended to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -18,15 +18,15 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 ------------------
 
 Because release 0.10.0 and later makes use of headers-first synchronization and
 parallel block download (see further), the block files and databases are not
-backwards-compatible with pre-0.10 versions of BGL Core or other software:
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -68,24 +68,24 @@ specified point in the future.
    blocks if they comply with the BIP65 rules for CLTV.
 
 For more information about the soft-forking change, please see
-<https://github.com/BGL/BGL/pull/6351>
+<https://github.com/bitcoin/bitcoin/pull/6351>
 
 Graphs showing the progress towards block version 4 adoption may be
 found at the URLs below:
 
 - Block versions over the last 50,000 blocks as progress towards BIP65
-  consensus enforcement: <http://BGL.sipa.be/ver-50k.png>
+  consensus enforcement: <http://bitcoin.sipa.be/ver-50k.png>
 
 - Block versions over the last 2,000 blocks showing the days to the
-  earliest possible BIP65 consensus-enforced block: <http://BGL.sipa.be/ver-2k.png>
+  earliest possible BIP65 consensus-enforced block: <http://bitcoin.sipa.be/ver-2k.png>
 
-**Notice to miners:** BGL Core’s block templates are now for
+**Notice to miners:** Bitcoin Core’s block templates are now for
 version 4 blocks only, and any mining software relying on its
 getblocktemplate must be updated in parallel to use libblkmaker either
 version FIXME or any version from FIXME onward.
 
 - If you are solo mining, this will affect you the moment you upgrade
-  BGL Core, which must be done prior to BIP65 achieving its 951/1001
+  Bitcoin Core, which must be done prior to BIP65 achieving its 951/1001
   status.
 
 - If you are mining with the stratum mining protocol: this does not
@@ -95,19 +95,19 @@ version FIXME or any version from FIXME onward.
   will affect you at the pool operator’s discretion, which must be no
   later than BIP65 achieving its 951/1001 status.
 
-[BIP65]: https://github.com/BGL/bips/blob/master/bip-0065.mediawiki
+[BIP65]: https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki
 
 Windows bug fix for corrupted UTXO database on unclean shutdowns
 ----------------------------------------------------------------
 
 Several Windows users reported that they often need to reindex the
-entire blockchain after an unclean shutdown of BGL Core on Windows
+entire blockchain after an unclean shutdown of Bitcoin Core on Windows
 (or an unclean shutdown of Windows itself). Although unclean shutdowns
 remain unsafe, this release no longer relies on memory-mapped files for
 the UTXO database, which significantly reduced the frequency of unclean
 shutdowns leading to required reindexes during testing.
 
-For more information, see: <https://github.com/BGL/BGL/pull/6917>
+For more information, see: <https://github.com/bitcoin/bitcoin/pull/6917>
 
 Other fixes for database corruption on Windows are expected in the
 next major release.
@@ -129,8 +129,8 @@ git merge commit are mentioned.
 - #6953 `a2f2fb6` build: disable -Wself-assign
 - #6953 `cf67d8b` Bugfix: Allow mining on top of old tip blocks for testnet (fixes testnet-in-a-box use case)
 - #6953 `b3964e3` Drop "with minimal dependencies" from description
-- #6953 `43c2789` Split BGL-tx into its own package
-- #6953 `dfe0d4d` Include BGL-tx binary on Debian/Ubuntu
+- #6953 `43c2789` Split bitcoin-tx into its own package
+- #6953 `dfe0d4d` Include bitcoin-tx binary on Debian/Ubuntu
 - #6953 `612efe8` [Qt] Raise debug window when requested
 - #6953 `3ad96bd` Fix locking in GetTransaction
 - #6953 `9c81005` Fix spelling of Qt
@@ -169,4 +169,4 @@ Thanks to everyone who directly contributed to this release:
 
 And those who contributed additional code review and/or security research.
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.11.0.md
+++ b/doc/release-notes/release-notes-0.11.0.md
@@ -7,7 +7,7 @@ bug fixes.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 Upgrading and downgrading
 =========================

--- a/doc/release-notes/release-notes-0.11.0.md
+++ b/doc/release-notes/release-notes-0.11.0.md
@@ -1,13 +1,13 @@
-BGL Core version 0.11.0 is now available from:
+Bitcoin Core version 0.11.0 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.11.0/>
+  <https://bitcoin.org/bin/bitcoin-core-0.11.0/>
 
 This is a new major version release, bringing both new features and
 bug fixes.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -17,15 +17,15 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 ------------------
 
 Because release 0.10.0 and later makes use of headers-first synchronization and
 parallel block download (see further), the block files and databases are not
-backwards-compatible with pre-0.10 versions of BGL Core or other software:
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -67,7 +67,7 @@ free transactions (with enough priority) will be accepted. It defaults to 15.
 Reducing this number reduces the speed at which the mempool can grow due
 to free transactions.
 
-For example, add the following to `BGL.conf`:
+For example, add the following to `bitcoin.conf`:
 
     minrelaytxfee=0.00005 
     limitfreerelay=5
@@ -82,11 +82,11 @@ Block file pruning
 
 This release supports running a fully validating node without maintaining a copy 
 of the raw block and undo data on disk. To recap, there are four types of data 
-related to the blockchain in the BGL system: the raw blocks as received over 
+related to the blockchain in the bitcoin system: the raw blocks as received over 
 the network (blk???.dat), the undo data (rev???.dat), the block index and the 
 UTXO set (both LevelDB databases). The databases are built from the raw data.
 
-Block pruning allows BGL Core to delete the raw block and undo data once 
+Block pruning allows Bitcoin Core to delete the raw block and undo data once 
 it's been validated and used to build the databases. At that point, the raw data 
 is used only to relay blocks to other nodes, to handle reorganizations, to look 
 up old transactions (if -txindex is enabled or via the RPC/REST interfaces), or 
@@ -95,7 +95,7 @@ all blocks in the blockchain.
 
 The user specifies how much space to allot for block & undo files. The minimum 
 allowed is 550MB. Note that this is in addition to whatever is required for the 
-block index and UTXO databases. The minimum was chosen so that BGL Core will 
+block index and UTXO databases. The minimum was chosen so that Bitcoin Core will 
 be able to maintain at least 288 blocks on disk (two days worth of blocks at 10 
 minutes per block). In rare instances it is possible that the amount of space 
 used will exceed the pruning target in order to keep the required last 288 
@@ -192,7 +192,7 @@ transaction (re)broadcast:
 One such application is selective Tor usage, where the node runs on the normal
 internet but transactions are broadcasted over Tor.
 
-For an example script see [BGL-submittx](https://github.com/laanwj/BGL-submittx).
+For an example script see [bitcoin-submittx](https://github.com/laanwj/bitcoin-submittx).
 
 Privacy: Stream isolation for Tor
 ----------------------------------
@@ -297,7 +297,7 @@ git merge commit are mentioned.
 
 ### Build system
 - #5501 `c76c9d2` Add mips, mipsel and aarch64 to depends platforms
-- #5334 `cf87536` libBGLconsensus: Add pkg-config support
+- #5334 `cf87536` libbitcoinconsensus: Add pkg-config support
 - #5514 `ed11d53` Fix 'make distcheck'
 - #5505 `a99ef7d` Build winshutdownmonitor.cpp on Windows only
 - #5582 `e8a6639` Osx toolchain update
@@ -309,7 +309,7 @@ git merge commit are mentioned.
 - #5149 `c7abfa5` Add script to verify all merge commits are signed
 - #6082 `7abbb7e` qt: disable qt tests when one of the checks for the gui fails
 - #6244 `0401aa2` configure: Detect (and reject) LibreSSL
-- #6269 `95aca44` gitian: Use the new BGL-detached-sigs git repo for OSX signatures
+- #6269 `95aca44` gitian: Use the new bitcoin-detached-sigs git repo for OSX signatures
 - #6285 `ef1d506` Fix scheduler build with some boost versions.
 - #6280 `25c2216` depends: fix Boost 1.55 build on GCC 5
 - #6303 `b711599` gitian: add a gitian-win-signer descriptor
@@ -346,8 +346,8 @@ git merge commit are mentioned.
 - #5626 `ab0d798` Fix icon sizes and column width
 - #5683 `c7b22aa` add new osx dmg background picture
 - #5620 `7823598` Payment request expiration bug fix
-- #5729 `9c4a5a5` Allow unit changes for read-only BGLAmountField
-- #5753 `0f44672` Add BGL logo to about screen
+- #5729 `9c4a5a5` Allow unit changes for read-only BitcoinAmountField
+- #5753 `0f44672` Add bitcoin logo to about screen
 - #5629 `a956586` Prevent amount overflow problem with payment requests
 - #5830 `215475a` Don't save geometry for options and about/help window
 - #5793 `d26f0b2` Honor current network when creating autostart link
@@ -392,11 +392,11 @@ git merge commit are mentioned.
 - #5366 `47a79bb` No longer check osx compatibility in RenameThread
 - #5689 `07f4386` openssl: abstract out OPENSSL_cleanse
 - #5708 `8b298ca` Add list of implemented BIPs
-- #5809 `46bfbe7` Add BGL-cli man page
+- #5809 `46bfbe7` Add bitcoin-cli man page
 - #5839 `86eb461` keys: remove libsecp256k1 verification until it's actually supported
 - #5749 `d734d87` Help messages correctly formatted (79 chars)
 - #5884 `7077fe6` BUGFIX: Stack around the variable 'rv' was corrupted
-- #5849 `41259ca` contrib/init/BGLd.openrc: Compatibility with previous OpenRC init script variables
+- #5849 `41259ca` contrib/init/bitcoind.openrc: Compatibility with previous OpenRC init script variables
 - #5950 `41113e3` Fix locale fallback and guard tests against invalid locale settings
 - #5965 `7c6bfb1` Add git-subtree-check.sh script
 - #6033 `1623f6e` FreeBSD, OpenBSD thread renaming
@@ -404,9 +404,9 @@ git merge commit are mentioned.
 - #6104 `3e2559c` Show an init message while activating best chain
 - #6125 `351f73e` Clean up parsing of bool command line args
 - #5964 `b4c219b` Lightweight task scheduler
-- #6116 `30dc3c1` [OSX] rename BGL-Qt.app to BGL-Core.app
+- #6116 `30dc3c1` [OSX] rename Bitcoin-Qt.app to Bitcoin-Core.app
 - #6168 `b3024f0` contrib/linearize: Support linearization of testnet blocks
-- #6098 `7708fcd` Update Windows resource files (and add one for BGL-tx)
+- #6098 `7708fcd` Update Windows resource files (and add one for bitcoin-tx)
 - #6159 `e1412d3` Catch errors on datadir lock and pidfile delete
 - #6186 `182686c` Fix two problems in CSubnet parsing
 - #6174 `df992b9` doc: add translation strings policy
@@ -427,7 +427,7 @@ Thanks to everyone who directly contributed to this release:
 - azeteki
 - Ben Holden-Crowther
 - bikinibabe
-- BGLPRReadingGroup
+- BitcoinPRReadingGroup
 - Blake Jakopovic
 - BtcDrak
 - charlescharles
@@ -501,5 +501,5 @@ And all those who contributed additional code review and/or security research:
 
 - Sergio Demian Lerner
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
 

--- a/doc/release-notes/release-notes-0.11.1.md
+++ b/doc/release-notes/release-notes-0.11.1.md
@@ -1,13 +1,13 @@
-BGL Core version 0.11.1 is now available from:
+Bitcoin Core version 0.11.1 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.11.1/>
+  <https://bitcoin.org/bin/bitcoin-core-0.11.1/>
 
 This is a new minor version release, bringing security fixes. It is recommended
 to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -17,15 +17,15 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 ------------------
 
 Because release 0.10.0 and later makes use of headers-first synchronization and
 parallel block download (see further), the block files and databases are not
-backwards-compatible with pre-0.10 versions of BGL Core or other software:
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -61,7 +61,7 @@ using distribution provided packages.
 Additionally, upnp has been disabled by default. This may result in a lower
 number of reachable nodes on IPv4, however this prevents future libupnpc
 vulnerabilities from being a structural risk to the network
-(see https://github.com/BGL/BGL/pull/6795).
+(see https://github.com/bitcoin/bitcoin/pull/6795).
 
 Test for LowS signatures before relaying
 -----------------------------------------
@@ -76,26 +76,26 @@ for nuisance malleability on SIGHASH_ALL P2PKH transactions. On the down-side
 it will block most transactions made by sufficiently out of date software.
 
 Unlike the other avenues to change txids on transactions this
-one was randomly violated by all deployed BGL software prior to
+one was randomly violated by all deployed bitcoin software prior to
 its discovery. So, while other malleability vectors where made
 non-standard as soon as they were discovered, this one has remained
 permitted. Even BIP62 did not propose applying this rule to
 old version transactions, but conforming implementations have become
 much more common since BIP62 was initially written.
 
-BGL Core has produced compatible signatures since a28fb70e in
+Bitcoin Core has produced compatible signatures since a28fb70e in
 September 2013, but this didn't make it into a release until 0.9
-in March 2014; BGLj has done so for a similar span of time.
-BGLjs and electrum have been more recently updated.
+in March 2014; Bitcoinj has done so for a similar span of time.
+Bitcoinjs and electrum have been more recently updated.
 
 This does not replace the need for BIP62 or similar, as miners can
 still cooperate to break transactions.  Nor does it replace the
 need for wallet software to handle malleability sanely[1]. This
 only eliminates the cheap and irritating DOS attack.
 
-[1] On the Malleability of BGL Transactions
+[1] On the Malleability of Bitcoin Transactions
 Marcin Andrychowicz, Stefan Dziembowski, Daniel Malinowski, Łukasz Mazurek
-http://fc15.ifca.ai/preproceedings/BGL/paper_9.pdf
+http://fc15.ifca.ai/preproceedings/bitcoin/paper_9.pdf
 
 Minimum relay fee default increase
 -----------------------------------
@@ -108,7 +108,7 @@ outrageous memory usage on nodes due to the mempool ballooning. This is a
 temporary measure, bridging the time until a dynamic method for determining
 this fee is merged (which will be in 0.12).
 
-(see https://github.com/BGL/BGL/pull/6793, as well as the 0.11
+(see https://github.com/bitcoin/bitcoin/pull/6793, as well as the 0.11
 release notes, in which this value was suggested)
 
 0.11.1 Change log
@@ -124,7 +124,7 @@ git merge commit are mentioned.
 - #6384 `8e5a969` qt: Force TLS1.0+ for SSL connections
 - #6471 `92401c2` Depends: bump to qt 5.5
 - #6224 `93b606a` Be even stricter in processing unrequested blocks
-- #6571 `100ac4e` libBGLconsensus: avoid a crash in multi-threaded environments
+- #6571 `100ac4e` libbitcoinconsensus: avoid a crash in multi-threaded environments
 - #6545 `649f5d9` Do not store more than 200 timedata samples.
 - #6694 `834e299` [QT] fix thin space word wrap line break issue
 - #6703 `1cd7952` Backport bugfixes to 0.11
@@ -168,5 +168,5 @@ And those who contributed additional code review and/or security research:
 - timothy on IRC for reporting the issue
 - Vulnerability in miniupnp discovered by Aleksandar Nikolic of Cisco Talos
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
 

--- a/doc/release-notes/release-notes-0.11.2.md
+++ b/doc/release-notes/release-notes-0.11.2.md
@@ -8,7 +8,7 @@ recommended to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 Upgrading and downgrading
 =========================

--- a/doc/release-notes/release-notes-0.11.2.md
+++ b/doc/release-notes/release-notes-0.11.2.md
@@ -1,6 +1,6 @@
-BGL Core version 0.11.2 is now available from:
+Bitcoin Core version 0.11.2 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.11.2/>
+  <https://bitcoin.org/bin/bitcoin-core-0.11.2/>
 
 This is a new minor version release, bringing bug fixes, the BIP65
 (CLTV) consensus change, and relay policy preparation for BIP113. It is
@@ -8,7 +8,7 @@ recommended to upgrade to this version as soon as possible.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -18,15 +18,15 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 ------------------
 
 Because release 0.10.0 and later makes use of headers-first synchronization and
 parallel block download (see further), the block files and databases are not
-backwards-compatible with pre-0.10 versions of BGL Core or other software:
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -68,24 +68,24 @@ specified point in the future.
    blocks if they comply with the BIP65 rules for CLTV.
 
 For more information about the soft-forking change, please see
-<https://github.com/BGL/BGL/pull/6351>
+<https://github.com/bitcoin/bitcoin/pull/6351>
 
 Graphs showing the progress towards block version 4 adoption may be
 found at the URLs below:
 
 - Block versions over the last 50,000 blocks as progress towards BIP65
-  consensus enforcement: <http://BGL.sipa.be/ver-50k.png>
+  consensus enforcement: <http://bitcoin.sipa.be/ver-50k.png>
 
 - Block versions over the last 2,000 blocks showing the days to the
-  earliest possible BIP65 consensus-enforced block: <http://BGL.sipa.be/ver-2k.png>
+  earliest possible BIP65 consensus-enforced block: <http://bitcoin.sipa.be/ver-2k.png>
 
-**Notice to miners:** BGL Core’s block templates are now for
+**Notice to miners:** Bitcoin Core’s block templates are now for
 version 4 blocks only, and any mining software relying on its
 getblocktemplate must be updated in parallel to use libblkmaker either
 version 0.4.3 or any version from 0.5.2 onward.
 
 - If you are solo mining, this will affect you the moment you upgrade
-  BGL Core, which must be done prior to BIP65 achieving its 951/1001
+  Bitcoin Core, which must be done prior to BIP65 achieving its 951/1001
   status.
 
 - If you are mining with the stratum mining protocol: this does not
@@ -95,12 +95,12 @@ version 0.4.3 or any version from 0.5.2 onward.
   will affect you at the pool operator’s discretion, which must be no
   later than BIP65 achieving its 951/1001 status.
 
-[BIP65]: https://github.com/BGL/bips/blob/master/bip-0065.mediawiki
+[BIP65]: https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki
 
 BIP113 mempool-only locktime enforcement using GetMedianTimePast()
 ----------------------------------------------------------------
 
-BGL transactions currently may specify a locktime indicating when
+Bitcoin transactions currently may specify a locktime indicating when
 they may be added to a valid block.  Current consensus rules require
 that blocks have a block header time greater than the locktime specified
 in any transaction in that block.
@@ -143,19 +143,19 @@ forward. To compensate, subtract one hour (3,600 seconds) from your
 locktimes to allow those transactions to be included in mempools at
 approximately the expected time.
 
-[BIP113]: https://github.com/BGL/bips/blob/master/bip-0113.mediawiki
+[BIP113]: https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki
 
 Windows bug fix for corrupted UTXO database on unclean shutdowns
 ----------------------------------------------------------------
 
 Several Windows users reported that they often need to reindex the
-entire blockchain after an unclean shutdown of BGL Core on Windows
+entire blockchain after an unclean shutdown of Bitcoin Core on Windows
 (or an unclean shutdown of Windows itself). Although unclean shutdowns
 remain unsafe, this release no longer relies on memory-mapped files for
 the UTXO database, which significantly reduced the frequency of unclean
 shutdowns leading to required reindexes during testing.
 
-For more information, see: <https://github.com/BGL/BGL/pull/6917>
+For more information, see: <https://github.com/bitcoin/bitcoin/pull/6917>
 
 Other fixes for database corruption on Windows are expected in the
 next major release.
@@ -176,8 +176,8 @@ git merge commit are mentioned.
 - #6351 `6af25b0` Add BIP65 to getblockchaininfo softforks list
 - #6688 `01878c9` Fix locking in GetTransaction
 - #6653 `b3eaa30` [Qt] Raise debug window when requested
-- #6600 `1e672ae` Debian/Ubuntu: Include BGL-tx binary
-- #6600 `2394f4d` Debian/Ubuntu: Split BGL-tx into its own package
+- #6600 `1e672ae` Debian/Ubuntu: Include bitcoin-tx binary
+- #6600 `2394f4d` Debian/Ubuntu: Split bitcoin-tx into its own package
 - #5987 `33d6825` Bugfix: Allow mining on top of old tip blocks for testnet
 - #6852 `21e58b8` build: make sure OpenSSL heeds noexecstack
 - #6846 `af6edac` alias `-h` for `--help`
@@ -214,4 +214,4 @@ Thanks to everyone who directly contributed to this release:
 
 And those who contributed additional code review and/or security research.
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.12.0.md
+++ b/doc/release-notes/release-notes-0.12.0.md
@@ -6,7 +6,7 @@ This is a new major version release, bringing new features and other improvement
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 Upgrading and downgrading
 =========================
@@ -331,7 +331,7 @@ practice. In future releases, a higher value may also help the network
 as a whole: stored blocks could be served to other nodes.
 
 For further information about pruning, you may also consult the [release
-notes of v0.11.0](https://github.com/BGL/BGL/blob/v0.11.0/doc/release-notes.md#block-file-pruning).
+notes of v0.11.0](https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/release-notes.md#block-file-pruning).
 
 `NODE_BLOOM` service bit
 ------------------------

--- a/doc/release-notes/release-notes-0.12.0.md
+++ b/doc/release-notes/release-notes-0.12.0.md
@@ -1,12 +1,12 @@
-BGL Core version 0.12.0 is now available from:
+Bitcoin Core version 0.12.0 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.12.0/>
+  <https://bitcoin.org/bin/bitcoin-core-0.12.0/>
 
 This is a new major version release, bringing new features and other improvements.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -16,8 +16,8 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 -----------------
@@ -26,7 +26,7 @@ Downgrade warning
 
 Because release 0.10.0 and later makes use of headers-first synchronization and
 parallel block download (see further), the block files and databases are not
-backwards-compatible with pre-0.10 versions of BGL Core or other software:
+backwards-compatible with pre-0.10 versions of Bitcoin Core or other software:
 
 * Blocks will be stored on disk out of order (in the order they are
 received, really), which makes it incompatible with some tools or
@@ -48,10 +48,10 @@ This does not affect wallet forward or backward compatibility.
 
 Because release 0.12.0 and later will obfuscate the chainstate on every
 fresh sync or reindex, the chainstate is not backwards-compatible with
-pre-0.12 versions of BGL Core or other software.
+pre-0.12 versions of Bitcoin Core or other software.
 
 If you want to downgrade after you have done a reindex with 0.12.0 or later,
-you will need to reindex when you first start BGL Core version 0.11 or
+you will need to reindex when you first start Bitcoin Core version 0.11 or
 earlier.
 
 Notable changes
@@ -60,8 +60,8 @@ Notable changes
 Signature validation using libsecp256k1
 ---------------------------------------
 
-ECDSA signatures inside BGL transactions now use validation using
-[libsecp256k1](https://github.com/BGL-core/secp256k1) instead of OpenSSL.
+ECDSA signatures inside Bitcoin transactions now use validation using
+[libsecp256k1](https://github.com/bitcoin-core/secp256k1) instead of OpenSSL.
 
 Depending on the platform, this means a significant speedup for raw signature
 validation speed. The advantage is largest on x86_64, where validation is over
@@ -98,7 +98,7 @@ Direct headers announcement (BIP 130)
 -------------------------------------
 
 Between compatible peers, [BIP 130]
-(https://github.com/BGL/bips/blob/master/bip-0130.mediawiki)
+(https://github.com/bitcoin/bips/blob/master/bip-0130.mediawiki)
 direct headers announcement is used. This means that blocks are advertised by
 announcing their headers directly, instead of just announcing the hash. In a
 reorganization, all new headers are sent, instead of just the new tip. This
@@ -107,15 +107,15 @@ can often prevent an extra roundtrip before the actual block is downloaded.
 Memory pool limiting
 --------------------
 
-Previous versions of BGL Core had their mempool limited by checking
+Previous versions of Bitcoin Core had their mempool limited by checking
 a transaction's fees against the node's minimum relay fee. There was no
 upper bound on the size of the mempool and attackers could send a large
 number of transactions paying just slighly more than the default minimum
 relay fee to crash nodes with relatively low RAM. A temporary workaround
-for previous versions of BGL Core was to raise the default minimum
+for previous versions of Bitcoin Core was to raise the default minimum
 relay fee.
 
-BGL Core 0.12 will have a strict maximum size on the mempool. The
+Bitcoin Core 0.12 will have a strict maximum size on the mempool. The
 default value is 300 MB and can be configured with the `-maxmempool`
 parameter. Whenever a transaction would cause the mempool to exceed
 its maximum size, the transaction that (along with in-mempool descendants) has
@@ -124,7 +124,7 @@ minimum relay feerate will be increased to match this feerate plus the initial
 minimum relay feerate. The initial minimum relay feerate is set to
 1000 satoshis per kB.
 
-BGL Core 0.12 also introduces new default policy limits on the length and
+Bitcoin Core 0.12 also introduces new default policy limits on the length and
 size of unconfirmed transaction chains that are allowed in the mempool
 (generally limiting the length of unconfirmed chains to 25 transactions, with a
 total size of 101 KB).  These limits can be overridden using command line
@@ -134,11 +134,11 @@ Opt-in Replace-by-fee transactions
 ----------------------------------
 
 It is now possible to replace transactions in the transaction memory pool of
-BGL Core 0.12 nodes. BGL Core will only allow replacement of
+Bitcoin Core 0.12 nodes. Bitcoin Core will only allow replacement of
 transactions which have any of their inputs' `nSequence` number set to less
 than `0xffffffff - 1`.  Moreover, a replacement transaction may only be
 accepted when it pays sufficient fee, as described in [BIP 125]
-(https://github.com/BGL/bips/blob/master/bip-0125.mediawiki).
+(https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki).
 
 Transaction replacement can be disabled with a new command line option,
 `-mempoolreplacement=0`.  Transactions signaling replacement under BIP125 will
@@ -156,7 +156,7 @@ updated RPC calls `gettransaction` and `listtransactions`, which now have an
 additional field in the output indicating if a transaction is replaceable under
 BIP125 ("bip125-replaceable").
 
-Note that the wallet in BGL Core 0.12 does not yet have support for
+Note that the wallet in Bitcoin Core 0.12 does not yet have support for
 creating transactions that would be replaceable under BIP 125.
 
 
@@ -173,7 +173,7 @@ overridden with the option `-rpccookiefile`.
 This is similar to Tor's CookieAuthentication: see
 https://www.torproject.org/docs/tor-manual.html.en
 
-This allows running BGLd without having to do any manual configuration.
+This allows running bitcoind without having to do any manual configuration.
 
 Relay: Any sequence of pushdatas in OP_RETURN outputs now allowed
 -----------------------------------------------------------------
@@ -196,14 +196,14 @@ returned (previously all relevant hashes were returned).
 Relay and Mining: Priority transactions
 ---------------------------------------
 
-BGL Core has a heuristic 'priority' based on coin value and age. This
+Bitcoin Core has a heuristic 'priority' based on coin value and age. This
 calculation is used for relaying of transactions which do not pay the
 minimum relay fee, and can be used as an alternative way of sorting
-transactions for mined blocks. BGL Core will relay transactions with
+transactions for mined blocks. Bitcoin Core will relay transactions with
 insufficient fees depending on the setting of `-limitfreerelay=<r>` (default:
 `r=15` kB per minute) and `-blockprioritysize=<s>`.
 
-In BGL Core 0.12, when mempool limit has been reached a higher minimum
+In Bitcoin Core 0.12, when mempool limit has been reached a higher minimum
 relay fee takes effect to limit memory usage. Transactions which do not meet
 this higher effective minimum relay fee will not be relayed or mined even if
 they rank highly according to the priority heuristic.
@@ -224,7 +224,7 @@ Note, however, that if mining priority transactions is left disabled, the
 priority delta will be ignored and only the fee metric will be effective.
 
 This internal automatic prioritization handling is being considered for removal
-entirely in BGL Core 0.13, and it is at this time undecided whether the
+entirely in Bitcoin Core 0.13, and it is at this time undecided whether the
 more accurate priority calculation for chained unconfirmed transactions will be
 restored. Community direction on this topic is particularly requested to help
 set project priorities.
@@ -234,15 +234,15 @@ Automatically use Tor hidden services
 
 Starting with Tor version 0.2.7.1 it is possible, through Tor's control socket
 API, to create and destroy 'ephemeral' hidden services programmatically.
-BGL Core has been updated to make use of this.
+Bitcoin Core has been updated to make use of this.
 
 This means that if Tor is running (and proper authorization is available),
-BGL Core automatically creates a hidden service to listen on, without
-manual configuration. BGL Core will also use Tor automatically to connect
+Bitcoin Core automatically creates a hidden service to listen on, without
+manual configuration. Bitcoin Core will also use Tor automatically to connect
 to other .onion nodes if the control socket can be successfully opened. This
 will positively affect the number of available .onion nodes and their usage.
 
-This new feature is enabled by default if BGL Core is listening, and
+This new feature is enabled by default if Bitcoin Core is listening, and
 a connection to Tor can be made. It can be configured with the `-listenonion`,
 `-torcontrol` and `-torpassword` settings. To show verbose debugging
 information, pass `-debug=tor`.
@@ -250,7 +250,7 @@ information, pass `-debug=tor`.
 Notifications through ZMQ
 -------------------------
 
-BGLd can now (optionally) asynchronously notify clients through a
+Bitcoind can now (optionally) asynchronously notify clients through a
 ZMQ-based PUB socket of the arrival of new transactions and blocks.
 This feature requires installation of the ZMQ C API library 4.x and
 configuring its use through the command line or configuration file.
@@ -263,8 +263,8 @@ Various improvements have been made to how the wallet calculates
 transaction fees.
 
 Users can decide to pay a predefined fee rate by setting `-paytxfee=<n>`
-(or `settxfee <n>` rpc during runtime). A value of `n=0` signals BGL
-Core to use floating fees. By default, BGL Core will use floating
+(or `settxfee <n>` rpc during runtime). A value of `n=0` signals Bitcoin
+Core to use floating fees. By default, Bitcoin Core will use floating
 fees.
 
 Based on past transaction data, floating fees approximate the fees
@@ -275,9 +275,9 @@ Sometimes, it is not possible to give good estimates, or an estimate
 at all. Therefore, a fallback value can be set with `-fallbackfee=<f>`
 (default: `0.0002` BTC/kB).
 
-At all times, BGL Core will cap fees at `-maxtxfee=<x>` (default:
+At all times, Bitcoin Core will cap fees at `-maxtxfee=<x>` (default:
 0.10) BTC.
-Furthermore, BGL Core will never create transactions paying less than
+Furthermore, Bitcoin Core will never create transactions paying less than
 the current minimum relay fee.
 Finally, a user can set the minimum fee rate for all transactions with
 `-mintxfee=<i>`, which defaults to 1000 satoshis per kB.
@@ -320,7 +320,7 @@ However, rescans as well as the RPCs `importwallet`, `importaddress`,
 `importprivkey` are disabled.
 
 To enable block pruning set `prune=<N>` on the command line or in
-`BGL.conf`, where `N` is the number of MiB to allot for
+`bitcoin.conf`, where `N` is the number of MiB to allot for
 raw block & undo data.
 
 A value of 0 disables pruning. The minimal value above 0 is 550. Your
@@ -331,13 +331,13 @@ practice. In future releases, a higher value may also help the network
 as a whole: stored blocks could be served to other nodes.
 
 For further information about pruning, you may also consult the [release
-notes of v0.11.0](https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/release-notes.md#block-file-pruning).
+notes of v0.11.0](https://github.com/bitcoin/bitcoin/blob/v0.11.0/doc/release-notes.md#block-file-pruning).
 
 `NODE_BLOOM` service bit
 ------------------------
 
 Support for the `NODE_BLOOM` service bit, as described in [BIP
-111](https://github.com/BGL/bips/blob/master/bip-0111.mediawiki), has been
+111](https://github.com/bitcoin/bips/blob/master/bip-0111.mediawiki), has been
 added to the P2P protocol code.
 
 BIP 111 defines a service bit to allow peers to advertise that they support
@@ -369,7 +369,7 @@ RPC: Low-level API changes
 * The `asm` property of each scriptSig now contains the decoded signature hash
   type for each signature that provides a valid defined hash type.
 
-* OP_NOP2 has been renamed to OP_CHECKLOCKTIMEVERIFY by [BIP 65](https://github.com/BGL/bips/blob/master/bip-0065.mediawiki)
+* OP_NOP2 has been renamed to OP_CHECKLOCKTIMEVERIFY by [BIP 65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
 
 The following items contain assembly representations of scriptSig signatures
 and are affected by this change:
@@ -379,7 +379,7 @@ and are affected by this change:
 - RPC `decodescript`
 - REST `/rest/tx/` (JSON format)
 - REST `/rest/block/` (JSON format when including extended tx details)
-- `BGL-tx -json`
+- `bitcoin-tx -json`
 
 For example, the `scriptSig.asm` property of a transaction input that
 previously showed an assembly representation of:
@@ -429,16 +429,16 @@ caching. A sample config for apache2 could look like:
     SSLCertificateFile /etc/apache2/ssl/server.crt
     SSLCertificateKeyFile /etc/apache2/ssl/server.key
 
-    <Location /BGLrpc>
+    <Location /bitcoinrpc>
         ProxyPass http://127.0.0.1:8332/
         ProxyPassReverse http://127.0.0.1:8332/
         # optional enable digest auth
         # AuthType Digest
         # ...
 
-        # optional bypass BGLd rpc basic auth
+        # optional bypass bitcoind rpc basic auth
         # RequestHeader set Authorization "Basic <hash>"
-        # get the <hash> from the shell with: base64 <<< BGLrpc:<password>
+        # get the <hash> from the shell with: base64 <<< bitcoinrpc:<password>
     </Location>
 
     # Or, balance the load:
@@ -459,7 +459,7 @@ Other P2P Changes
 -----------------
 
 The list of banned peers is now stored on disk rather than in memory.
-Restarting BGLd will no longer clear out the list of banned peers; instead
+Restarting bitcoind will no longer clear out the list of banned peers; instead
 a new RPC call (`clearbanned`) can be used to manually clear the list.  The new
 `setban` RPC call can also be used to manually ban or unban a peer.
 
@@ -637,14 +637,14 @@ git merge commit are mentioned.
 ### Build system
 
 - #6210 `0e4f2a0` build: disable optional use of gmp in internal secp256k1 build (Wladimir J. van der Laan)
-- #6214 `87406aa` [OSX] revert renaming of BGL-Qt.app and use CFBundleDisplayName (partial revert of #6116) (Jonas Schnelli)
+- #6214 `87406aa` [OSX] revert renaming of Bitcoin-Qt.app and use CFBundleDisplayName (partial revert of #6116) (Jonas Schnelli)
 - #6218 `9d67b10` build/gitian misc updates (Cory Fields)
-- #6269 `d4565b6` gitian: Use the new BGL-detached-sigs git repo for OSX signatures (Cory Fields)
+- #6269 `d4565b6` gitian: Use the new bitcoin-detached-sigs git repo for OSX signatures (Cory Fields)
 - #6418 `d4a910c` Add autogen.sh to source tarball. (randy-waterhouse)
 - #6373 `1ae3196` depends: non-qt bumps for 0.12 (Cory Fields)
 - #6434 `059b352` Preserve user-passed CXXFLAGS with --enable-debug (Gavin Andresen)
 - #6501 `fee6554` Misc build fixes (Cory Fields)
-- #6600 `ef4945f` Include BGL-tx binary on Debian/Ubuntu (Zak Wilcox)
+- #6600 `ef4945f` Include bitcoin-tx binary on Debian/Ubuntu (Zak Wilcox)
 - #6619 `4862708` depends: bump miniupnpc and ccache (Michael Ford)
 - #6801 `ae69a75` [depends] Latest config.guess and config.sub (Michael Ford)
 - #6938 `193f7b5` build: If both Qt4 and Qt5 are installed, use Qt5 (Wladimir J. van der Laan)
@@ -719,7 +719,7 @@ git merge commit are mentioned.
 - #6337 `0564c5b` Testing infrastructure: mocktime fixes (Gavin Andresen)
 - #6350 `60abba1` add unit tests for the decodescript rpc (mruddy)
 - #5881 `3203a08` Fix and improve txn_doublespend.py test (Tom Harding)
-- #6390 `6a73d66` tests: Fix BGL-tx signing test case (Wladimir J. van der Laan)
+- #6390 `6a73d66` tests: Fix bitcoin-tx signing test case (Wladimir J. van der Laan)
 - #6368 `7fc25c2` CLTV: Add more tests to improve coverage (Esteban Ordano)
 - #6414 `5121c68` Fix intermittent test failure, reduce test time (Tom Harding)
 - #6417 `44fa82d` [QA] fix possible reorg issue in (fund)rawtransaction(s).py RPC test (Jonas Schnelli)
@@ -732,7 +732,7 @@ git merge commit are mentioned.
 - #6509 `bb4faee` Fix race condition on test node shutdown (Casey Rodarmor)
 - #6523 `561f8af` Add p2p-fullblocktest.py (Casey Rodarmor)
 - #6590 `981fd92` Fix stale socket rebinding and re-enable python tests for Windows (Cory Fields)
-- #6730 `cb4d6d0` build: Remove dependency of BGL-cli on secp256k1 (Wladimir J. van der Laan)
+- #6730 `cb4d6d0` build: Remove dependency of bitcoin-cli on secp256k1 (Wladimir J. van der Laan)
 - #6616 `5ab5dca` Regression Tests: Migrated rpc-tests.sh to all Python rpc-tests.py (Peter Tschipper)
 - #6720 `d479311` Creates unittests for addrman, makes addrman more testable. (Ethan Heilman)
 - #6853 `c834f56` Added fPowNoRetargeting field to Consensus::Params (Eric Lombrozo)
@@ -750,7 +750,7 @@ git merge commit are mentioned.
 - #7063 `6abf6eb` [Tests] Add prioritisetransaction RPC test (Suhas Daftuar)
 - #7137 `16f4a6e` Tests: Explicitly set chain limits in replace-by-fee test (Suhas Daftuar)
 - #7216 `9572e49` Removed offline testnet DNSSeed 'alexykot.me'. (tnull)
-- #7209 `f3ad812` test: don't override BGLD and BGLCLI if they're set (Wladimir J. van der Laan)
+- #7209 `f3ad812` test: don't override BITCOIND and BITCOINCLI if they're set (Wladimir J. van der Laan)
 - #7226 `301f16a` Tests: Add more tests to p2p-fullblocktest (Suhas Daftuar)
 - #7153 `9ef7c54` [Tests] Add mempool_limit.py test (Jonas Schnelli)
 - #7170 `453c567` tests: Disable Tor interaction (Wladimir J. van der Laan)
@@ -764,9 +764,9 @@ git merge commit are mentioned.
 - #5975 `1fea667` Consensus: Decouple ContextualCheckBlockHeader from checkpoints (Jorge Timón)
 - #6061 `eba2f06` Separate Consensus::CheckTxInputs and GetSpendHeight in CheckInputs (Jorge Timón)
 - #5994 `786ed11` detach wallet from miner (Jonas Schnelli)
-- #6387 `11576a5` [BGL-cli] improve error output (Jonas Schnelli)
-- #6401 `6db53b4` Add BGLD_SIGTERM_TIMEOUT to OpenRC init scripts (Florian Schmaus)
-- #6430 `b01981e` doc: add documentation for shared library libBGLconsensus (Braydon Fuller)
+- #6387 `11576a5` [bitcoin-cli] improve error output (Jonas Schnelli)
+- #6401 `6db53b4` Add BITCOIND_SIGTERM_TIMEOUT to OpenRC init scripts (Florian Schmaus)
+- #6430 `b01981e` doc: add documentation for shared library libbitcoinconsensus (Braydon Fuller)
 - #6372 `dcc495e` Update Linearize tool to support Windows paths; fix variable scope; update README and example configuration (Paul Georgiou)
 - #6453 `8fe5cce` Separate core memory usage computation in core_memusage.h (Pieter Wuille)
 - #6149 `633fe10` Buffer log messages and explicitly open logs (Adam Weiss)
@@ -891,4 +891,4 @@ Thanks to everyone who directly contributed to this release:
 - Zak Wilcox
 - zathras-crypto
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.12.1.md
+++ b/doc/release-notes/release-notes-0.12.1.md
@@ -7,7 +7,7 @@ softfork, various bugfixes and updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 Upgrading and downgrading
 =========================

--- a/doc/release-notes/release-notes-0.12.1.md
+++ b/doc/release-notes/release-notes-0.12.1.md
@@ -1,13 +1,13 @@
-BGL Core version 0.12.1 is now available from:
+Bitcoin Core version 0.12.1 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.12.1/>
+  <https://bitcoin.org/bin/bitcoin-core-0.12.1/>
 
 This is a new minor version release, including the BIP9, BIP68 and BIP112
 softfork, various bugfixes and updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 Upgrading and downgrading
 =========================
@@ -17,8 +17,8 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Downgrade warning
 -----------------
@@ -27,10 +27,10 @@ Downgrade warning
 
 Because release 0.12.0 and later will obfuscate the chainstate on every
 fresh sync or reindex, the chainstate is not backwards-compatible with
-pre-0.12 versions of BGL Core or other software.
+pre-0.12 versions of Bitcoin Core or other software.
 
 If you want to downgrade after you have done a reindex with 0.12.0 or later,
-you will need to reindex when you first start BGL Core version 0.11 or
+you will need to reindex when you first start Bitcoin Core version 0.11 or
 earlier.
 
 Notable changes
@@ -49,15 +49,15 @@ bits together with setting bit 0 to indicate support for this combined
 deployment, shown as "csv" in the `getblockchaininfo` RPC call.
 
 For more information about the soft forking change, please see
-<https://github.com/BGL/BGL/pull/7648>
+<https://github.com/bitcoin/bitcoin/pull/7648>
 
 This specific backport pull-request can be viewed at
-<https://github.com/BGL/BGL/pull/7543>
+<https://github.com/bitcoin/bitcoin/pull/7543>
 
-[BIP9]: https://github.com/BGL/bips/blob/master/bip-0009.mediawiki
-[BIP68]: https://github.com/BGL/bips/blob/master/bip-0068.mediawiki
-[BIP112]: https://github.com/BGL/bips/blob/master/bip-0112.mediawiki
-[BIP113]: https://github.com/BGL/bips/blob/master/bip-0113.mediawiki
+[BIP9]: https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki
+[BIP68]: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
+[BIP112]: https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki
+[BIP113]: https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki
 
 BIP68 soft fork to enforce sequence locks for relative locktime
 ---------------------------------------------------------------
@@ -68,27 +68,27 @@ invalid for a defined period of time after confirmation of its corresponding
 outpoint.
 
 For more information about the implementation, see
-<https://github.com/BGL/BGL/pull/7184>
+<https://github.com/bitcoin/bitcoin/pull/7184>
 
 BIP112 soft fork to enforce OP_CHECKSEQUENCEVERIFY
 --------------------------------------------------
 
 [BIP112][] redefines the existing OP_NOP3 as OP_CHECKSEQUENCEVERIFY (CSV)
-for a new opcode in the BGL scripting system that in combination with
+for a new opcode in the Bitcoin scripting system that in combination with
 [BIP68][] allows execution pathways of a script to be restricted based
 on the age of the output being spent.
 
 For more information about the implementation, see
-<https://github.com/BGL/BGL/pull/7524>
+<https://github.com/bitcoin/bitcoin/pull/7524>
 
 BIP113 locktime enforcement soft fork
 -------------------------------------
 
-BGL Core 0.11.2 previously introduced mempool-only locktime
+Bitcoin Core 0.11.2 previously introduced mempool-only locktime
 enforcement using GetMedianTimePast(). This release seeks to
 consensus enforce the rule.
 
-BGL transactions currently may specify a locktime indicating when
+Bitcoin transactions currently may specify a locktime indicating when
 they may be added to a valid block.  Current consensus rules require
 that blocks have a block header time greater than the locktime specified
 in any transaction in that block.
@@ -132,7 +132,7 @@ locktimes to allow those transactions to be included in mempools at
 approximately the expected time.
 
 For more information about the implementation, see
-<https://github.com/BGL/BGL/pull/6566>
+<https://github.com/bitcoin/bitcoin/pull/6566>
 
 Miscellaneous
 -------------
@@ -194,5 +194,5 @@ Thanks to everyone who directly contributed to this release:
 - Suhas Daftuar
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
 

--- a/doc/release-notes/release-notes-0.13.0.md
+++ b/doc/release-notes/release-notes-0.13.0.md
@@ -7,7 +7,7 @@ and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.13.0.md
+++ b/doc/release-notes/release-notes-0.13.0.md
@@ -1,28 +1,28 @@
-BGL Core version 0.13.0 is now available from:
+Bitcoin Core version 0.13.0 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.13.0/>
+  <https://bitcoin.org/bin/bitcoin-core-0.13.0/>
 
 This is a new major version release, including new features, various bugfixes
 and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 Compatibility
 ==============
 
 Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
 an OS initially released in 2001. This means that not even critical security
-updates will be released anymore. Without security updates, using a BGL
+updates will be released anymore. Without security updates, using a bitcoin
 wallet on a XP machine is irresponsible at least.
 
-In addition to that, with 0.12.x there have been varied reports of BGL Core
-randomly crashing on Windows XP. It is [not clear](https://github.com/BGL/BGL/issues/7681#issuecomment-217439891)
+In addition to that, with 0.12.x there have been varied reports of Bitcoin Core
+randomly crashing on Windows XP. It is [not clear](https://github.com/bitcoin/bitcoin/issues/7681#issuecomment-217439891)
 what the source of these crashes is, but it is likely that upstream
 libraries such as Qt are no longer being tested on XP.
 
@@ -48,21 +48,21 @@ For this reason the default was changed to 300 MiB in this release.
 For nodes on low-memory systems, the database cache can be changed back to
 100 MiB (or to another value) by either:
 
-- Adding `dbcache=100` in BGL.conf
+- Adding `dbcache=100` in bitcoin.conf
 - Changing it in the GUI under `Options → Size of database cache`
 
 Note that the database cache setting has the most performance impact
 during initial sync of a node, and when catching up after downtime.
 
 
-BGL-cli: arguments privacy
+bitcoin-cli: arguments privacy
 ------------------------------
 
 The RPC command line client gained a new argument, `-stdin`
 to read extra arguments from standard input, one per line until EOF/Ctrl-D.
 For example:
 
-    $ src/BGL-cli -stdin walletpassphrase
+    $ src/bitcoin-cli -stdin walletpassphrase
     mysecretcode
     120
     ..... press Ctrl-D here to end input
@@ -76,7 +76,7 @@ table by any user on the system.
 C++11 and Python 3
 ------------------
 
-Various code modernizations have been done. The BGL Core code base has
+Various code modernizations have been done. The Bitcoin Core code base has
 started using C++11. This means that a C++11-capable compiler is now needed for
 building. Effectively this means GCC 4.7 or higher, or Clang 3.3 or higher.
 
@@ -95,9 +95,9 @@ executables.
 
 The following extra files can be found in the download directory or torrent:
 
-- `BGL-${VERSION}-arm-linux-gnueabihf.tar.gz`: Linux binaries targeting
+- `bitcoin-${VERSION}-arm-linux-gnueabihf.tar.gz`: Linux binaries targeting
   the 32-bit ARMv7-A architecture.
-- `BGL-${VERSION}-aarch64-linux-gnu.tar.gz`: Linux binaries targeting
+- `bitcoin-${VERSION}-aarch64-linux-gnu.tar.gz`: Linux binaries targeting
   the 64-bit ARMv8-A architecture.
 
 ARM builds are still experimental. If you have problems on a certain device or
@@ -122,7 +122,7 @@ in PR 8068.
 The primary goal is reducing the bandwidth spikes at relay time, though in many
 cases it also reduces propagation delay. It is automatically enabled between
 compatible peers.
-[BIP 152](https://github.com/BGL/bips/blob/master/bip-0152.mediawiki)
+[BIP 152](https://github.com/bitcoin/bips/blob/master/bip-0152.mediawiki)
 
 As a side-effect, ordinary non-mining nodes will download and upload blocks
 faster if those blocks were produced by miners using similar transaction
@@ -156,23 +156,23 @@ You can't disable HD key generation once you have created a HD wallet.
 
 There is no distinction between internal (change) and external keys.
 
-HD wallets are incompatible with older versions of BGL Core.
+HD wallets are incompatible with older versions of Bitcoin Core.
 
-[Pull request](https://github.com/BGL/BGL/pull/8035/files), [BIP 32](https://github.com/BGL/bips/blob/master/bip-0032.mediawiki)
+[Pull request](https://github.com/bitcoin/bitcoin/pull/8035/files), [BIP 32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki)
 
 
 Segregated Witness
 ------------------
 
 The code preparations for Segregated Witness ("segwit"), as described in [BIP
-141](https://github.com/BGL/bips/blob/master/bip-0141.mediawiki), [BIP
-143](https://github.com/BGL/bips/blob/master/bip-0143.mediawiki), [BIP
-144](https://github.com/BGL/bips/blob/master/bip-0144.mediawiki), and [BIP
-145](https://github.com/BGL/bips/blob/master/bip-0145.mediawiki) are
+141](https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki), [BIP
+143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki), [BIP
+144](https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki), and [BIP
+145](https://github.com/bitcoin/bips/blob/master/bip-0145.mediawiki) are
 finished and included in this release.  However, BIP 141 does not yet specify
 activation parameters on mainnet, and so this release does not support segwit
 use on mainnet.  Testnet use is supported, and after BIP 141 is updated with
-proposed parameters, a future release of BGL Core is expected that
+proposed parameters, a future release of Bitcoin Core is expected that
 implements those parameters for mainnet.
 
 Furthermore, because segwit activation is not yet specified for mainnet,
@@ -199,7 +199,7 @@ The command line option `-blockmaxsize` remains an option to specify the
 maximum number of serialized bytes in a generated block.  In addition, the new
 command line option `-blockmaxweight` has been added, which specifies the
 maximum "block weight" of a generated block, as defined by [BIP 141 (Segregated
-Witness)] (https://github.com/BGL/bips/blob/master/bip-0141.mediawiki).
+Witness)] (https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki).
 
 In preparation for Segregated Witness, the mining algorithm has been modified
 to optimize transaction selection for a given block weight, rather than a given
@@ -216,7 +216,7 @@ support `-blockmaxsize` performs additional computation to ensure that
 constraint is met.  (Note that for mainnet, in this release, the equivalent
 parameter for `-blockmaxweight` would be four times the desired
 `-blockmaxsize`.  See [BIP 141]
-(https://github.com/BGL/bips/blob/master/bip-0141.mediawiki) for additional
+(https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki) for additional
 details.)
 
 In the future, the `-blockmaxsize` option may be removed, as block creation is
@@ -232,7 +232,7 @@ files on disk. These two have now been split up, so that all blocks are known
 before validation starts. This was necessary to make certain optimizations that
 are available during normal synchronizations also available during reindexing.
 
-The two phases are distinct in the BGL-Qt GUI. During the first one,
+The two phases are distinct in the Bitcoin-Qt GUI. During the first one,
 "Reindexing blocks on disk" is shown. During the second (slower) one,
 "Processing blocks on disk" is shown.
 
@@ -277,7 +277,7 @@ Low-level P2P changes
 - The optional new p2p message "feefilter" is implemented and the protocol
   version is bumped to 70013. Upon receiving a feefilter message from a peer,
   a node will not send invs for any transactions which do not meet the filter
-  feerate. [BIP 133](https://github.com/BGL/bips/blob/master/bip-0133.mediawiki)
+  feerate. [BIP 133](https://github.com/bitcoin/bips/blob/master/bip-0133.mediawiki)
 
 - The P2P alert system has been removed in PR #7692 and the `alert` P2P message
   is no longer supported.
@@ -326,10 +326,10 @@ Low-level RPC changes
 - Asm script outputs replacements for OP_NOP2 and OP_NOP3
 
   - OP_NOP2 has been renamed to OP_CHECKLOCKTIMEVERIFY by [BIP 
-65](https://github.com/BGL/bips/blob/master/bip-0065.mediawiki)
+65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
 
   - OP_NOP3 has been renamed to OP_CHECKSEQUENCEVERIFY by [BIP 
-112](https://github.com/BGL/bips/blob/master/bip-0112.mediawiki)
+112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki)
 
   - The following outputs are affected by this change:
 
@@ -338,7 +338,7 @@ Low-level RPC changes
     - RPC `decodescript`
     - REST `/rest/tx/` (JSON format)
     - REST `/rest/block/` (JSON format when including extended tx details)
-    - `BGL-tx -json`
+    - `bitcoin-tx -json`
 
 - The sorting of the output of the `getrawmempool` output has changed.
 
@@ -358,7 +358,7 @@ Low-level ZMQ changes
   listeners to detect lost notifications.
   The sequence number is always the last element in a multi-part ZMQ notification and
   therefore backward compatible. Each message type has its own counter.
-  PR [#7762](https://github.com/BGL/BGL/pull/7762).
+  PR [#7762](https://github.com/bitcoin/bitcoin/pull/7762).
 
 
 0.13.0 Change log
@@ -375,7 +375,7 @@ git merge commit are mentioned.
 - #7326 `2cd004b` Fix typo, wrong information in gettxout help text (paveljanik)
 - #7222 `82429d0` Indicate which transactions are signaling opt-in RBF (sdaftuar)
 - #7480 `b49a623` Changed getnetworkhps value to double to avoid overflow (instagibbs)
-- #7550 `8b958ab` Input-from-stdin mode for BGL-cli (laanwj)
+- #7550 `8b958ab` Input-from-stdin mode for bitcoin-cli (laanwj)
 - #7670 `c9a1265` Use cached block hash in blockToJSON() (rat4)
 - #7726 `9af69fa` Correct importaddress help reference to importpubkey (CypherGrue)
 - #7766 `16555b6` Register calls where they are defined (laanwj)
@@ -540,7 +540,7 @@ git merge commit are mentioned.
 - #7604 `354b03d` build: Remove spurious dollar sign. Fixes #7189 (dooglus)
 - #7605 `7f001bd` Remove openssl info from init/log and from Qt debug window (jonasschnelli)
 - #7628 `87d6562` Add 'copy full transaction details' option (ericshawlinux)
-- #7613 `3798e5d` Add autocomplete to BGL-qt's console window (GamerSg)
+- #7613 `3798e5d` Add autocomplete to bitcoin-qt's console window (GamerSg)
 - #7668 `b24266c` Fix history deletion bug after font size change (achow101)
 - #7680 `41d2dfa` Remove reflection from `about` icon (laanwj)
 - #7686 `f034bce` Remove 0-fee from send dialog (MarcoFalke)
@@ -557,13 +557,13 @@ git merge commit are mentioned.
 - #8014 `77b49ac` Sort transactions by date (Tyler-Hardin)
 - #8073 `eb2f6f7` askpassphrasedialog: Clear pass fields on accept (rat4)
 - #8129 `ee1533e` Fix RPC console auto completer (UdjinM6)
-- #7636 `fb0ac48` Add BGL address label to request payment QR code (makevoid)
+- #7636 `fb0ac48` Add bitcoin address label to request payment QR code (makevoid)
 - #8231 `760a6c7` Fix a bug where the SplashScreen will not be hidden during startup (jonasschnelli)
-- #8256 `af2421c` BUG: BGL-qt crash (fsb4000)
-- #8257 `ff03c50` Do not ask a UI question from BGLd (sipa)
+- #8256 `af2421c` BUG: bitcoin-qt crash (fsb4000)
+- #8257 `ff03c50` Do not ask a UI question from bitcoind (sipa)
 - #8288 `91abb77` Network-specific example address (laanwj)
 - #7707 `a914968` UI support for abandoned transactions (jonasschnelli)
-- #8207 `f7a403b` Add a link to the BGL-Core repository and website to the About Dialog (MarcoFalke)
+- #8207 `f7a403b` Add a link to the Bitcoin-Core repository and website to the About Dialog (MarcoFalke)
 - #8281 `6a87eb0` Remove client name from debug window (laanwj)
 - #8407 `45eba4b` Add dbcache migration path (jonasschnelli)
 
@@ -650,7 +650,7 @@ git merge commit are mentioned.
 - #8038 `e2bf830` Various minor fixes (MarcoFalke)
 - #8072 `1b87e5b` Travis: 'make check' in parallel and verbose (theuni)
 - #8056 `8844ef1` Remove hardcoded "4 nodes" from test_framework (MarcoFalke)
-- #8047 `37f9a1f` Test_framework: Set wait-timeout for BGLd procs (MarcoFalke)
+- #8047 `37f9a1f` Test_framework: Set wait-timeout for bitcoind procs (MarcoFalke)
 - #8095 `6700cc9` Test framework: only cleanup on successful test runs (sdaftuar)
 - #8098 `06bd4f6` Test_framework: Append portseed to tmpdir (MarcoFalke)
 - #8104 `6ff2c8d` Add timeout to sync_blocks() and sync_mempools() (sdaftuar)
@@ -660,7 +660,7 @@ git merge commit are mentioned.
 - #8090 `a2df115` Adding P2SH(p2pkh) script test case (Christewart)
 - #7992 `ec45cc5` Extend #7956 with one more test (TheBlueMatt)
 - #8139 `ae5575b` Fix interrupted HTTP RPC connection workaround for Python 3.5+ (sipa)
-- #8164 `0f24eaf` [BGL-Tx] fix missing test fixtures, fix 32bit atoi issue (jonasschnelli)
+- #8164 `0f24eaf` [Bitcoin-Tx] fix missing test fixtures, fix 32bit atoi issue (jonasschnelli)
 - #8166 `0b5279f` Src/test: Do not shadow local variables (paveljanik)
 - #8141 `44c1b1c` Continuing port of java comparison tool (mrbandrews)
 - #8201 `36b7400` fundrawtransaction: Fix race, assert amounts (MarcoFalke)
@@ -670,7 +670,7 @@ git merge commit are mentioned.
 - #8216 `0d41d70` Assert 'changePosition out of bounds'  (MarcoFalke)
 - #8222 `961893f` Enable mempool consistency checks in unit tests (sipa)
 - #7751 `84370d5` test_framework: python3.4 authproxy compat (laanwj)
-- #7744 `d8e862a` test_framework: detect failure of BGLd startup (laanwj)
+- #7744 `d8e862a` test_framework: detect failure of bitcoind startup (laanwj)
 - #8280 `115735d` Increase sync_blocks() timeouts in pruning.py (MarcoFalke)
 - #8340 `af9b7a9` Solve trivial merge conflict in p2p-segwit.py (MarcoFalke)
 - #8067 `3e4cf8f` Travis: use slim generic image, and some fixups (theuni)
@@ -707,7 +707,7 @@ git merge commit are mentioned.
 - #7791 `e30a5b0` Change Precise to Trusty in gitian-building.md (JeremyRand)
 - #7838 `8bb5d3d` Update gitian build guide to debian 8.4.0 (fanquake)
 - #7855 `b778e59` Replace precise with trusty (MarcoFalke)
-- #7975 `fc23fee` Update BGL-core GitHub links (MarcoFalke)
+- #7975 `fc23fee` Update bitcoin-core GitHub links (MarcoFalke)
 - #8034 `e3a8207` Add basic git squash workflow (fanquake)
 - #7813 `214ec0b` Update port in tor.md (MarcoFalke)
 - #8193 `37c9830` Use Debian 8.5 in the gitian-build guide (fanquake)
@@ -865,4 +865,4 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 - Yuri Zhykin
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.13.1.md
+++ b/doc/release-notes/release-notes-0.13.1.md
@@ -1,6 +1,6 @@
-BGL Core version 0.13.1 is now available from:
+Bitcoin Core version 0.13.1 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.13.1/>
+  <https://bitcoin.org/bin/bitcoin-core-0.13.1/>
 
 This is a new minor version release, including activation parameters for the
 segwit softfork, various bugfixes and performance improvements, as well as
@@ -8,22 +8,22 @@ updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 Compatibility
 ==============
 
 Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
 an OS initially released in 2001. This means that not even critical security
-updates will be released anymore. Without security updates, using a BGL
+updates will be released anymore. Without security updates, using a bitcoin
 wallet on a XP machine is irresponsible at least.
 
-In addition to that, with 0.12.x there have been varied reports of BGL Core
-randomly crashing on Windows XP. It is [not clear](https://github.com/BGL/BGL/issues/7681#issuecomment-217439891)
+In addition to that, with 0.12.x there have been varied reports of Bitcoin Core
+randomly crashing on Windows XP. It is [not clear](https://github.com/bitcoin/bitcoin/issues/7681#issuecomment-217439891)
 what the source of these crashes is, but it is likely that upstream
 libraries such as Qt are no longer being tested on XP.
 
@@ -56,9 +56,9 @@ covered by the txid. This provides several immediate benefits:
   identifier (txid) of transactions without referencing the witness, which can
   sometimes be changed by third-parties (such as miners) or by co-signers in a
   multisig spend. This solves all known cases of unwanted transaction
-  malleability, which is a problem that makes programming BGL wallet
+  malleability, which is a problem that makes programming Bitcoin wallet
   software more difficult and which seriously complicates the design of smart
-  contracts for BGL.
+  contracts for Bitcoin.
 
 - **Capacity increase:** Segwit transactions contain new fields that are not
   part of the data currently used to calculate the size of a block, which
@@ -72,7 +72,7 @@ covered by the txid. This provides several immediate benefits:
   following section for details).
 
 - **Weighting data based on how it affects node performance:** Some parts of
-  each BGL block need to be stored by nodes in order to validate future
+  each Bitcoin block need to be stored by nodes in order to validate future
   blocks; other parts of a block can be immediately forgotten (pruned) or used
   only for helping other nodes sync their copy of the block chain.  One large
   part of the immediately prunable data are transaction signatures (witnesses),
@@ -89,8 +89,8 @@ covered by the txid. This provides several immediate benefits:
   (such as hardware wallets), reduces the amount of data the signature
   generator needs to download, and allows the signature generator to operate
   more quickly.  This is made possible by having the generator sign the amount
-  of BGLs they think they are spending, and by having full nodes refuse to
-  accept those signatures unless the amount of BGLs being spent is exactly
+  of bitcoins they think they are spending, and by having full nodes refuse to
+  accept those signatures unless the amount of bitcoins being spent is exactly
   the same as was signed.  For non-segwit transactions, wallets instead had to
   download the complete previous transactions being spent for every payment
   they made, which could be a slow operation on hardware wallets and in other
@@ -105,7 +105,7 @@ covered by the txid. This provides several immediate benefits:
   different signature method that doesn't suffer from this problem and doesn't
   have any unwanted side-effects.
 
-- **Increased security for multisig:** BGL addresses (both P2PKH addresses
+- **Increased security for multisig:** Bitcoin addresses (both P2PKH addresses
   that start with a '1' and P2SH addresses that start with a '3') use a hash
   function known as RIPEMD-160.  For P2PKH addresses, this provides about 160
   bits of security---which is beyond what cryptographers believe can be broken
@@ -115,15 +115,15 @@ covered by the txid. This provides several immediate benefits:
   Segwit allows advanced transactions to use the SHA256 hash function instead,
   which provides about 128 bits of security  (that is 281 trillion times as
   much security as 80 bits and is equivalent to the maximum bits of security
-  believed to be provided by BGL's choice of parameters for its Elliptic
+  believed to be provided by Bitcoin's choice of parameters for its Elliptic
   Curve Digital Security Algorithm [ECDSA].)
 
 - **More efficient almost-full-node security** Satoshi Nakamoto's original
-  BGL paper describes a method for allowing newly-started full nodes to
+  Bitcoin paper describes a method for allowing newly-started full nodes to
   skip downloading and validating some data from historic blocks that are
   protected by large amounts of proof of work.  Unfortunately, Nakamoto's
   method can't guarantee that a newly-started node using this method will
-  produce an accurate copy of BGL's current ledger (called the UTXO set),
+  produce an accurate copy of Bitcoin's current ledger (called the UTXO set),
   making the node vulnerable to falling out of consensus with other nodes.
   Although the problems with Nakamoto's method can't be fixed in a soft fork,
   Segwit accomplishes something similar to his original proposal: it makes it
@@ -131,18 +131,18 @@ covered by the txid. This provides several immediate benefits:
   (specifically, the segregated witnesses) while still ensuring that the node
   can build an accurate copy of the UTXO set for the block chain with the most
   proof of work.  Segwit enables this capability at the consensus layer, but
-  note that BGL Core does not provide an option to use this capability as
+  note that Bitcoin Core does not provide an option to use this capability as
   of this 0.13.1 release.
 
 - **Script versioning:** Segwit makes it easy for future soft forks to allow
-  BGL users to individually opt-in to almost any change in the BGL
+  Bitcoin users to individually opt-in to almost any change in the Bitcoin
   Script language when those users receive new transactions.  Features
-  currently being researched by BGL Core contributors that may use this
+  currently being researched by Bitcoin Core contributors that may use this
   capability include support for Schnorr signatures, which can improve the
   privacy and efficiency of multisig transactions (or transactions with
   multiple inputs), and Merklized Abstract Syntax Trees (MAST), which can
   improve the privacy and efficiency of scripts with two or more conditions.
-  Other BGL community members are studying several other improvements
+  Other Bitcoin community members are studying several other improvements
   that can be made using script versioning.
 
 Activation for the segwit soft fork is being managed using BIP9
@@ -159,13 +159,13 @@ For more information about segwit, please see the [segwit FAQ][], the
 operator, please see the [versionbits FAQ][] for information about
 signaling support for a soft fork.
 
-[Segwit FAQ]: https://BGLcore.org/en/2016/01/26/segwit-benefits/
-[segwit wallet developers guide]: https://BGLcore.org/en/segwit_wallet_dev/
-[BIP141]: https://github.com/BGL/bips/blob/master/bip-0141.mediawiki
-[BIP143]: https://github.com/BGL/bips/blob/master/bip-0143.mediawiki
-[BIP144]: https://github.com/BGL/bips/blob/master/bip-0144.mediawiki
-[BIP145]: https://github.com/BGL/bips/blob/master/bip-0145.mediawiki
-[versionbits FAQ]: https://BGLcore.org/en/2016/06/08/version-bits-miners-faq/
+[Segwit FAQ]: https://bitcoincore.org/en/2016/01/26/segwit-benefits/
+[segwit wallet developers guide]: https://bitcoincore.org/en/segwit_wallet_dev/
+[BIP141]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
+[BIP143]: https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
+[BIP144]: https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki
+[BIP145]: https://github.com/bitcoin/bips/blob/master/bip-0145.mediawiki
+[versionbits FAQ]: https://bitcoincore.org/en/2016/06/08/version-bits-miners-faq/
 
 
 Null dummy soft fork
@@ -183,7 +183,7 @@ a third-party to insert data into other people's transactions, changing
 the transaction's txid (called transaction malleability) and possibly
 causing other problems.
 
-Since BGL Core 0.10.0, nodes have defaulted to only relaying and
+Since Bitcoin Core 0.10.0, nodes have defaulted to only relaying and
 mining transactions whose dummy element was a null value (0x00, also
 called OP_0).  The null dummy soft fork turns this relay rule into a
 consensus rule both for non-segwit transactions and segwit transactions,
@@ -196,7 +196,7 @@ as segwit.
 
 For more information, please see [BIP147][].
 
-[BIP147]: https://github.com/BGL/bips/blob/master/bip-0147.mediawiki
+[BIP147]: https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki
 
 Low-level RPC changes
 ---------------------
@@ -215,9 +215,9 @@ is provided below.
 
 The following extra files can be found in the download directory or torrent:
 
-- `BGL-${VERSION}-arm-linux-gnueabihf.tar.gz`: Linux binaries targeting
+- `bitcoin-${VERSION}-arm-linux-gnueabihf.tar.gz`: Linux binaries targeting
   the 32-bit ARMv7-A architecture.
-- `BGL-${VERSION}-aarch64-linux-gnu.tar.gz`: Linux binaries targeting
+- `bitcoin-${VERSION}-aarch64-linux-gnu.tar.gz`: Linux binaries targeting
   the 64-bit ARMv8-A architecture.
 
 ARM builds are still experimental. If you have problems on a certain device or
@@ -243,7 +243,7 @@ git merge commit are mentioned.
 
 ### Consensus
 - #8636 `9dfa0c8` Implement NULLDUMMY softfork (BIP147) (jl2012)
-- #8848 `7a34a46` Add NULLDUMMY verify flag in BGLconsensus.h (jl2012)
+- #8848 `7a34a46` Add NULLDUMMY verify flag in bitcoinconsensus.h (jl2012)
 - #8937 `8b66659` Define start and end time for segwit deployment (sipa)
 
 ### RPC and other APIs
@@ -275,13 +275,13 @@ git merge commit are mentioned.
 - #8612 `2215c22` Check for compatibility with download in FindNextBlocksToDownload (sipa)
 - #8606 `bbf379b` Fix some locks (sipa)
 - #8594 `ab295bb` Do not add random inbound peers to addrman (gmaxwell)
-- #8940 `5b4192b` Add x9 service bit support to dnsseed.bluematt.me, seed.BGLstats.com (TheBlueMatt, cdecker)
+- #8940 `5b4192b` Add x9 service bit support to dnsseed.bluematt.me, seed.bitcoinstats.com (TheBlueMatt, cdecker)
 - #8944 `685e4c7` Remove bogus assert on number of oubound connections. (TheBlueMatt)
 - #8949 `0dbc48a` Be more agressive in getting connections to peers with relevant services (gmaxwell)
 
 ### Build system
-- #8293 `fa5b249` Allow building libBGLconsensus without any univalue (luke-jr)
-- #8492 `8b0bdd3` Allow building bench_BGL by itself (luke-jr)
+- #8293 `fa5b249` Allow building libbitcoinconsensus without any univalue (luke-jr)
+- #8492 `8b0bdd3` Allow building bench_bitcoin by itself (luke-jr)
 - #8563 `147003c` Add configure check for -latomic (ajtowns)
 - #8626 `ea51b0f` Berkeley DB v6 compatibility fix (netsafe)
 - #8520 `75f2065` Remove check for `openssl/ec.h` (laanwj)
@@ -320,16 +320,16 @@ git merge commit are mentioned.
 - #8418 `ff893aa` Add tests for compact blocks (sdaftuar)
 - #8803 `375437c` Ping regularly in p2p-segwit.py to keep connection alive (jl2012)
 - #8827 `9bbe66e` Split up slow RPC calls to avoid pruning test timeouts (sdaftuar)
-- #8829 `2a8bca4` Add BGL-tx JSON tests (jnewbery)
+- #8829 `2a8bca4` Add bitcoin-tx JSON tests (jnewbery)
 - #8834 `1dd1783` blockstore: Switch to dumb dbm (MarcoFalke)
 - #8835 `d87227d` nulldummy.py: Don't run unused code (MarcoFalke)
-- #8836 `eb18cc1` BGL-util-test.py should fail if the output file is empty (jnewbery)
+- #8836 `eb18cc1` bitcoin-util-test.py should fail if the output file is empty (jnewbery)
 - #8839 `31ab2f8` Avoid ConnectionResetErrors during RPC tests (laanwj)
 - #8840 `cbc3fe5` Explicitly set encoding to utf8 when opening text files (laanwj)
 - #8841 `3e4abb5` Fix nulldummy test (jl2012)
 - #8854 `624a007` Fix race condition in p2p-compactblocks test (sdaftuar)
 - #8857 `1f60d45` mininode: Only allow named args in wait_until (MarcoFalke)
-- #8860 `0bee740` util: Move wait_BGLds() into stop_nodes() (MarcoFalke)
+- #8860 `0bee740` util: Move wait_bitcoinds() into stop_nodes() (MarcoFalke)
 - #8882 `b73f065` Fix race conditions in p2p-compactblocks.py and sendheaders.py (sdaftuar)
 - #8904 `cc6f551` Fix compact block shortids for a test case (dagurval)
 
@@ -337,7 +337,7 @@ git merge commit are mentioned.
 - #8754 `0e2c6bd` Target protobuf 2.6 in OS X build notes. (fanquake)
 - #8461 `b17a3f9` Document return value of networkhashps for getmininginfo RPC endpoint (jlopp)
 - #8512 `156e305` Corrected JSON typo on setban of net.cpp (sevastos)
-- #8683 `8a7d7ff` Fix incorrect file name BGL.qrc  (BGLsSG)
+- #8683 `8a7d7ff` Fix incorrect file name bitcoin.qrc  (bitcoinsSG)
 - #8891 `5e0dd9e` Update bips.md for Segregated Witness (fanquake)
 - #8545 `863ae74` Update git-subtree-check.sh README (MarcoFalke)
 - #8607 `486650a` Fix doxygen off-by-one comments, fix typos (MarcoFalke)
@@ -352,7 +352,7 @@ git merge commit are mentioned.
 - #8742 `d31ac72` Specify Protobuf version 2 in paymentrequest.proto (fanquake)
 - #8414,#8558,#8676,#8700,#8701,#8702 Add missing copyright headers (isle2983, kazcw)
 - #8899 `4ed2627` Fix wake from sleep issue with Boost 1.59.0 (fanquake)
-- #8817 `bcf3806` update BGL-tx to output witness data (jnewbery)
+- #8817 `bcf3806` update bitcoin-tx to output witness data (jnewbery)
 - #8513 `4e5fc31` Fix a type error that would not compile on OSX. (JeremyRubin)
 - #8392 `30eac2d` Fix several node initialization issues (sipa)
 - #8548 `305d8ac` Use `__func__` to get function name for output printing (MarcoFalke)
@@ -407,4 +407,4 @@ Thanks to everyone who directly contributed to this release:
 - whythat
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.13.1.md
+++ b/doc/release-notes/release-notes-0.13.1.md
@@ -8,7 +8,7 @@ updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.13.2.md
+++ b/doc/release-notes/release-notes-0.13.2.md
@@ -1,28 +1,28 @@
-BGL Core version 0.13.2 is now available from:
+Bitcoin Core version 0.13.2 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.13.2/>
+  <https://bitcoin.org/bin/bitcoin-core-0.13.2/>
 
 This is a new minor version release, including various bugfixes and
 performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 Compatibility
 ==============
 
 Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
 an OS initially released in 2001. This means that not even critical security
-updates will be released anymore. Without security updates, using a BGL
+updates will be released anymore. Without security updates, using a bitcoin
 wallet on a XP machine is irresponsible at least.
 
-In addition to that, with 0.12.x there have been varied reports of BGL Core
-randomly crashing on Windows XP. It is [not clear](https://github.com/BGL/BGL/issues/7681#issuecomment-217439891)
+In addition to that, with 0.12.x there have been varied reports of Bitcoin Core
+randomly crashing on Windows XP. It is [not clear](https://github.com/bitcoin/bitcoin/issues/7681#issuecomment-217439891)
 what the source of these crashes is, but it is likely that upstream
 libraries such as Qt are no longer being tested on XP.
 
@@ -111,7 +111,7 @@ git merge commit are mentioned.
 - #8972 `6f86b53` Make warnings label selectable (jonasschnelli) (MarcoFalke)
 - #9185 `6d70a73` Fix coincontrol sort issue (jonasschnelli)
 - #9094 `5f3a12c` Use correct conversion function for boost::path datadir (laanwj)
-- #8908 `4a974b2` Update BGL-qt.desktop (s-matthew-english)
+- #8908 `4a974b2` Update bitcoin-qt.desktop (s-matthew-english)
 - #9190 `dc46b10` Plug many memory leaks (laanwj)
 
 ### Wallet
@@ -134,7 +134,7 @@ git merge commit are mentioned.
 - #8838 `094848b` Calculate size and weight of block correctly in CreateNewBlock() (jnewbery)
 - #8920 `40169dc` Set minimum required Boost to 1.47.0 (fanquake)
 - #9251 `a710a43` Improvement of documentation of command line parameter 'whitelist' (wodry)
-- #8932 `106da69` Allow BGL-tx to create v2 transactions (btcdrak)
+- #8932 `106da69` Allow bitcoin-tx to create v2 transactions (btcdrak)
 - #8929 `12428b4` add software-properties-common (sigwo)
 - #9120 `08d1c90` bug: Missed one "return false" in recent refactoring in #9067 (UdjinM6)
 - #9067 `f85ee01` Fix exit codes (UdjinM6)
@@ -175,4 +175,4 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 - wodry
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.13.2.md
+++ b/doc/release-notes/release-notes-0.13.2.md
@@ -7,7 +7,7 @@ performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.14.0.md
+++ b/doc/release-notes/release-notes-0.14.0.md
@@ -7,7 +7,7 @@ and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 
@@ -96,7 +96,7 @@ ZMQ On Windows
 
 Previously the ZeroMQ notification system was unavailable on Windows
 due to various issues with ZMQ. These have been fixed upstream and
-now ZMQ can be used on Windows. Please see [this document](https://github.com/BGL/BGL/blob/master/doc/zmq.md) for
+now ZMQ can be used on Windows. Please see [this document](https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/zmq.md) for
 help with using ZMQ in general.
 
 Nested RPC Commands in Debug Console

--- a/doc/release-notes/release-notes-0.14.0.md
+++ b/doc/release-notes/release-notes-0.14.0.md
@@ -1,22 +1,22 @@
-BGL Core version 0.14.0 is now available from:
+Bitcoin Core version 0.14.0 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.14.0/>
+  <https://bitcoin.org/bin/bitcoin-core-0.14.0/>
 
 This is a new major version release, including new features, various bugfixes
 and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later.
 
 Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
@@ -24,7 +24,7 @@ No attempt is made to prevent installing or running the software on Windows XP, 
 can still do so at your own risk but be aware that there are known instabilities and issues.
 Please do not report issues about Windows XP to the issue tracker.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notable changes
@@ -55,7 +55,7 @@ improved, leading to much shorter sync and initial block download times.
 Manual Pruning
 --------------
 
-BGL Core has supported automatically pruning the blockchain since 0.11. Pruning
+Bitcoin Core has supported automatically pruning the blockchain since 0.11. Pruning
 the blockchain allows for significant storage space savings as the vast majority of
 the downloaded data can be discarded after processing so very little of it remains
 on the disk.
@@ -96,7 +96,7 @@ ZMQ On Windows
 
 Previously the ZeroMQ notification system was unavailable on Windows
 due to various issues with ZMQ. These have been fixed upstream and
-now ZMQ can be used on Windows. Please see [this document](https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/zmq.md) for
+now ZMQ can be used on Windows. Please see [this document](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md) for
 help with using ZMQ in general.
 
 Nested RPC Commands in Debug Console
@@ -129,7 +129,7 @@ the same thing as the GUI icon. The command takes one boolean parameter,
 Out-of-sync Modal Info Layer
 ----------------------------
 
-When BGL Core is out-of-sync on startup, a semi-transparent information
+When Bitcoin Core is out-of-sync on startup, a semi-transparent information
 layer will be shown over top of the normal display. This layer contains
 details about the current sync progress and estimates the amount of time
 remaining to finish syncing. This layer can also be hidden and subsequently
@@ -138,19 +138,19 @@ unhidden by clicking on the progress bar at the bottom of the window.
 Support for JSON-RPC Named Arguments
 ------------------------------------
 
-Commands sent over the JSON-RPC interface and through the `BGL-cli` binary
+Commands sent over the JSON-RPC interface and through the `bitcoin-cli` binary
 can now use named arguments. This follows the [JSON-RPC specification](http://www.jsonrpc.org/specification)
 for passing parameters by-name with an object.
 
-`BGL-cli` has been updated to support this by parsing `name=value` arguments
+`bitcoin-cli` has been updated to support this by parsing `name=value` arguments
 when the `-named` option is given.
 
 Some examples:
 
-    src/BGL-cli -named help command="help"
-    src/BGL-cli -named getblockhash height=0
-    src/BGL-cli -named getblock blockhash=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
-    src/BGL-cli -named sendtoaddress address="(snip)" amount="1.0" subtractfeefromamount=true
+    src/bitcoin-cli -named help command="help"
+    src/bitcoin-cli -named getblockhash height=0
+    src/bitcoin-cli -named getblock blockhash=000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f
+    src/bitcoin-cli -named sendtoaddress address="(snip)" amount="1.0" subtractfeefromamount=true
 
 The order of arguments doesn't matter in this case. Named arguments are also
 useful to leave out arguments that should stay at their default value. The
@@ -189,7 +189,7 @@ commands such as `prioritisetransaction` so that those changes will not be lost.
 Final Alert
 -----------
 
-The Alert System was [disabled and deprecated](https://BGL.org/en/alert/2016-11-01-alert-retirement) in BGL Core 0.12.1 and removed in 0.13.0. 
+The Alert System was [disabled and deprecated](https://bitcoin.org/en/alert/2016-11-01-alert-retirement) in Bitcoin Core 0.12.1 and removed in 0.13.0. 
 The Alert System was retired with a maximum sequence final alert which causes any nodes
 supporting the Alert System to display a static hard-coded "Alert Key Compromised" message which also
 prevents any other alerts from overriding it. This final alert is hard-coded into this release
@@ -241,8 +241,8 @@ Low-level RPC changes
    the mempool or if `txindex` is enabled.
 
  - A new RPC command `getmemoryinfo` has been added which will return information
-   about the memory usage of BGL Core. This was added in conjunction with
-   optimizations to memory management. See [Pull #8753](https://github.com/BGL/BGL/pull/8753)
+   about the memory usage of Bitcoin Core. This was added in conjunction with
+   optimizations to memory management. See [Pull #8753](https://github.com/bitcoin/bitcoin/pull/8753)
    for more information.
 
  - A new RPC command `bumpfee` has been added which allows replacing an
@@ -367,7 +367,7 @@ and git merge commit are mentioned.
 - #8421 `b77bb95` httpserver: drop boost dependency (theuni)
 - #8638 `f061415` rest.cpp: change `HTTP_INTERNAL_SERVER_ERROR` to `HTTP_BAD_REQUEST` (djpnewton)
 - #8272 `91990ee` Make the dummy argument to getaddednodeinfo optional (sipa)
-- #8722 `bb843ad` BGL-cli: More detailed error reporting (laanwj)
+- #8722 `bb843ad` bitcoin-cli: More detailed error reporting (laanwj)
 - #6996 `7f71a3c` Add preciousblock RPC (sipa)
 - #8788 `97c7f73` Give RPC commands more information about the RPC request (jonasschnelli)
 - #7948 `5d2c8e5` Augment getblockchaininfo bip9\_softforks data (mruddy)
@@ -626,14 +626,14 @@ and git merge commit are mentioned.
 - #8680 `666eaf0` Address Travis spurious failures (theuni)
 - #8789 `e31a43c` pull-tester: Only print output when failed (MarcoFalke)
 - #8810 `14e8f99` tests: Add exception error message for JSONRPCException (laanwj)
-- #8830 `ef0801b` test: Add option to run BGL-util-test.py manually (jnewbery)
-- #8881 `e66cc1d` Add some verbose logging to BGL-util-test.py (jnewbery)
+- #8830 `ef0801b` test: Add option to run bitcoin-util-test.py manually (jnewbery)
+- #8881 `e66cc1d` Add some verbose logging to bitcoin-util-test.py (jnewbery)
 - #8922 `0329511` Send segwit-encoded blocktxn messages in p2p-compactblocks (TheBlueMatt)
 - #8873 `74dc388` Add microbenchmarks to profile more code paths (ryanofsky)
 - #9032 `6a8be7b` test: Add format-dependent comparison to bctest (laanwj)
-- #9023 `774db92` Add logging to BGL-util-test.py (jnewbery)
+- #9023 `774db92` Add logging to bitcoin-util-test.py (jnewbery)
 - #9065 `c9bdf9a` Merge `doc/unit-tests.md` into `src/test/README.md` (laanwj)
-- #9069 `ed64bce` Clean up bctest.py and BGL-util-test.py (jnewbery)
+- #9069 `ed64bce` Clean up bctest.py and bitcoin-util-test.py (jnewbery)
 - #9095 `b8f43e3` test: Fix test\_random includes (MarcoFalke)
 - #8894 `faec09b` Testing: Include fRelay in mininode version messages (jnewbery)
 - #9097 `e536499` Rework `sync_*` and preciousblock.py (MarcoFalke)
@@ -665,7 +665,7 @@ and git merge commit are mentioned.
 - #9628 `f895023` Increase a sync\_blocks timeout in pruning.py (sdaftuar)
 - #9638 `a7ea2f8` Actually test assertions in pruning.py (MarcoFalke)
 - #9647 `e99f0d7` Skip RAII event tests if libevent is built without `event_set_mem_functions` (luke-jr)
-- #9691 `fc67cd2` Init ECC context for `test_BGL_fuzzy` (gmaxwell)
+- #9691 `fc67cd2` Init ECC context for `test_bitcoin_fuzzy` (gmaxwell)
 - #9712 `d304fef` bench: Fix initialization order in registration (laanwj)
 - #9707 `b860915` Fix RPC failure testing (jnewbery)
 - #9269 `43e8150` Align struct COrphan definition (sipa)
@@ -711,25 +711,25 @@ and git merge commit are mentioned.
 - #8965 `23e03f8` Mention that PPA doesn't support Debian (anduck)
 - #9115 `bfc7aad` Mention reporting security issues responsibly (paveljanik)
 - #9840 `08e0690` Update sendfrom RPC help to correct coin selection misconception (ryanofsky)
-- #9865 `289204f` Change BGL address in RPC help message (marijnfs)
+- #9865 `289204f` Change bitcoin address in RPC help message (marijnfs)
 
 ### Miscellaneous
 - #8274 `7a2d402` util: Update tinyformat (laanwj)
 - #8291 `5cac8b1` util: CopyrightHolders: Check for untranslated substitution (MarcoFalke)
 - #8557 `44691f3` contrib: Rework verifybinaries (MarcoFalke)
 - #8621 `e8ed6eb` contrib: python: Don't use shell=True (MarcoFalke)
-- #8813 `fb24d7e` BGLd: Daemonize using daemon(3) (laanwj)
+- #8813 `fb24d7e` bitcoind: Daemonize using daemon(3) (laanwj)
 - #9004 `67728a3` Clarify `listenonion` (unsystemizer)
 - #8674 `bae81b8` tools for analyzing, updating and adding copyright headers in source files (isle2983)
 - #8976 `8c6218a` libconsensus: Add input validation of flags (laanwj)
 - #9112 `46027e8` Avoid ugly exception in log on unknown inv type (laanwj)
-- #8837 `2108911` Allow BGL-tx to parse partial transactions (jnewbery)
+- #8837 `2108911` Allow bitcoin-tx to parse partial transactions (jnewbery)
 - #9204 `74ced54` Clarify CreateTransaction error messages (instagibbs)
-- #9265 `31bcc66` BGL-cli: Make error message less confusing (laanwj)
+- #9265 `31bcc66` bitcoin-cli: Make error message less confusing (laanwj)
 - #9303 `72bf1b3` Update comments in ctaes (sipa)
 - #9417 `c4b7d4f` Do not evaluate hidden LogPrint arguments (sipa)
 - #9506 `593a00c` RFC: Improve style for if indentation (sipa)
-- #8883 `d5d4ad8` Add all standard TXO types to BGL-tx (jnewbery)
+- #8883 `d5d4ad8` Add all standard TXO types to bitcoin-tx (jnewbery)
 - #9531 `23281a4` Release notes for estimation changes  (morcos)
 - #9486 `f62bc10` Make peer=%d log prints consistent (TheBlueMatt)
 - #9552 `41cb05c` Add IPv6 support to qos.sh (jamesmacwhite)
@@ -870,4 +870,4 @@ Thanks to everyone who directly contributed to this release:
 - wodry
 - Zak Wilcox
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.14.1.md
+++ b/doc/release-notes/release-notes-0.14.1.md
@@ -1,22 +1,22 @@
-BGL Core version 0.14.1 is now available from:
+Bitcoin Core version 0.14.1 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.14.1/>
+  <https://bitcoin.org/bin/bitcoin-core-0.14.1/>
 
 This is a new minor version release, including various bugfixes and
 performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later.
 
 Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
@@ -24,7 +24,7 @@ No attempt is made to prevent installing or running the software on Windows XP, 
 can still do so at your own risk but be aware that there are known instabilities and issues.
 Please do not report issues about Windows XP to the issue tracker.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notable changes
@@ -75,7 +75,7 @@ this parameter.
 
 Additional information relating to running on low-memory systems can be found
 here:
-[reducing-BGLd-memory-usage.md](https://gist.github.com/laanwj/efe29c7661ce9b6620a7).
+[reducing-bitcoind-memory-usage.md](https://gist.github.com/laanwj/efe29c7661ce9b6620a7).
 
 0.14.1 Change log
 =================
@@ -117,7 +117,7 @@ git merge commit are mentioned.
 ### Miscellaneous
 - #10037 `4d8e660` Trivial: Fix typo in help getrawtransaction RPC (keystrike)
 - #10120 `e4c9a90` util: Work around (virtual) memory exhaustion on 32-bit w/ glibc (laanwj)
-- #10130 `ecc5232` BGL-tx input verification (awemany, jnewbery)
+- #10130 `ecc5232` bitcoin-tx input verification (awemany, jnewbery)
 
 Credits
 =======
@@ -139,5 +139,5 @@ Thanks to everyone who directly contributed to this release:
 - Suhas Daftuar
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
 

--- a/doc/release-notes/release-notes-0.14.1.md
+++ b/doc/release-notes/release-notes-0.14.1.md
@@ -7,7 +7,7 @@ performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.14.2.md
+++ b/doc/release-notes/release-notes-0.14.2.md
@@ -1,22 +1,22 @@
-BGL Core version 0.14.2 is now available from:
+Bitcoin Core version 0.14.2 is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.14.2/>
+  <https://bitcoin.org/bin/bitcoin-core-0.14.2/>
 
 This is a new minor version release, including various bugfixes and
 performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later.
 
 Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
@@ -24,7 +24,7 @@ No attempt is made to prevent installing or running the software on Windows XP, 
 can still do so at your own risk but be aware that there are known instabilities and issues.
 Please do not report issues about Windows XP to the issue tracker.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notable changes
@@ -40,7 +40,7 @@ other impact.
 
 This only affects users that have explicitly enabled UPnP through the GUI
 setting or through the `-upnp` option, as since the last UPnP vulnerability
-(in BGL Core 0.10.3) it has been disabled by default.
+(in Bitcoin Core 0.10.3) it has been disabled by default.
 
 If you use this option, it is recommended to upgrade to this version as soon as
 possible.
@@ -48,7 +48,7 @@ possible.
 Known Bugs
 ==========
 
-Since 0.14.0 the approximate transaction fee shown in BGL-Qt when using coin
+Since 0.14.0 the approximate transaction fee shown in Bitcoin-Qt when using coin
 control and smart fee estimation does not reflect any change in target from the
 smart fee slider. It will only present an approximate fee calculated using the
 default target. The fee calculated using the correct target is still applied to
@@ -71,7 +71,7 @@ git merge commit are mentioned.
 
 ### Build system
 - #10414 `ffb0c4b` miniupnpc 2.0.20170509 (fanquake)
-- #10228 `ae479bc` Regenerate BGL-config.h as necessary (theuni)
+- #10228 `ae479bc` Regenerate bitcoin-config.h as necessary (theuni)
 
 ### Miscellaneous
 - #10245 `44a17f2` Minor fix in build documentation for FreeBSD 11 (shigeya)
@@ -98,5 +98,5 @@ Thanks to everyone who directly contributed to this release:
 - Shigeya Suzuki
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
 

--- a/doc/release-notes/release-notes-0.14.2.md
+++ b/doc/release-notes/release-notes-0.14.2.md
@@ -7,7 +7,7 @@ performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.14.3.md
+++ b/doc/release-notes/release-notes-0.14.3.md
@@ -1,22 +1,22 @@
-BGL Core version *0.14.3* is now available from:
+Bitcoin Core version *0.14.3* is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.14.3/>
+  <https://bitcoin.org/bin/bitcoin-core-0.14.3/>
 
 This is a new minor version release, including various bugfixes and
 performance improvements.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later.
 
 Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
@@ -24,7 +24,7 @@ No attempt is made to prevent installing or running the software on Windows XP, 
 can still do so at your own risk but be aware that there are known instabilities and issues.
 Please do not report issues about Windows XP to the issue tracker.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notable changes
@@ -34,13 +34,13 @@ Denial-of-Service vulnerability CVE-2018-17144
  -------------------------------
 
 A denial-of-service vulnerability exploitable by miners has been discovered in
-BGL Core versions 0.14.0 up to 0.16.2. It is recommended to upgrade any of
+Bitcoin Core versions 0.14.0 up to 0.16.2. It is recommended to upgrade any of
 the vulnerable versions to 0.14.3, 0.15.2 or 0.16.3 as soon as possible.
 
 Known Bugs
 ==========
 
-Since 0.14.0 the approximate transaction fee shown in BGL-Qt when using coin
+Since 0.14.0 the approximate transaction fee shown in Bitcoin-Qt when using coin
 control and smart fee estimation does not reflect any change in target from the
 smart fee slider. It will only present an approximate fee calculated using the
 default target. The fee calculated using the correct target is still applied to
@@ -72,7 +72,7 @@ git merge commit are mentioned.
 
 ### Miscellaneous
 
-- #10451 `3612219` contrib/init/BGLd.openrcconf: Don't disable wallet by default (Luke Dashjr)
+- #10451 `3612219` contrib/init/bitcoind.openrcconf: Don't disable wallet by default (Luke Dashjr)
 - #10250 `e23cef0` Fix some empty vector references (Pieter Wuille)
 - #10196 `d28d583` PrioritiseTransaction updates the mempool tx counter (Suhas Daftuar)
 - #9497 `e207342` Fix CCheckQueue IsIdle (potential) race condition and remove dangerous constructors. (Jeremy Rubin)

--- a/doc/release-notes/release-notes-0.14.3.md
+++ b/doc/release-notes/release-notes-0.14.3.md
@@ -7,7 +7,7 @@ performance improvements.
 
 Please report bugs using the issue tracker at github:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.15.0.1.md
+++ b/doc/release-notes/release-notes-0.15.0.1.md
@@ -10,7 +10,7 @@ This is a minor bug fix for 0.15.0.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.15.0.1.md
+++ b/doc/release-notes/release-notes-0.15.0.1.md
@@ -1,28 +1,28 @@
-BGL Core version *0.15.0.1* is now available from:
+Bitcoin Core version *0.15.0.1* is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.15.0.1/>
+  <https://bitcoin.org/bin/bitcoin-core-0.15.0.1/>
 
 and
 
-  <https://BGLcore.org/bin/BGL-core-0.15.0.1/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.15.0.1/>
 
 This is a minor bug fix for 0.15.0.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the 
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 The first time you run version 0.15.0 or higher, your chainstate database will
 be converted to a new format, which will take anywhere from a few minutes to
@@ -51,10 +51,10 @@ processing the entire blockchain.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notable changes
@@ -84,4 +84,4 @@ Thanks to everyone who directly contributed to this release:
 - Jonas Schnelli
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.15.0.md
+++ b/doc/release-notes/release-notes-0.15.0.md
@@ -1,25 +1,25 @@
-BGL Core version *0.15.0* is now available from:
+Bitcoin Core version *0.15.0* is now available from:
 
-  <https://BGL.org/bin/BGL-core-0.15.0/>
+  <https://bitcoin.org/bin/bitcoin-core-0.15.0/>
 
 This is a new major version release, including new features, various bugfixes
 and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the 
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 The first time you run version 0.15.0, your chainstate database will be converted to a
 new format, which will take anywhere from a few minutes to half an hour,
@@ -48,10 +48,10 @@ processing the entire blockchain.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notes for 0.15.0
@@ -85,7 +85,7 @@ Version 0.15 contains a number of significant performance improvements, which ma
 Initial Block Download, startup, transaction and block validation much faster:
 
 - The chainstate database (which is used for tracking UTXOs) has been changed
-  from a per-transaction model to a per-output model (See [PR 10195](https://github.com/BGL/BGL/pull/10195)). Advantages of this model
+  from a per-transaction model to a per-output model (See [PR 10195](https://github.com/bitcoin/bitcoin/pull/10195)). Advantages of this model
   are that it:
     - avoids the CPU overhead of deserializing and serializing the unused outputs;
     - has more predictable memory usage;
@@ -98,32 +98,32 @@ Initial Block Download, startup, transaction and block validation much faster:
   a few extra gigabytes may be used.
 - Earlier versions experienced a spike in memory usage while flushing UTXO updates to disk.
   As a result, only half of the available memory was actually used as cache, and the other half was
-  reserved to accommodate flushing. This is no longer the case (See [PR 10148](https://github.com/BGL/BGL/pull/10148)), and the entirety of
+  reserved to accommodate flushing. This is no longer the case (See [PR 10148](https://github.com/bitcoin/bitcoin/pull/10148)), and the entirety of
   the available cache (see `-dbcache`) is now actually used as cache. This reduces the flushing
   frequency by a factor 2 or more.
 - In previous versions, signature validation for transactions has been cached when the
   transaction is accepted to the mempool. Version 0.15 extends this to cache the entire script
-  validity (See [PR 10192](https://github.com/BGL/BGL/pull/10192)). This means that if a transaction in a block has already been accepted to the
+  validity (See [PR 10192](https://github.com/bitcoin/bitcoin/pull/10192)). This means that if a transaction in a block has already been accepted to the
   mempool, the scriptSig does not need to be re-evaluated. Empirical tests show that
   this results in new block validation being 40-50% faster.
-- LevelDB has been upgraded to version 1.20 (See [PR 10544](https://github.com/BGL/BGL/pull/10544)). This version contains hardware acceleration for CRC
+- LevelDB has been upgraded to version 1.20 (See [PR 10544](https://github.com/bitcoin/bitcoin/pull/10544)). This version contains hardware acceleration for CRC
   on architectures supporting SSE 4.2. As a result, synchronization and block validation are now faster.
-- SHA256 hashing has been optimized for architectures supporting SSE 4 (See [PR 10821](https://github.com/BGL/BGL/pull/10821)). SHA256 is around
+- SHA256 hashing has been optimized for architectures supporting SSE 4 (See [PR 10821](https://github.com/bitcoin/bitcoin/pull/10821)). SHA256 is around
   50% faster on supported hardware, which results in around 5% faster IBD and block
   validation. In version 0.15, SHA256 hardware optimization is disabled in release builds by
   default, but can be enabled by using `--enable-experimental-asm` when building.
-- Refill of the keypool no longer flushes the wallet between each key which resulted in a ~20x speedup in creating a new wallet. Part of this speedup was used to increase the default keypool to 1000 keys to make recovery more robust. (See [PR 10831](https://github.com/BGL/BGL/pull/10831)).
+- Refill of the keypool no longer flushes the wallet between each key which resulted in a ~20x speedup in creating a new wallet. Part of this speedup was used to increase the default keypool to 1000 keys to make recovery more robust. (See [PR 10831](https://github.com/bitcoin/bitcoin/pull/10831)).
 
 Fee Estimation Improvements
 ---------------------------
 
-Fee estimation has been significantly improved in version 0.15, with more accurate fee estimates used by the wallet and a wider range of options for advanced users of the `estimatesmartfee` and `estimaterawfee` RPCs (See [PR 10199](https://github.com/BGL/BGL/pull/10199)).
+Fee estimation has been significantly improved in version 0.15, with more accurate fee estimates used by the wallet and a wider range of options for advanced users of the `estimatesmartfee` and `estimaterawfee` RPCs (See [PR 10199](https://github.com/bitcoin/bitcoin/pull/10199)).
 
 ### Changes to internal logic and wallet behavior
 
 - Internally, estimates are now tracked on 3 different time horizons. This allows for longer targets and means estimates adjust more quickly to changes in conditions.
 - Estimates can now be *conservative* or *economical*. *Conservative* estimates use longer time horizons to produce an estimate which is less susceptible to rapid changes in fee conditions. *Economical* estimates use shorter time horizons and will be more affected by short-term changes in fee conditions. Economical estimates may be considerably lower during periods of low transaction activity (for example over weekends), but may result in transactions being unconfirmed if prevailing fees increase rapidly.
-- By default, the wallet will use conservative fee estimates to increase the reliability of transactions being confirmed within the desired target. For transactions that are marked as replaceable, the wallet will use an economical estimate by default, since the fee can be 'bumped' if the fee conditions change rapidly (See [PR 10589](https://github.com/BGL/BGL/pull/10589)).
+- By default, the wallet will use conservative fee estimates to increase the reliability of transactions being confirmed within the desired target. For transactions that are marked as replaceable, the wallet will use an economical estimate by default, since the fee can be 'bumped' if the fee conditions change rapidly (See [PR 10589](https://github.com/bitcoin/bitcoin/pull/10589)).
 - Estimates can now be made for confirmation targets up to 1008 blocks (one week).
 - More data on historical fee rates is stored, leading to more precise fee estimates.
 - Transactions which leave the mempool due to eviction or other non-confirmed reasons are now taken into account by the fee estimation logic, leading to more accurate fee estimates.
@@ -132,27 +132,27 @@ Fee estimation has been significantly improved in version 0.15, with more accura
 ### Changes to fee estimate RPCs
 
 - The `estimatefee` RPC is now deprecated in favor of using only `estimatesmartfee` (which is the implementation used by the GUI)
-- The `estimatesmartfee` RPC interface has been changed (See [PR 10707](https://github.com/BGL/BGL/pull/10707)):
+- The `estimatesmartfee` RPC interface has been changed (See [PR 10707](https://github.com/bitcoin/bitcoin/pull/10707)):
     - The `nblocks` argument has been renamed to `conf_target` (to be consistent with other RPC methods).
     - An `estimate_mode` argument has been added. This argument takes one of the following strings: `CONSERVATIVE`, `ECONOMICAL` or `UNSET` (which defaults to `CONSERVATIVE`).
     - The RPC return object now contains an `errors` member, which returns errors encountered during processing.
-    - If BGL Core has not been running for long enough and has not seen enough blocks or transactions to produce an accurate fee estimation, an error will be returned (previously a value of -1 was used to indicate an error, which could be confused for a feerate).
+    - If Bitcoin Core has not been running for long enough and has not seen enough blocks or transactions to produce an accurate fee estimation, an error will be returned (previously a value of -1 was used to indicate an error, which could be confused for a feerate).
 - A new `estimaterawfee` RPC is added to provide raw fee data. External clients can query and use this data in their own fee estimation logic.
 
 Multi-wallet support
 --------------------
 
-BGL Core now supports loading multiple, separate wallets (See [PR 8694](https://github.com/BGL/BGL/pull/8694), [PR 10849](https://github.com/BGL/BGL/pull/10849)). The wallets are completely separated, with individual balances, keys and received transactions.
+Bitcoin Core now supports loading multiple, separate wallets (See [PR 8694](https://github.com/bitcoin/bitcoin/pull/8694), [PR 10849](https://github.com/bitcoin/bitcoin/pull/10849)). The wallets are completely separated, with individual balances, keys and received transactions.
 
-Multi-wallet is enabled by using more than one `-wallet` argument when starting BGL, either on the command line or in the BGL config file.
+Multi-wallet is enabled by using more than one `-wallet` argument when starting Bitcoin, either on the command line or in the Bitcoin config file.
 
-**In BGL-Qt, only the first wallet will be displayed and accessible for creating and signing transactions.** GUI selectable multiple wallets will be supported in a future version. However, even in 0.15 other loaded wallets will remain synchronized to the node's current tip in the background. This can be useful if running a pruned node, since loading a wallet where the most recent sync is beyond the pruned height results in having to download and revalidate the whole blockchain. Continuing to synchronize all wallets in the background avoids this problem.
+**In Bitcoin-Qt, only the first wallet will be displayed and accessible for creating and signing transactions.** GUI selectable multiple wallets will be supported in a future version. However, even in 0.15 other loaded wallets will remain synchronized to the node's current tip in the background. This can be useful if running a pruned node, since loading a wallet where the most recent sync is beyond the pruned height results in having to download and revalidate the whole blockchain. Continuing to synchronize all wallets in the background avoids this problem.
 
-BGL Core 0.15.0 contains the following changes to the RPC interface and `BGL-cli` for multi-wallet:
+Bitcoin Core 0.15.0 contains the following changes to the RPC interface and `bitcoin-cli` for multi-wallet:
 
-* When running BGL Core with a single wallet, there are **no** changes to the RPC interface or `BGL-cli`. All RPC calls and `BGL-cli` commands continue to work as before.
-* When running BGL Core with multi-wallet, all *node-level* RPC methods continue to work as before. HTTP RPC requests should be send to the normal `<RPC IP address>:<RPC port>` endpoint, and `BGL-cli` commands should be run as before. A *node-level* RPC method is any method which does not require access to the wallet.
-* When running BGL Core with multi-wallet, *wallet-level* RPC methods must specify the wallet for which they're intended in every request. HTTP RPC requests should be send to the `<RPC IP address>:<RPC port>/wallet/<wallet name>` endpoint, for example `127.0.0.1:8332/wallet/wallet1.dat`. `BGL-cli` commands should be run with a `-rpcwallet` option, for example `BGL-cli -rpcwallet=wallet1.dat getbalance`.
+* When running Bitcoin Core with a single wallet, there are **no** changes to the RPC interface or `bitcoin-cli`. All RPC calls and `bitcoin-cli` commands continue to work as before.
+* When running Bitcoin Core with multi-wallet, all *node-level* RPC methods continue to work as before. HTTP RPC requests should be send to the normal `<RPC IP address>:<RPC port>` endpoint, and `bitcoin-cli` commands should be run as before. A *node-level* RPC method is any method which does not require access to the wallet.
+* When running Bitcoin Core with multi-wallet, *wallet-level* RPC methods must specify the wallet for which they're intended in every request. HTTP RPC requests should be send to the `<RPC IP address>:<RPC port>/wallet/<wallet name>` endpoint, for example `127.0.0.1:8332/wallet/wallet1.dat`. `bitcoin-cli` commands should be run with a `-rpcwallet` option, for example `bitcoin-cli -rpcwallet=wallet1.dat getbalance`.
 * A new *node-level* `listwallets` RPC method is added to display which wallets are currently loaded. The names returned by this method are the same as those used in the HTTP endpoint and for the `rpcwallet` argument.
 
 Note that while multi-wallet is now fully supported, the RPC multi-wallet interface should be considered unstable for version 0.15.0, and there may backwards-incompatible changes in future versions.
@@ -160,18 +160,18 @@ Note that while multi-wallet is now fully supported, the RPC multi-wallet interf
 Replace-by-fee control in the GUI
 ---------------------------------
 
-BGL Core has supported creating opt-in replace-by-fee (RBF) transactions
+Bitcoin Core has supported creating opt-in replace-by-fee (RBF) transactions
 since version 0.12.0, and since version 0.14.0 has included a `bumpfee` RPC method to
 replace unconfirmed opt-in RBF transactions with a new transaction that pays
 a higher fee.
 
 In version 0.15, creating an opt-in RBF transaction and replacing the unconfirmed
-transaction with a higher-fee transaction are both supported in the GUI (See [PR 9592](https://github.com/BGL/BGL/pull/9592)).
+transaction with a higher-fee transaction are both supported in the GUI (See [PR 9592](https://github.com/bitcoin/bitcoin/pull/9592)).
 
 Removal of Coin Age Priority
 ----------------------------
 
-In previous versions of BGL Core, a portion of each block could be reserved for transactions based on the age and value of UTXOs they spent. This concept (Coin Age Priority) is a policy choice by miners, and there are no consensus rules around the inclusion of Coin Age Priority transactions in blocks. In practice, only a few miners continue to use Coin Age Priority for transaction selection in blocks. BGL Core 0.15 removes all remaining support for Coin Age Priority (See [PR 9602](https://github.com/BGL/BGL/pull/9602)). This has the following implications:
+In previous versions of Bitcoin Core, a portion of each block could be reserved for transactions based on the age and value of UTXOs they spent. This concept (Coin Age Priority) is a policy choice by miners, and there are no consensus rules around the inclusion of Coin Age Priority transactions in blocks. In practice, only a few miners continue to use Coin Age Priority for transaction selection in blocks. Bitcoin Core 0.15 removes all remaining support for Coin Age Priority (See [PR 9602](https://github.com/bitcoin/bitcoin/pull/9602)). This has the following implications:
 
 - The concept of *free transactions* has been removed. High Coin Age Priority transactions would previously be allowed to be relayed even if they didn't attach a miner fee. This is no longer possible since there is no concept of Coin Age Priority. The `-limitfreerelay` and `-relaypriority` options which controlled relay of free transactions have therefore been removed.
 - The `-sendfreetransactions` option has been removed, since almost all miners do not include transactions which do not attach a transaction fee.
@@ -185,26 +185,26 @@ In previous versions of BGL Core, a portion of each block could be reserved for 
 Mempool Persistence Across Restarts
 -----------------------------------
 
-Version 0.14 introduced mempool persistence across restarts (the mempool is saved to a `mempool.dat` file in the data directory prior to shutdown and restores the mempool when the node is restarted). Version 0.15 allows this feature to be switched on or off using the `-persistmempool` command-line option (See [PR 9966](https://github.com/BGL/BGL/pull/9966)). By default, the option is set to true, and the mempool is saved on shutdown and reloaded on startup. If set to false, the `mempool.dat` file will not be loaded on startup or saved on shutdown.
+Version 0.14 introduced mempool persistence across restarts (the mempool is saved to a `mempool.dat` file in the data directory prior to shutdown and restores the mempool when the node is restarted). Version 0.15 allows this feature to be switched on or off using the `-persistmempool` command-line option (See [PR 9966](https://github.com/bitcoin/bitcoin/pull/9966)). By default, the option is set to true, and the mempool is saved on shutdown and reloaded on startup. If set to false, the `mempool.dat` file will not be loaded on startup or saved on shutdown.
 
 New RPC methods
 ---------------
 
 Version 0.15 introduces several new RPC methods:
 
-- `abortrescan` stops current wallet rescan, e.g. when triggered by an `importprivkey` call (See [PR 10208](https://github.com/BGL/BGL/pull/10208)).
-- `combinerawtransaction` accepts a JSON array of raw transactions and combines them into a single raw transaction (See [PR 10571](https://github.com/BGL/BGL/pull/10571)).
+- `abortrescan` stops current wallet rescan, e.g. when triggered by an `importprivkey` call (See [PR 10208](https://github.com/bitcoin/bitcoin/pull/10208)).
+- `combinerawtransaction` accepts a JSON array of raw transactions and combines them into a single raw transaction (See [PR 10571](https://github.com/bitcoin/bitcoin/pull/10571)).
 - `estimaterawfee` returns raw fee data so that customized logic can be implemented to analyze the data and calculate estimates. See [Fee Estimation Improvements](#fee-estimation-improvements) for full details on changes to the fee estimation logic and interface.
 - `getchaintxstats` returns statistics about the total number and rate of transactions
-  in the chain (See [PR 9733](https://github.com/BGL/BGL/pull/9733)).
+  in the chain (See [PR 9733](https://github.com/bitcoin/bitcoin/pull/9733)).
 - `listwallets` lists wallets which are currently loaded. See the *Multi-wallet* section
   of these release notes for full details (See [Multi-wallet support](#multi-wallet-support)).
-- `uptime` returns the total runtime of the `BGLd` server since its last start (See [PR 10400](https://github.com/BGL/BGL/pull/10400)).
+- `uptime` returns the total runtime of the `bitcoind` server since its last start (See [PR 10400](https://github.com/bitcoin/bitcoin/pull/10400)).
 
 Low-level RPC changes
 ---------------------
 
-- When using BGL Core in multi-wallet mode, RPC requests for wallet methods must specify
+- When using Bitcoin Core in multi-wallet mode, RPC requests for wallet methods must specify
   the wallet that they're intended for. See [Multi-wallet support](#multi-wallet-support) for full details.
 
 - The new database model no longer stores information about transaction
@@ -222,15 +222,15 @@ Low-level RPC changes
   `bytes_serialized`. The first is a more accurate estimate of actual disk usage, but
   is not deterministic. The second is unrelated to disk usage, but is a
   database-independent metric of UTXO set size: it counts every UTXO entry as 50 + the
-  length of its scriptPubKey (See [PR 10426](https://github.com/BGL/BGL/pull/10426)).
+  length of its scriptPubKey (See [PR 10426](https://github.com/bitcoin/bitcoin/pull/10426)).
 
-- `signrawtransaction` can no longer be used to combine multiple transactions into a single transaction. Instead, use the new `combinerawtransaction` RPC (See [PR 10571](https://github.com/BGL/BGL/pull/10571)).
+- `signrawtransaction` can no longer be used to combine multiple transactions into a single transaction. Instead, use the new `combinerawtransaction` RPC (See [PR 10571](https://github.com/bitcoin/bitcoin/pull/10571)).
 
-- `fundrawtransaction` no longer accepts a `reserveChangeKey` option. This option used to allow RPC users to fund a raw transaction using an key from the keypool for the change address without removing it from the available keys in the keypool. The key could then be re-used for a `getnewaddress` call, which could potentially result in confusing or dangerous behaviour (See [PR 10784](https://github.com/BGL/BGL/pull/10784)).
+- `fundrawtransaction` no longer accepts a `reserveChangeKey` option. This option used to allow RPC users to fund a raw transaction using an key from the keypool for the change address without removing it from the available keys in the keypool. The key could then be re-used for a `getnewaddress` call, which could potentially result in confusing or dangerous behaviour (See [PR 10784](https://github.com/bitcoin/bitcoin/pull/10784)).
 
 - `estimatepriority` and `estimatesmartpriority` have been removed. See [Removal of Coin Age Priority](#removal-of-coin-age-priority).
 
-- The `listunspent` RPC now takes a `query_options` argument (see [PR 8952](https://github.com/BGL/BGL/pull/8952)), which is a JSON object
+- The `listunspent` RPC now takes a `query_options` argument (see [PR 8952](https://github.com/bitcoin/bitcoin/pull/8952)), which is a JSON object
   containing one or more of the following members:
   - `minimumAmount` - a number specifying the minimum value of each UTXO
   - `maximumAmount` - a number specifying the maximum value of each UTXO
@@ -240,22 +240,22 @@ Low-level RPC changes
 - The `getmempoolancestors`, `getmempooldescendants`, `getmempoolentry` and `getrawmempool` RPCs no longer return `startingpriority` and `currentpriority`. See [Removal of Coin Age Priority](#removal-of-coin-age-priority).
 
 - The `dumpwallet` RPC now returns the full absolute path to the dumped wallet. It
-  used to return no value, even if successful (See [PR 9740](https://github.com/BGL/BGL/pull/9740)).
+  used to return no value, even if successful (See [PR 9740](https://github.com/bitcoin/bitcoin/pull/9740)).
 
-- In the `getpeerinfo` RPC, the return object for each peer now returns an `addrbind` member, which contains the ip address and port of the connection to the peer. This is in addition to the `addrlocal` member which contains the ip address and port of the local node as reported by the peer (See [PR 10478](https://github.com/BGL/BGL/pull/10478)).
+- In the `getpeerinfo` RPC, the return object for each peer now returns an `addrbind` member, which contains the ip address and port of the connection to the peer. This is in addition to the `addrlocal` member which contains the ip address and port of the local node as reported by the peer (See [PR 10478](https://github.com/bitcoin/bitcoin/pull/10478)).
 
-- The `disconnectnode` RPC can now disconnect a node specified by node ID (as well as by IP address/port). To disconnect a node based on node ID, call the RPC with the new `nodeid` argument (See [PR 10143](https://github.com/BGL/BGL/pull/10143)).
+- The `disconnectnode` RPC can now disconnect a node specified by node ID (as well as by IP address/port). To disconnect a node based on node ID, call the RPC with the new `nodeid` argument (See [PR 10143](https://github.com/bitcoin/bitcoin/pull/10143)).
 
-- The second argument in `prioritisetransaction` has been renamed from `priority_delta` to `dummy` since BGL Core no longer has a concept of coin age priority. The `dummy` argument has no functional effect, but is retained for positional argument compatibility. See [Removal of Coin Age Priority](#removal-of-coin-age-priority).
+- The second argument in `prioritisetransaction` has been renamed from `priority_delta` to `dummy` since Bitcoin Core no longer has a concept of coin age priority. The `dummy` argument has no functional effect, but is retained for positional argument compatibility. See [Removal of Coin Age Priority](#removal-of-coin-age-priority).
 
-- The `resendwallettransactions` RPC throws an error if the `-walletbroadcast` option is set to false (See [PR 10995](https://github.com/BGL/BGL/pull/10995)).
+- The `resendwallettransactions` RPC throws an error if the `-walletbroadcast` option is set to false (See [PR 10995](https://github.com/bitcoin/bitcoin/pull/10995)).
 
-- The second argument in the `submitblock` RPC argument has been renamed from `parameters` to `dummy`. This argument never had any effect, and the renaming is simply to communicate this fact to the user (See [PR 10191](https://github.com/BGL/BGL/pull/10191))
+- The second argument in the `submitblock` RPC argument has been renamed from `parameters` to `dummy`. This argument never had any effect, and the renaming is simply to communicate this fact to the user (See [PR 10191](https://github.com/bitcoin/bitcoin/pull/10191))
   (Clients should, however, use positional arguments for `submitblock` in order to be compatible with BIP 22.)
 
 - The `verbose` argument of `getblock` has been renamed to `verbosity` and now takes an integer from 0 to 2. Verbose level 0 is equivalent to `verbose=false`. Verbose level 1 is equivalent to `verbose=true`. Verbose level 2 will give the full transaction details of each transaction in the output as given by `getrawtransaction`. The old behavior of using the `verbose` named argument and a boolean value is still maintained for compatibility.
 
-- Error codes have been updated to be more accurate for the following error cases (See [PR 9853](https://github.com/BGL/BGL/pull/9853)):
+- Error codes have been updated to be more accurate for the following error cases (See [PR 9853](https://github.com/bitcoin/bitcoin/pull/9853)):
   - `getblock` now returns RPC_MISC_ERROR if the block can't be found on disk (for
   example if the block has been pruned). Previously returned RPC_INTERNAL_ERROR.
   - `pruneblockchain` now returns RPC_MISC_ERROR if the blocks cannot be pruned
@@ -268,13 +268,13 @@ Low-level RPC changes
   or subnet is invalid. Previously returned RPC_CLIENT_NODE_ALREADY_ADDED.
   - `setban` now returns RPC_CLIENT_INVALID_IP_OR_SUBNET if the user tries to unban
   a node that has not previously been banned. Previously returned RPC_MISC_ERROR.
-  - `removeprunedfunds` now returns RPC_WALLET_ERROR if `BGLd` is unable to remove
+  - `removeprunedfunds` now returns RPC_WALLET_ERROR if `bitcoind` is unable to remove
   the transaction. Previously returned RPC_INTERNAL_ERROR.
   - `removeprunedfunds` now returns RPC_INVALID_PARAMETER if the transaction does not
   exist in the wallet. Previously returned RPC_INTERNAL_ERROR.
   - `fundrawtransaction` now returns RPC_INVALID_ADDRESS_OR_KEY if an invalid change
   address is provided. Previously returned RPC_INVALID_PARAMETER.
-  - `fundrawtransaction` now returns RPC_WALLET_ERROR if `BGLd` is unable to create
+  - `fundrawtransaction` now returns RPC_WALLET_ERROR if `bitcoind` is unable to create
   the transaction. The error message provides further details. Previously returned
   RPC_INTERNAL_ERROR.
   - `bumpfee` now returns RPC_INVALID_PARAMETER if the provided transaction has
@@ -331,17 +331,17 @@ Low-level RPC changes
 - #9740 `9fec4da` Add friendly output to dumpwallet (aideca)
 - #10426 `16f6c98` Replace bytes_serialized with bogosize (sipa)
 - #10252 `980deaf` RPC/Mining: Restore API compatibility for prioritisetransaction (luke-jr)
-- #9672 `46311e7` Opt-into-RBF for RPC & BGL-tx (luke-jr)
+- #9672 `46311e7` Opt-into-RBF for RPC & bitcoin-tx (luke-jr)
 - #10481 `9c248e3` Decodehextx scripts sanity check  (achow101)
 - #10488 `fa1f106` Note that the prioritizetransaction dummy value is deprecated, and has no meaning (TheBlueMatt)
 - #9738 `c94b89e` gettxoutproof() should return consistent result (jnewbery)
 - #10191 `00350bd` [trivial] Rename unused RPC arguments 'dummy' (jnewbery)
 - #10627 `b62b4c8` fixed listunspent rpc convert parameter (tnakagawa)
 - #10412 `bef02fb` Improve wallet rescan API (ryanofsky)
-- #10400 `1680ee0` [RPC] Add an uptime command that displays the amount of time (in seconds) BGLd has been running (rvelhote)
+- #10400 `1680ee0` [RPC] Add an uptime command that displays the amount of time (in seconds) bitcoind has been running (rvelhote)
 - #10683 `d81bec7` rpc: Move the `generate` RPC call to rpcwallet (laanwj)
 - #10710 `30bc0f6` REST/RPC example update (Mirobit)
-- #10747 `9edda0c` [rpc] fix verbose argument for getblock in BGL-cli (jnewbery)
+- #10747 `9edda0c` [rpc] fix verbose argument for getblock in bitcoin-cli (jnewbery)
 - #10589 `104f5f2` More economical fee estimates for RBF and RPC options to control (morcos)
 - #10543 `b27b004` Change API to estimaterawfee (morcos)
 - #10807 `afd2fca` getbalance example covers at least 6 confirms (instagibbs)
@@ -450,7 +450,7 @@ Low-level RPC changes
 - #10136 `81da4c7` build: Disable Wshadow warning (laanwj)
 - #10166 `64962ae` Ignore Doxyfile generated from Doxyfile.in template (paveljanik)
 - #10239 `0416ea9` Make Boost use std::atomic internally (sipa)
-- #10228 `27faa6c` build: regenerate BGL-config.h as necessary (theuni)
+- #10228 `27faa6c` build: regenerate bitcoin-config.h as necessary (theuni)
 - #10273 `8979f45` [scripts] Minor improvements to `macdeployqtplus` script (chrisgavin)
 - #10325 `a26280b` 0.15.0 Depends Updates (fanquake)
 - #10328 `79aeff6` Update contrib/debian to latest Ubuntu PPA upload (TheBlueMatt)
@@ -576,7 +576,7 @@ Low-level RPC changes
 - #9497 `2c781fb` CCheckQueue Unit Tests (JeremyRubin)
 - #10024 `9225de2` [trivial] Use log.info() instead of print() in remaining functional test cases (jnewbery)
 - #9956 `3192e52` Reorganise qa directory (jnewbery)
-- #10017 `02d64bd` combine_logs.py - aggregates log files from multiple BGLds during functional tests (jnewbery)
+- #10017 `02d64bd` combine_logs.py - aggregates log files from multiple bitcoinds during functional tests (jnewbery)
 - #10047 `dfef6b6` [tests] Remove unused variables and imports (practicalswift)
 - #9701 `a230b05` Make bumpfee tests less fragile (ryanofsky)
 - #10053 `ca20923` [test] Allow functional test cases to be skipped (jnewbery)
@@ -596,7 +596,7 @@ Low-level RPC changes
 - #10152 `080d7c7` [trivial] remove unused line in Travis config (jnewbery)
 - #10159 `df1ca9e` [tests] color test results and sort alphabetically (jnewbery)
 - #10124 `88799ea` [test] Suppress test logging spam (jnewbery)
-- #10142 `ed09dd3` Run BGL_test-qt under minimal QPA platform (ryanofsky)
+- #10142 `ed09dd3` Run bitcoin_test-qt under minimal QPA platform (ryanofsky)
 - #9949 `a27dbc5` [bench] Avoid function call arguments which are pointers to uninitialized values (practicalswift)
 - #10187 `b44adf9` tests: Fix test_runner return value in case of skipped test (laanwj)
 - #10197 `d86bb07` [tests] Functional test warnings (jnewbery)
@@ -634,7 +634,7 @@ Low-level RPC changes
 - #10415 `217b416` [tests] Speed up fuzzing by ~200x when using afl-fuzz (practicalswift)
 - #10445 `b4b057a` Add test for empty chain and reorg consistency for gettxoutsetinfo (gmaxwell)
 - #10423 `1aefc94` [tests] skipped tests should clean up after themselves (jnewbery)
-- #10359 `329fc1d` [tests] functional tests should call BGLTestFramework start/stop node methods (jnewbery)
+- #10359 `329fc1d` [tests] functional tests should call BitcoinTestFramework start/stop node methods (jnewbery)
 - #10514 `e103b3f` Bugfix: missing == 0 after randrange (sipa)
 - #10515 `c871f32` [test] Add test for getchaintxstats (jimmysong)
 - #10509 `bea5b00` Remove xvfb configuration from travis (ryanofsky)
@@ -648,12 +648,12 @@ Low-level RPC changes
 - #10555 `643fa0b` [tests] various improvements to zmq_test.py (jnewbery)
 - #10533 `d083bd9` [tests] Use cookie auth instead of rpcuser and rpcpassword (achow101)
 - #10632 `c68a9a6` qa: Add stopatheight test (MarcoFalke)
-- #10636 `4bc853b` [qa] util: Check return code after closing BGLd proc (MarcoFalke)
+- #10636 `4bc853b` [qa] util: Check return code after closing bitcoind proc (MarcoFalke)
 - #10662 `e0a7801` Initialize randomness in benchmarks (achow101)
 - #10612 `7c87a9c` The young person's guide to the test_framework (jnewbery)
 - #10659 `acb1153` [qa] blockchain: Pass on closed connection during generate call (MarcoFalke)
 - #10690 `416af3e` [qa] Bugfix: allow overriding extra_args in ComparisonTestFramework (sdaftuar)
-- #10556 `65cc7aa` Move stop/start functions from utils.py into BGLTestFramework (jnewbery)
+- #10556 `65cc7aa` Move stop/start functions from utils.py into BitcoinTestFramework (jnewbery)
 - #10704 `dd07f47` [tests] nits in dbcrash.py (jnewbery)
 - #10743 `be82498` [test] don't run dbcrash.py on Travis (jnewbery)
 - #10761 `d3b5870` [tests] fix replace_by_fee.py (jnewbery)
@@ -694,7 +694,7 @@ Low-level RPC changes
 - #9734 `0c17afc` Add updating of chainTxData to release process (sipa)
 - #10063 `530fcbd` add missing spaces so that markdown recognizes headline (flack)
 - #10085 `db1ae54` Docs: remove 'noconnect' option (jlopp)
-- #10090 `8e4f7e7` Update BGL.conf with example for pruning (coinables)
+- #10090 `8e4f7e7` Update bitcoin.conf with example for pruning (coinables)
 - #9424 `1a5aaab` Change LogAcceptCategory to use uint32_t rather than sets of strings (gmaxwell)
 - #10036 `fbf36ca` Fix init README format to render correctly on github (jlopp)
 - #10058 `a2cd0b0` No need to use OpenSSL malloc/free (tjps)
@@ -718,10 +718,10 @@ Low-level RPC changes
 - #10372 `15254e9` Add perf counter data to GetStrongRandBytes state in scheduler (TheBlueMatt)
 - #10461 `55b72f3` Update style guide (sipa)
 - #10486 `10e8c0a` devtools: Retry after signing fails in github-merge (laanwj)
-- #10447 `f259263` Make BGLd invalid argument error message specific (laanwj)
+- #10447 `f259263` Make bitcoind invalid argument error message specific (laanwj)
 - #10495 `6a38b79` contrib: Update location of seeds.txt (laanwj)
 - #10469 `b6b150b` Fixing typo in rpcdump.cpp help message (keystrike)
-- #10451 `27b9931` contrib/init/BGLd.openrcconf: Don't disable wallet by default (luke-jr)
+- #10451 `27b9931` contrib/init/bitcoind.openrcconf: Don't disable wallet by default (luke-jr)
 - #10323 `00d3692` Update to latest libsecp256k1 master (sipa)
 - #10422 `cec9e1e` Fix timestamp in fee estimate debug message (morcos)
 - #10566 `5d034ee` [docs] Use the "domain name setup" image (previously unused) in the gitian docs (practicalswift)
@@ -740,9 +740,9 @@ Low-level RPC changes
 - #10728 `7397af9` fix typo in help text for removeprunedfunds (AkioNak)
 - #10193 `6dbcc74` scripted-diff: Remove #include <boost/foreach.hpp> (jtimon)
 - #10676 `379aed0` document script-based return fields for validateaddress (instagibbs)
-- #10651 `cef4b5c` Verify binaries from BGLcore.org and BGL.org (TheBlueMatt)
+- #10651 `cef4b5c` Verify binaries from bitcoincore.org and bitcoin.org (TheBlueMatt)
 - #10786 `ca4c545` Add PR description to merge commit in github-merge.py (sipa)
-- #10812 `c5904e8` [utils] Allow BGL-cli's -rpcconnect option to be used with square brackets (jnewbery)
+- #10812 `c5904e8` [utils] Allow bitcoin-cli's -rpcconnect option to be used with square brackets (jnewbery)
 - #10842 `3895e25` Fix incorrect Doxygen tag (@ince → @since). Doxygen parameter name matching (practicalswift)
 - #10681 `df0793f` add gdb attach process to test README (instagibbs)
 - #10789 `1124328` Punctuation/grammer fixes in rpcwallet.cpp (stevendlander)
@@ -759,7 +759,7 @@ Low-level RPC changes
 - #9792 `342b9bc` FastRandomContext improvements and switch to ChaCha20 (sipa)
 - #9505 `67ed40e` Prevector Quick Destruct (JeremyRubin)
 - #10820 `ef37f20` Use cpuid intrinsics instead of asm code (sipa)
-- #9999 `a328904` [LevelDB] Plug leveldb logs to BGL logs (NicolasDorier)
+- #9999 `a328904` [LevelDB] Plug leveldb logs to bitcoin logs (NicolasDorier)
 - #9693 `c5e9e42` Prevent integer overflow in ReadVarInt (gmaxwell)
 - #10129 `351d0ad` scheduler: fix sub-second precision with boost < 1.50 (theuni)
 - #10153 `fade788` logging: Fix off-by-one for shrinkdebugfile default (MarcoFalke)
@@ -771,7 +771,7 @@ Low-level RPC changes
 - #10837 `8bc6d1f` Fix resource leak on error in GetDevURandom (corebob)
 - #10832 `89bb036` init: Factor out AppInitLockDataDirectory and fix startup core dump issue (laanwj)
 - #10914 `b995a37` Add missing lock in CScheduler::AreThreadsServicingQueue() (TheBlueMatt)
-- #10958 `659c096` Update to latest BGL patches for LevelDB (sipa)
+- #10958 `659c096` Update to latest Bitcoin patches for LevelDB (sipa)
 - #10919 `c1c671f` Fix more init bugs (TheBlueMatt)
 
 Credits
@@ -875,4 +875,4 @@ Thanks to everyone who directly contributed to this release:
 - Warren Togami
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.15.0.md
+++ b/doc/release-notes/release-notes-0.15.0.md
@@ -7,7 +7,7 @@ and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.15.1.md
+++ b/doc/release-notes/release-notes-0.15.1.md
@@ -11,7 +11,7 @@ performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.15.1.md
+++ b/doc/release-notes/release-notes-0.15.1.md
@@ -1,29 +1,29 @@
-BGL Core version *0.15.1* is now available from:
+Bitcoin Core version *0.15.1* is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.15.1/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.15.1/>
 
 or
 
-  <https://BGL.org/bin/BGL-core-0.15.1/>
+  <https://bitcoin.org/bin/bitcoin-core-0.15.1/>
 
 This is a new minor version release, including various bugfixes and
 performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the 
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 The first time you run version 0.15.0 or higher, your chainstate database will
 be converted to a new format, which will take anywhere from a few minutes to
@@ -52,10 +52,10 @@ processing the entire blockchain.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 
@@ -65,7 +65,7 @@ Notable changes
 Network fork safety enhancements
 --------------------------------
 
-A number of changes to the way BGL Core deals with peer connections and invalid blocks
+A number of changes to the way Bitcoin Core deals with peer connections and invalid blocks
 have been made, as a safety precaution against blockchain forks and misbehaving peers.
 
 - Unrequested blocks with less work than the minimum-chain-work are now no longer processed even
@@ -202,19 +202,19 @@ Low-level RPC changes
 - #11399 `a825d4a` Fix bip68-sequence rpc test (jl2012)
 - #11150 `847c75e` Add getmininginfo test (mess110)
 - #11407 `806c78f` add functional test for mempoolreplacement command line arg (instagibbs)
-- #11433 `e169349` Restore BGL-util-test py2 compatibility (MarcoFalke)
+- #11433 `e169349` Restore bitcoin-util-test py2 compatibility (MarcoFalke)
 - #11308 `2e1ac70` zapwallettxes: Wait up to 3s for mempool reload (MarcoFalke)
-- #10798 `716066d` test BGL-cli (jnewbery)
+- #10798 `716066d` test bitcoin-cli (jnewbery)
 - #11443 `019c492` Allow "make cov" out-of-tree; Fix rpc mapping check (MarcoFalke)
 - #11445 `51bad91` 0.15.1 Backports (MarcoFalke)
 - #11319 `2f0b30a` Fix error introduced into p2p-segwit.py, and prevent future similar errors (sdaftuar)
 - #10552 `e4605d9` Tests for zmqpubrawtx and zmqpubrawblock (achow101)
 - #11067 `eeb24a3` TestNode: Add wait_until_stopped helper method (MarcoFalke)
 - #11068 `5398f20` Move wait_until to util (MarcoFalke)
-- #11125 `812c870` Add BGL-cli -stdin and -stdinrpcpass functional tests (promag)
+- #11125 `812c870` Add bitcoin-cli -stdin and -stdinrpcpass functional tests (promag)
 - #11077 `1d80d1e` fix timeout issues from TestNode (jnewbery)
 - #11078 `f1ced0d` Make p2p-leaktests.py more robust (jnewbery)
-- #11210 `f3f7891` Stop test_BGL-qt touching ~/.BGL (MeshCollider)
+- #11210 `f3f7891` Stop test_bitcoin-qt touching ~/.bitcoin (MeshCollider)
 - #11234 `f0b6795` Remove redundant testutil.cpp|h files (MeshCollider)
 - #11215 `cef0319` fixups from set_test_params() (jnewbery)
 - #11345 `f9cf7b5` Check connectivity before sending in assumevalid.py (jnewbery)
@@ -232,7 +232,7 @@ Low-level RPC changes
 - #11310 `b6468d3` Test listwallets RPC (mess110)
 
 ### Miscellaneous
-- #11377 `75997c3` Disallow uncompressed pubkeys in BGL-tx [multisig] output adds (TheBlueMatt)
+- #11377 `75997c3` Disallow uncompressed pubkeys in bitcoin-tx [multisig] output adds (TheBlueMatt)
 - #11437 `dea3b87` [Docs] Update Windows build instructions for using WSL and Ubuntu 17.04 (fanquake)
 - #11318 `8b61aee` Put back inadvertently removed copyright notices (gmaxwell)
 - #11442 `cf18f42` [Docs] Update OpenBSD Build Instructions for OpenBSD 6.2 (fanquake)
@@ -274,4 +274,4 @@ Thanks to everyone who directly contributed to this release:
 - Tomas van der Wansem
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.15.2.md
+++ b/doc/release-notes/release-notes-0.15.2.md
@@ -7,7 +7,7 @@ performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.15.2.md
+++ b/doc/release-notes/release-notes-0.15.2.md
@@ -1,25 +1,25 @@
-BGL Core version *0.15.2* is now available from:
+Bitcoin Core version *0.15.2* is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.15.2/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.15.2/>
 
 This is a new minor version release, including various bugfixes and
 performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the 
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 The first time you run version 0.15.0 or higher, your chainstate database will
 be converted to a new format, which will take anywhere from a few minutes to
@@ -48,10 +48,10 @@ processing the entire blockchain.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 
@@ -62,7 +62,7 @@ Denial-of-Service vulnerability CVE-2018-17144
 -------------------------------
 
 A denial-of-service vulnerability exploitable by miners has been discovered in
-BGL Core versions 0.14.0 up to 0.16.2. It is recommended to upgrade any of
+Bitcoin Core versions 0.14.0 up to 0.16.2. It is recommended to upgrade any of
 the vulnerable versions to 0.15.2 or 0.16.3 as soon as possible.
 
 0.15.2 Change log
@@ -87,9 +87,9 @@ the vulnerable versions to 0.15.2 or 0.16.3 as soon as possible.
 - #11289 `42ea47d` Add wallet backup text to import*, add* and dumpwallet RPCs (MeshCollider)
 - #11590 `6372a75` [Wallet] always show help-line of wallet encryption calls (Jonas Schnelli)
 
-### BGL-tx
+### bitcoin-tx
 
-- #11554 `a69cc07` Sanity-check script sizes in BGL-tx (TheBlueMatt)
+- #11554 `a69cc07` Sanity-check script sizes in bitcoin-tx (TheBlueMatt)
 
 ### Tests
 - #11277 `3a6cdd4` Add test for multiwallet batch RPC calls (Russell Yanofsky)

--- a/doc/release-notes/release-notes-0.16.0.md
+++ b/doc/release-notes/release-notes-0.16.0.md
@@ -1,25 +1,25 @@
-BGL Core version 0.16.0 is now available from:
+Bitcoin Core version 0.16.0 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.16.0/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.16.0/>
 
 This is a new major version release, including new features, various bugfixes
 and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 The first time you run version 0.15.0 or newer, your chainstate database will be converted to a
 new format, which will take anywhere from a few minutes to half an hour,
@@ -40,10 +40,10 @@ wallets that were created with older versions are not affected by this.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notable changes
@@ -54,7 +54,7 @@ Wallet changes
 
 ### Segwit Wallet
 
-BGL Core 0.16.0 introduces full support for segwit in the wallet and user interfaces. A new `-addresstype` argument has been added, which supports `legacy`, `p2sh-segwit` (default), and `bech32` addresses. It controls what kind of addresses are produced by `getnewaddress`, `getaccountaddress`, and `createmultisigaddress`. A `-changetype` argument has also been added, with the same options, and by default equal to `-addresstype`, to control which kind of change is used.
+Bitcoin Core 0.16.0 introduces full support for segwit in the wallet and user interfaces. A new `-addresstype` argument has been added, which supports `legacy`, `p2sh-segwit` (default), and `bech32` addresses. It controls what kind of addresses are produced by `getnewaddress`, `getaccountaddress`, and `createmultisigaddress`. A `-changetype` argument has also been added, with the same options, and by default equal to `-addresstype`, to control which kind of change is used.
 
 A new `address_type` parameter has been added to the `getnewaddress` and `addmultisigaddress` RPCs to specify which type of address to generate.
 A `change_type` argument has been added to the `fundrawtransaction` RPC to override the `-changetype` argument for specific transactions.
@@ -92,9 +92,9 @@ use the `replaceable` argument for individual transactions.
 
 ### Wallets directory configuration (`-walletdir`)
 
-BGL Core now has more flexibility in where the wallets directory can be
+Bitcoin Core now has more flexibility in where the wallets directory can be
 located. Previously wallet database files were stored at the top level of the
-BGL data directory. The behavior is now:
+bitcoin data directory. The behavior is now:
 
 - For new installations (where the data directory doesn't already exist),
   wallets will now be stored in a new `wallets/` subdirectory inside the data
@@ -112,7 +112,7 @@ becomes unavailable during operation, funds may be lost.
 
 Build: Minimum GCC bumped to 4.8.x
 ------------------------------------
-The minimum version of the GCC compiler required to compile BGL Core is now 4.8. No effort will be
+The minimum version of the GCC compiler required to compile Bitcoin Core is now 4.8. No effort will be
 made to support older versions of GCC. See discussion in issue #11732 for more information.
 The minimum version for the Clang compiler is still 3.3. Other minimum dependency versions can be found in `doc/dependencies.md` in the repository.
 
@@ -191,14 +191,14 @@ The `validateaddress` RPC output has been extended with a few new fields, and su
 Other changed command-line options
 ----------------------------------
 - `-debuglogfile=<file>` can be used to specify an alternative debug logging file.
-- BGL-cli now has an `-stdinrpcpass` option to allow the RPC password to be read from standard input.
+- bitcoin-cli now has an `-stdinrpcpass` option to allow the RPC password to be read from standard input.
 - The `-usehd` option has been removed.
-- BGL-cli now supports a new `-getinfo` flag which returns an output like that of the now-removed `getinfo` RPC.
+- bitcoin-cli now supports a new `-getinfo` flag which returns an output like that of the now-removed `getinfo` RPC.
 
 Testing changes
 ----------------
 - The default regtest JSON-RPC port has been changed to 18443 to avoid conflict with testnet's default of 18332.
-- Segwit is now always active in regtest mode by default. Thus, if you upgrade a regtest node you will need to either -reindex or use the old rules by adding `vbparams=segwit:0:999999999999` to your regtest BGL.conf. Failure to do this will result in a CheckBlockIndex() assertion failure that will look like: Assertion `(pindexFirstNeverProcessed != nullptr) == (pindex->nChainTx == 0)' failed.
+- Segwit is now always active in regtest mode by default. Thus, if you upgrade a regtest node you will need to either -reindex or use the old rules by adding `vbparams=segwit:0:999999999999` to your regtest bitcoin.conf. Failure to do this will result in a CheckBlockIndex() assertion failure that will look like: Assertion `(pindexFirstNeverProcessed != nullptr) == (pindex->nChainTx == 0)' failed.
 
 0.16.0 change log
 ------------------
@@ -235,7 +235,7 @@ Testing changes
 - #11740 `59d3dc8` Implement BIP159 NODE_NETWORK_LIMITED (pruned peers) *signaling only* (jonasschnelli)
 - #11583 `37ffa16` Do not make it trivial for inbound peers to generate log entries (TheBlueMatt)
 - #11363 `ba2f195` Split socket create/connect (theuni)
-- #11917 `bc66765` Add testnet DNS seed:  seed.testnet.BGL.sprovoost.nl (Sjors)
+- #11917 `bc66765` Add testnet DNS seed:  seed.testnet.bitcoin.sprovoost.nl (Sjors)
 - #11512 `6e89de5` Use GetDesireableServiceFlags in seeds, dnsseeds, fixing static seed adding (TheBlueMatt)
 - #12262 `16bac24` Hardcoded seed update (laanwj)
 - #12270 `9cf6393` Update chainTxData for 0.16 (laanwj)
@@ -268,7 +268,7 @@ Testing changes
 - #11923 `81c89e9` Remove unused fNoncriticalErrors variable from CWalletDB::FindWalletTx (PierreRochard)
 - #11726 `604e08c` Cleanups + nit fixes for walletdir PR (MeshCollider)
 - #11403 `d889c03` Segwit wallet support (sipa)
-- #11970 `b7450cd` Add test coverage for BGL-cli multiwallet calls (ryanofsky)
+- #11970 `b7450cd` Add test coverage for bitcoin-cli multiwallet calls (ryanofsky)
 - #11904 `66e3af7` Add a lock to the wallet directory (MeshCollider)
 - #12101 `c7978be` Clamp walletpassphrase timeout to 2^30 seconds and check its bounds (achow101)
 - #12210 `17180fa` Deprecate addwitnessaddress (laanwj)
@@ -281,7 +281,7 @@ Testing changes
 ### RPC and other APIs
 - #11008 `3841aaf` Enable disablesafemode by default (gmaxwell)
 - #11050 `7ed57d3` Avoid treating null RPC arguments different from missing arguments (ryanofsky)
-- #10997 `affe927` Add option -stdinrpcpass to BGL-cli to allow RPC password to be read from standard input (jharvell)
+- #10997 `affe927` Add option -stdinrpcpass to bitcoin-cli to allow RPC password to be read from standard input (jharvell)
 - #11179 `e0e3cbb` Push down safe mode checks (laanwj)
 - #11203 `d745b4c` add wtxid to mempool entry output (sdaftuar)
 - #11099 `bc561b4` Add savemempool RPC (greenaddress)
@@ -366,7 +366,7 @@ Testing changes
 - #11541 `bb9ab0f` Build: Fix Automake warnings when running autogen.sh (fanquake)
 - #11611 `0e70791` [build] Don't fail when passed --disable-lcov and lcov isn't available (fanquake)
 - #11651 `3c098a8` refactor: Make all #includes relative to project root (laanwj, MeshCollider, ryanofsky)
-- #11621 `1f7695b` [build] Add temp_BGL_locale_qrc to CLEAN_QT to fix make distcheck (fanquake)
+- #11621 `1f7695b` [build] Add temp_bitcoin_locale_qrc to CLEAN_QT to fix make distcheck (fanquake)
 - #11755 `84fa645` [Docs] Bump minimum required version of GCC to 4.8 (fanquake)
 - #9254 `6d3dc52` [depends] ZeroMQ 4.2.2 (fanquake)
 - #11842 `3c8f0a3` [build] Add missing stuff to clean-local (kallewoof)
@@ -376,7 +376,7 @@ Testing changes
 - #11903 `8f68fd2` [trivial] Add required package dependencies for depends cross compilation (jonasschnelli)
 - #12168 `45cf8a0`  #include sys/fcntl.h to just fcntl.h (without sys/) (jsarenik)
 - #12095 `3fa1ab4` Use BDB_LIBS/CFLAGS and pass --disable-replication (fanquake)
-- #11711 `6378e5c` BGL_qt.m4: Minor fixes and clean-ups (fanquake)
+- #11711 `6378e5c` bitcoin_qt.m4: Minor fixes and clean-ups (fanquake)
 - #11989 `90d4104` .gitignore: add QT Creator artifacts (Sjors)
 - #11577 `c0ae864` Fix warnings (-Wsign-compare) when building with DEBUG_ADDRMAN (practicalswift)
 
@@ -389,7 +389,7 @@ Testing changes
 - #11260 `52f8877` travis: Assert default datadir isn't created, Run scripted diff only once (MarcoFalke)
 - #11271 `638e6c5` travis: filter out pyenv (theuni)
 - #11285 `3255d63` Add -usehd to excluded args in check-doc.py (MeshCollider)
-- #11297 `16e4184` Make sure ~/.BGL doesn't exist before build (MeshCollider)
+- #11297 `16e4184` Make sure ~/.bitcoin doesn't exist before build (MeshCollider)
 - #11311 `cce94c5` travis: Revert default datadir check (MarcoFalke)
 - #11300 `f4ed44a` Add a lint check for trailing whitespace (MeshCollider)
 - #11323 `4ce2f3d` mininode: add an optimistic write and disable nagle (theuni)
@@ -535,7 +535,7 @@ Testing changes
 - #10781 `60dd9cc` Python cleanups (practicalswift)
 - #10701 `50fae68` Remove the virtual specifier for functions with the override specifier (practicalswift)
 - #11164 `38a54a5` Fix boost headers included as user instead of system headers (danra)
-- #11143 `3aa60b7` Fix include path for BGL-config.h (danra)
+- #11143 `3aa60b7` Fix include path for bitcoin-config.h (danra)
 - #8330 `59e1789` Structure Packing Optimizations in C{,Mutable}Transaction (JeremyRubin)
 - #10845 `39ae413` Remove unreachable code (practicalswift)
 - #11238 `6acdb1f` Add assertions before potential null deferences (MeshCollider)
@@ -578,8 +578,8 @@ Testing changes
 
 ### Miscellaneous
 - #11246 `777519b` github-merge: Coalesce git fetches (laanwj)
-- #10871 `c9a4aa8` Handle getinfo in BGL-cli w/ -getinfo (revival of #8843) (achow101)
-- #11419 `093074b` Utils: Fix launchctl not being able to stop BGLd (OmeGak)
+- #10871 `c9a4aa8` Handle getinfo in bitcoin-cli w/ -getinfo (revival of #8843) (achow101)
+- #11419 `093074b` Utils: Fix launchctl not being able to stop bitcoind (OmeGak)
 - #11394 `6e4e98e` Perform a weaker subtree check in Travis (sipa)
 - #11702 `4122112` [build] Add a script for installing db4 (jamesob)
 - #11794 `dd49862` Prefix leveldb debug logging (laanwj)
@@ -596,7 +596,7 @@ Testing changes
 - #11951 `1fb34e0` Remove dead feeest-file read code for old versions (TheBlueMatt)
 - #11421 `9ccafb1` Merge current secp256k1 subtree (MarcoFalke)
 - #11573 `2631d55` [Util] Update tinyformat.h (fanquake)
-- #10529 `331352f` Improve BGLd systemd service file (Flowdalic)
+- #10529 `331352f` Improve bitcoind systemd service file (Flowdalic)
 - #11620 `70fec9e` [build] .gitignore: add background.tiff (Sjors)
 - #11558 `68e021e` Minimal code changes to allow msvc compilation (sipsorcery)
 - #11284 `10bee0d` Fix invalid memory access in CScript::operator+= (guidovranken, ajtowns)
@@ -717,4 +717,4 @@ Thanks to everyone who directly contributed to this release:
 - Willy Ko
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.16.0.md
+++ b/doc/release-notes/release-notes-0.16.0.md
@@ -7,7 +7,7 @@ and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.16.1.md
+++ b/doc/release-notes/release-notes-0.16.1.md
@@ -1,25 +1,25 @@
-BGL Core version 0.16.1 is now available from:
+Bitcoin Core version 0.16.1 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.16.1/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.16.1/>
 
 This is a new minor version release, with various bugfixes
 as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 The first time you run version 0.15.0 or newer, your chainstate database will be converted to a
 new format, which will take anywhere from a few minutes to half an hour,
@@ -40,10 +40,10 @@ wallets that were created with older versions are not affected by this.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notable changes
@@ -97,11 +97,11 @@ weights.
 - #12804 `4bdb0ce` Fix intermittent rpc_net.py failure. (jnewbery)
 - #12553 `0e98f96` Prefer wait_until over polling with time.sleep (Empact)
 - #12486 `cfebd40` Round target fee to 8 decimals in assert_fee_amount (kallewoof)
-- #12843 `df38b13` Test starting BGLd with -h and -version (jnewbery)
+- #12843 `df38b13` Test starting bitcoind with -h and -version (jnewbery)
 - #12475 `41c29f6` Fix python TypeError in script.py (MarcoFalke)
 - #12638 `0a76ed2` Cache only chain and wallet for regtest datadir (MarcoFalke)
 - #12902 `7460945` Handle potential cookie race when starting node (sdaftuar)
-- #12904 `6c26df0` Ensure BGLd processes are cleaned up when tests end (sdaftuar)
+- #12904 `6c26df0` Ensure bitcoind processes are cleaned up when tests end (sdaftuar)
 - #13049 `9ea62a3` Backports (MarcoFalke)
 - #13201 `b8aacd6` Handle disconnect_node race (sdaftuar)
 
@@ -142,4 +142,4 @@ Thanks to everyone who directly contributed to this release:
 - Tamas Blummer
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.16.1.md
+++ b/doc/release-notes/release-notes-0.16.1.md
@@ -7,7 +7,7 @@ as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.16.2.md
+++ b/doc/release-notes/release-notes-0.16.2.md
@@ -7,7 +7,7 @@ as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.16.2.md
+++ b/doc/release-notes/release-notes-0.16.2.md
@@ -1,25 +1,25 @@
-BGL Core version 0.16.2 is now available from:
+Bitcoin Core version 0.16.2 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.16.2/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.16.2/>
 
 This is a new minor version release, with various bugfixes
 as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 The first time you run version 0.15.0 or newer, your chainstate database will be converted to a
 new format, which will take anywhere from a few minutes to half an hour,
@@ -40,10 +40,10 @@ wallets that were created with older versions are not affected by this.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 0.16.2 change log
@@ -113,4 +113,4 @@ And to those that reported security issues:
 - Braydon Fuller
 - Himanshu Mehta
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.16.3.md
+++ b/doc/release-notes/release-notes-0.16.3.md
@@ -6,7 +6,7 @@ This is a new minor version release, with various bugfixes.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.16.3.md
+++ b/doc/release-notes/release-notes-0.16.3.md
@@ -1,24 +1,24 @@
-BGL Core version 0.16.3 is now available from:
+Bitcoin Core version 0.16.3 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.16.3/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.16.3/>
 
 This is a new minor version release, with various bugfixes.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 The first time you run version 0.15.0 or newer, your chainstate database will be converted to a
 new format, which will take anywhere from a few minutes to half an hour,
@@ -39,10 +39,10 @@ wallets that were created with older versions are not affected by this.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 Notable changes
@@ -52,7 +52,7 @@ Denial-of-Service vulnerability
 -------------------------------
 
 A denial-of-service vulnerability (CVE-2018-17144) exploitable by miners has
-been discovered in BGL Core versions 0.14.0 up to 0.16.2. It is recommended
+been discovered in Bitcoin Core versions 0.14.0 up to 0.16.2. It is recommended
 to upgrade any of the vulnerable versions to 0.16.3 as soon as possible.
 
 0.16.3 change log
@@ -65,7 +65,7 @@ to upgrade any of the vulnerable versions to 0.16.3 as soon as possible.
 - #13547 `212ef1f` Make `signrawtransaction*` give an error when amount is needed but missing (ajtowns)
 
 ### Miscellaneous
-- #13655 `1cdbea7` BGLconsensus: invalid flags error should be set to `BGLconsensus_err` (afk11)
+- #13655 `1cdbea7` bitcoinconsensus: invalid flags error should be set to `bitcoinconsensus_err` (afk11)
 
 ### Documentation
 - #13844 `11b9dbb` correct the help output for -prune (hebasto)

--- a/doc/release-notes/release-notes-0.17.0.1.md
+++ b/doc/release-notes/release-notes-0.17.0.1.md
@@ -1,16 +1,16 @@
-BGL Core version 0.17.0.1 is now available from:
+Bitcoin Core version 0.17.0.1 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.17.0.1/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.17.0.1/>
 
 This release provides a minor bug fix for 0.17.0.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 Notable changes
 ===============

--- a/doc/release-notes/release-notes-0.17.0.1.md
+++ b/doc/release-notes/release-notes-0.17.0.1.md
@@ -6,7 +6,7 @@ This release provides a minor bug fix for 0.17.0.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.17.0.md
+++ b/doc/release-notes/release-notes-0.17.0.md
@@ -1,25 +1,25 @@
-BGL Core version 0.17.0 is now available from:
+Bitcoin Core version 0.17.0 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.17.0/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.17.0/>
 
 This is a new major version release, including new features, various bugfixes
 and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 If your node has a txindex, the txindex db will be migrated the first time you run 0.17.0 or newer, which may take up to a few hours. Your node will not be functional until this migration completes.
 
@@ -46,10 +46,10 @@ processing the entire blockchain.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.10+, and Windows 7 and newer (Windows XP is not supported).
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 From 0.17.0 onwards macOS <10.10 is no longer supported. 0.17.0 is built using Qt 5.9.x, which doesn't
@@ -69,7 +69,7 @@ Changed configuration options
 -----------------------------
 
 - `-includeconf=<file>` can be used to include additional configuration files.
-  Only works inside the `BGL.conf` file, not inside included files or from
+  Only works inside the `bitcoin.conf` file, not inside included files or from
   command-line. Multiple files may be included. Can be disabled from command-
   line via `-noincludeconf`. Note that multi-argument commands like
   `-includeconf` will override preceding `-noincludeconf`, i.e.
@@ -78,7 +78,7 @@ Changed configuration options
   includeconf=relative.conf
   ```
 
-  as BGL.conf will still include `relative.conf`.
+  as bitcoin.conf will still include `relative.conf`.
 
 GUI changes
 -----------
@@ -109,7 +109,7 @@ same as before.
 Dynamic loading and creation of wallets
 ---------------------------------------
 
-Previously, wallets could only be loaded or created at startup, by specifying `-wallet` parameters on the command line or in the BGL.conf file. It is now possible to load, create and unload wallets dynamically at runtime:
+Previously, wallets could only be loaded or created at startup, by specifying `-wallet` parameters on the command line or in the bitcoin.conf file. It is now possible to load, create and unload wallets dynamically at runtime:
 
 - Existing wallets can be loaded by calling the `loadwallet` RPC. The wallet can be specified as file/directory basename (which must be located in the `walletdir` directory), or as an absolute path to a file/directory.
 - New wallets can be created (and loaded) by calling the `createwallet` RPC. The provided name must not match a wallet file in the `walletdir` directory or the name of a wallet that is currently loaded.
@@ -131,8 +131,8 @@ It is now possible for a single configuration file to set different
 options for different networks. This is done by using sections or by
 prefixing the option with the network, such as:
 
-    main.uacomment=BGL
-    test.uacomment=BGL-testnet
+    main.uacomment=bitcoin
+    test.uacomment=bitcoin-testnet
     regtest.uacomment=regtest
     [main]
     mempoolsize=300
@@ -151,7 +151,7 @@ outside of sections.
 
 A new 'label' API has been introduced for the wallet. This is intended as a
 replacement for the deprecated 'account' API. The 'account' can continue to
-be used in V0.17 by starting BGLd with the '-deprecatedrpc=accounts'
+be used in V0.17 by starting bitcoind with the '-deprecatedrpc=accounts'
 argument, and will be fully removed in V0.18.
 
 The label RPC methods mirror the account functionality, with the following functional differences:
@@ -184,18 +184,18 @@ Here are the changes to RPC methods:
 | `listtransactions`     | The `account` named parameter has been renamed to `dummy`. If provided, the `dummy` parameter must be set to the string `*`, unless running with the `-deprecatedrpc=accounts` argument (in which case functionality is unchanged). |
 | `getbalance`           | `account`, `minconf` and `include_watchonly` parameters are deprecated, and can only be used if running with '-deprecatedrpc=accounts' |
 
-BIP 174 Partially Signed BGL Transactions support
+BIP 174 Partially Signed Bitcoin Transactions support
 -----------------------------------------------------
 
-[BIP 174 PSBT](https://github.com/BGL/bips/blob/master/bip-0174.mediawiki) is an interchange format for BGL transactions that are not fully signed
+[BIP 174 PSBT](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki) is an interchange format for Bitcoin transactions that are not fully signed
 yet, together with relevant metadata to help entities work towards signing it.
 It is intended to simplify workflows where multiple parties need to cooperate to
 produce a transaction. Examples include hardware wallets, multisig setups, and
-[CoinJoin](https://BGLtalk.org/?topic=279249) transactions.
+[CoinJoin](https://bitcointalk.org/?topic=279249) transactions.
 
 ### Overall workflow
 
-Overall, the construction of a fully signed BGL transaction goes through the
+Overall, the construction of a fully signed Bitcoin transaction goes through the
 following steps:
 
 - A **Creator** proposes a particular transaction to be created. He constructs
@@ -210,7 +210,7 @@ following steps:
   partial signature for the inputs for which they have relevant key(s).
 - A **Finalizer** is run for each input to convert the partial signatures and
   possibly script information into a final `scriptSig` and/or `scriptWitness`.
-- An **Extractor** produces a valid BGL transaction (in network format)
+- An **Extractor** produces a valid Bitcoin transaction (in network format)
   from a PSBT for which all inputs are finalized.
 
 Generally, each of the above (excluding Creator and Extractor) will simply
@@ -256,7 +256,7 @@ hardware implementations will typically implement multiple roles simultaneously.
 Upgrading non-HD wallets to HD wallets
 --------------------------------------
 
-Since BGL Core 0.13.0, creating new BIP 32 Hierarchical Deterministic wallets has been supported by BGL Core but old non-HD wallets could not be upgraded to HD. Now non-HD wallets can be upgraded to HD using the `-upgradewallet` command line option. This upgrade will result in the all keys in the keypool being marked as used and a new keypool generated. **A new backup must be made when this upgrade is performed.**
+Since Bitcoin Core 0.13.0, creating new BIP 32 Hierarchical Deterministic wallets has been supported by Bitcoin Core but old non-HD wallets could not be upgraded to HD. Now non-HD wallets can be upgraded to HD using the `-upgradewallet` command line option. This upgrade will result in the all keys in the keypool being marked as used and a new keypool generated. **A new backup must be made when this upgrade is performed.**
 
 Additionally, `-upgradewallet` can be used to upgraded from a non-split HD chain (all keys generated with `m/0'/0'/i'`) to a split HD chain (receiving keys generated with `'m/0'/0'/i'` and change keys generated with `m'/0'/1'/i'`). When this upgrade occurs, all keys already in the keypool will remain in the keypool to be used until all keys from before the upgrade are exhausted. This is to avoid issues with backups and downgrades when some keys may come from the change key keypool. Users can begin using the new split HD chain keypools by using the `newkeypool` RPC to mark all keys in the keypool as used and begin using a new keypool generated from the split HD chain.
 
@@ -290,9 +290,9 @@ Low-level RPC changes
    `fee`, `modifiedfee`, `ancestorfee` and `descendantfee`.
 - The new RPC `getzmqnotifications` returns information about active ZMQ
   notifications.
-- When BGL is not started with any `-wallet=<path>` options, the name of
+- When bitcoin is not started with any `-wallet=<path>` options, the name of
   the default wallet returned by `getwalletinfo` and `listwallets` RPCs is
-  now the empty string `""` instead of `"wallet.dat"`. If BGL is started
+  now the empty string `""` instead of `"wallet.dat"`. If bitcoin is started
   with any `-wallet=<path>` options, there is no change in behavior, and the
   name of any wallet is just its `<path>` string.
 - Passing an empty string (`""`) as the `address_type` parameter to
@@ -322,7 +322,7 @@ Low-level RPC changes
   `pubkeys`, `sigsrequired`, `pubkey`, `addresses`, `embedded`, `iscompressed`,
   `account`, `timestamp`, `hdkeypath`, `hdmasterkeyid`.
 - `signrawtransaction` is deprecated and will be fully removed in v0.18. To use
-  `signrawtransaction` in v0.17, restart BGLd with
+  `signrawtransaction` in v0.17, restart bitcoind with
   `-deprecatedrpc=signrawtransaction`. Projects should transition to using
   `signrawtransactionwithkey` and `signrawtransactionwithwallet` before
   upgrading to v0.18.
@@ -336,7 +336,7 @@ Other API changes
 
 - The log timestamp format is now ISO 8601 (e.g. "2018-02-28T12:34:56Z").
 
-- When running BGLd with `-debug` but without `-daemon`, logging to stdout
+- When running bitcoind with `-debug` but without `-daemon`, logging to stdout
   is now the default behavior. Setting `-printtoconsole=1` no longer implicitly
   disables logging to debug.log. Instead, logging to file can be explicitly disabled
   by setting `-debuglogfile=0`.
@@ -345,7 +345,7 @@ Transaction index changes
 -------------------------
 
 The transaction index is now built separately from the main node procedure,
-meaning the `-txindex` flag can be toggled without a full reindex. If BGLd
+meaning the `-txindex` flag can be toggled without a full reindex. If bitcoind
 is run with `-txindex` on a node that is already partially or fully synced
 without one, the transaction index will be built in the background and become
 available once caught up. When switching from running `-txindex` to running
@@ -417,7 +417,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #10387 `5c2aff8` Eventually connect to `NODE_NETWORK_LIMITED` peers (jonasschnelli)
 - #9037 `a36834f` Add test-before-evict discipline to addrman (EthanHeilman)
 - #12622 `e1d6e2a` Correct addrman logging (laanwj)
-- #11962 `0a01843` add seed.BGL.sprovoost.nl to DNS seeds (Sjors)
+- #11962 `0a01843` add seed.bitcoin.sprovoost.nl to DNS seeds (Sjors)
 - #12569 `23e7fe8` Increase signal-to-noise ratio in debug.log by adjusting log level when logging failed non-manual connect():s (practicalswift)
 - #12855 `c199869` Minor accumulated cleanups (tjps)
 - #13153 `ef46c99` Add missing newlines to debug logging (laanwj)
@@ -568,7 +568,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #12080 `56cc022` Add support to search the address book (promag)
 - #12621 `2bac3e4` Avoid querying unnecessary model data when filtering transactions (promag)
 - #12721 `e476826` remove "new" button during receive-mode in addressbook (jonasschnelli)
-- #12723 `310dc61` Qt5: Warning users about invalid-BIP21 URI BGL:// (krab)
+- #12723 `310dc61` Qt5: Warning users about invalid-BIP21 URI bitcoin:// (krab)
 - #12610 `25cf18f` Multiwallet for the GUI (jonasschnelli)
 - #12779 `f4353da` Remove unused method setupAmountWidget(…) (practicalswift)
 - #12795 `68484d6` do not truncate .dat extension for wallets in gui (instagibbs)
@@ -587,7 +587,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13043 `6e249e4` OptionsDialog: add prune setting (Sjors)
 - #13506 `6579d80` load wallet in UI after possible init aborts (jonasschnelli)
 - #13458 `dc53f7f` Drop qt4 support (laanwj)
-- #13528 `b877c39` Move BGLGUI initializers to class, fix initializer order warning (laanwj)
+- #13528 `b877c39` Move BitcoinGUI initializers to class, fix initializer order warning (laanwj)
 - #13536 `baf3a3a` coincontrol: Remove unused qt4 workaround (MarcoFalke)
 - #13537 `10ffca7` Peer table: Visualize inbound/outbound state for every row (wodry)
 - #13791 `2c14c1f` Reject dialogs if key escape is pressed (promag)
@@ -623,7 +623,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13465 `81069a7` Avoid concurrency issue when make multiple target (ken2812221)
 - #13454 `45c00f8` Make sure `LC_ALL=C` is set in all shell scripts (practicalswift)
 - #13480 `31145a3` Avoid copies in range-for loops and add a warning to detect them (theuni)
-- #13486 `66e1a08` Move rpc/util.cpp from libBGL-util to libBGL-server (ken2812221)
+- #13486 `66e1a08` Move rpc/util.cpp from libbitcoin-util to libbitcoin-server (ken2812221)
 - #13580 `40334c7` Detect if char equals `int8_t` (ken2812221)
 - #12788 `287e4ed` Tune wildcards for LIBSECP256K1 target (kallewoof)
 - #13611 `b55f0c3` bugfix: Use `__cpuid_count` for gnu C to avoid gitian build fail (ken2812221)
@@ -633,7 +633,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13659 `90b1c7e` add missing leveldb defines (theuni)
 - #13368 `c0f1569` Update gitian-build.sh for docker (achow101)
 - #13171 `19d8ca5` Change gitian-descriptors to use bionic instead (ken2812221)
-- #13604 `75bea05` Add depends 32-bit arm support for BGL-qt (TheCharlatan)
+- #13604 `75bea05` Add depends 32-bit arm support for bitcoin-qt (TheCharlatan)
 - #13623 `9cdb19f` Migrate gitian-build.sh to python (ken2812221)
 - #13689 `8c36432` disable Werror when building zmq (greenaddress)
 - #13617 `cf7f9ae` release: Require macos 10.10+ (fanquake)
@@ -641,7 +641,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13095 `415f2bf` update `ax_boost_chrono`/`unit_test_framework` (fanquake)
 - #13732 `e8ffec6` Fix Qt's rcc determinism (Fuzzbawls)
 - #13782 `8284f1d` Fix osslsigncode compile issue in gitian-build (ken2812221)
-- #13696 `2ab7208` Add aarch64 qt depends support for cross compiling BGL-qt (TheCharlatan)
+- #13696 `2ab7208` Add aarch64 qt depends support for cross compiling bitcoin-qt (TheCharlatan)
 - #13705 `b413ba0` Add format string linter (practicalswift)
 - #14000 `48c8459` fix qt determinism (theuni)
 - #14018 `3e4829a` Bugfix: NSIS: Exclude `Makefile*` from docs (luke-jr)
@@ -652,12 +652,12 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #12252 `8d57319` Require all tests to follow naming convention (ajtowns)
 - #12295 `935eb8d` Enable flake8 warnings for all currently non-violated rules (practicalswift)
 - #11858 `b4d8549` Prepare tests for Windows (MarcoFalke)
-- #11771 `2dbc4a4` Change invalidtxrequest to use BGLTestFramework (jnewbery)
+- #11771 `2dbc4a4` Change invalidtxrequest to use BitcoinTestFramework (jnewbery)
 - #12200 `d09968f` Bind functional test nodes to 127.0.0.1 (Sjors)
 - #12425 `26dc2da` Add some script tests (richardkiss)
 - #12455 `23481fa` Fix bip68 sequence test to reflect updated rpc error message (Empact)
 - #12477 `acd1e61` Plug memory leaks and stack-use-after-scope (MarcoFalke)
-- #12443 `07090c5` Move common args to BGL.conf (MarcoFalke)
+- #12443 `07090c5` Move common args to bitcoin.conf (MarcoFalke)
 - #12570 `39dcac2` Add test cases for HexStr (`std::reverse_iterator` and corner cases) (kostaz)
 - #12582 `6012f1c` Fix ListCoins test failure due to unset `g_wallet_allow_fallback_fee` (ryanofsky)
 - #12516 `7f99964` Avoid unintentional unsigned integer wraparounds in tests (practicalswift)
@@ -665,7 +665,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #12600 `29088b1` Add a test for large tx output scripts with segwit input (richardkiss)
 - #12627 `791c3ea` Fix some tests to work on native windows (MarcoFalke)
 - #12405 `0f58d7f` travis: Full clone for git subtree check (MarcoFalke)
-- #11772 `0630974` Change invalidblockrequest to use BGLTestFramework (jnewbery)
+- #11772 `0630974` Change invalidblockrequest to use BitcoinTestFramework (jnewbery)
 - #12681 `1846296` Fix ComputeTimeSmart test failure with `-DDEBUG_LOCKORDER` (ryanofsky)
 - #12682 `9f04c8e` travis: Clone depth 1 unless `$check_doc` (MarcoFalke)
 - #12710 `00d1680` Append scripts to new `test_list` array to fix bad assignment (jeffrade)
@@ -678,9 +678,9 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #12806 `18606eb` Fix function names in `feature_blocksdir` (MarcoFalke)
 - #12811 `0d8fc8d` Make summary row bold-red if any test failed and show failed tests at end of table (laanwj)
 - #12790 `490644d` Use blockmaxweight where tests previously had blockmaxsize (conscott)
-- #11773 `f0f9732` Change `feature_block.py` to use BGLTestFramework (jnewbery)
+- #11773 `f0f9732` Change `feature_block.py` to use BitcoinTestFramework (jnewbery)
 - #12839 `40f4baf` Remove travis checkout depth (laanwj)
-- #11817 `2a09a78` Change `feature_csv_activation.py` to use BGLTestFramework (jnewbery)
+- #11817 `2a09a78` Change `feature_csv_activation.py` to use BitcoinTestFramework (jnewbery)
 - #12284 `fa5825d` Remove assigned but never used local variables. Enable Travis checking for unused local variables (practicalswift)
 - #12719 `9beded5` Add note about test suite naming convention in developer-notes.md (practicalswift)
 - #12861 `c564424` Stop `feature_block.py` from blowing up memory (jnewbery)
@@ -690,7 +690,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #12766 `69310a3` Tidy up REST interface functional tests (romanz)
 - #12849 `83c7533` Add logging in loops in `p2p_sendhears.py` (ccdle12)
 - #12895 `d6f10b2` Add note about test suite name uniqueness requirement to developer notes (practicalswift)
-- #12856 `27278df` Add Metaclass for BGLTestFramework (WillAyd)
+- #12856 `27278df` Add Metaclass for BitcoinTestFramework (WillAyd)
 - #12918 `6fc5a05` Assert on correct variable (kallewoof)
 - #11878 `a04440f` Add Travis check for duplicate includes (practicalswift)
 - #12917 `cf8073f` Windows fixups for functional tests (MarcoFalke)
@@ -747,7 +747,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13219 `08516e0` bench: Add block assemble benchmark (MarcoFalke)
 - #13530 `b1dc39d` bench: Add missing pow.h header (laanwj)
 - #12686 `2643fa5` Add -ftrapv to CFLAGS and CXXFLAGS when --enable-debug is used. Enable -ftrapv in Travis (practicalswift)
-- #12882 `d96bdd7` Make `test_BGL` pass under ThreadSanitzer (clang). Fix lock-order-inversion (potential deadlock) (practicalswift)
+- #12882 `d96bdd7` Make `test_bitcoin` pass under ThreadSanitzer (clang). Fix lock-order-inversion (potential deadlock) (practicalswift)
 - #13535 `2328039` `wallet_basic`: Specify minimum required amount for listunspent (MarcoFalke)
 - #13551 `c93c360` Fix incorrect documentation for test case `cuckoocache_hit_rate_ok` (practicalswift)
 - #13563 `b330f3f` bench: Simplify coinselection (promag)
@@ -763,7 +763,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13663 `cbc9b50` Avoid read/write to default datadir (MarcoFalke)
 - #13682 `f8a32a3` bench: Remove unused variable (practicalswift)
 - #13638 `6fcdb5e` Use `MAX_SCRIPT_ELEMENT_SIZE` from script.py (domob1812)
-- #13687 `9d26b69` travis: Check that ~/.BGL is never created (MarcoFalke)
+- #13687 `9d26b69` travis: Check that ~/.bitcoin is never created (MarcoFalke)
 - #13715 `e1260a7` fixes mininode's P2PConnection sending messages on closing transport (marcoagner)
 - #13729 `aa9429a` travis: Avoid unnecessarily setting env variables on the lint build (Empact)
 - #13747 `ab28b5b` Skip P2PConnection's `is_closing()` check when not available (domob1812)
@@ -774,7 +774,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13779 `d25079a` travis: Improve readability of travis.yml and log outputs (scravy)
 - #13822 `0fb9c87` bench: Make coinselection output groups pass eligibility filter (achow101)
 - #13247 `e83d82a` Add tests to SingleThreadedSchedulerClient() and document the memory model (skeees)
-- #13811 `660abc1` travis: Run `bench_BGL` once (MarcoFalke)
+- #13811 `660abc1` travis: Run `bench_bitcoin` once (MarcoFalke)
 - #13837 `990e182` Extract `rpc_timewait` as test param (MarcoFalke)
 - #13851 `9c4324d` fix locale for lint-shell (scravy)
 - #13823 `489b51b` quote path in authproxy for external multiwallets (MarcoFalke)
@@ -809,8 +809,8 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #10694 `ae5bcc7` Remove redundant code in MutateTxSign(CMutableTransaction&, const std::string&) (practicalswift)
 - #12659 `3d16f58` Improve Fatal LevelDB Log Messages (eklitzke)
 - #12643 `0f0229d` util: Remove unused `sync_chain` (MarcoFalke)
-- #12102 `7fb8fb4` Apply hardening measures in BGLd systemd service file (Flowdalic)
-- #12652 `55f490a` BGL-cli: Provide a better error message when BGLd is not running (practicalswift)
+- #12102 `7fb8fb4` Apply hardening measures in bitcoind systemd service file (Flowdalic)
+- #12652 `55f490a` bitcoin-cli: Provide a better error message when bitcoind is not running (practicalswift)
 - #12630 `c290508` Provide useful error message if datadir is not writable (murrayn)
 - #11881 `624bee9` Remove Python2 support (jnewbery)
 - #12821 `082e26c` contrib: Remove unused import string (MarcoFalke)
@@ -831,7 +831,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13031 `826acc9` Fix for utiltime to compile with msvc (sipsorcery)
 - #13119 `81743b5` Remove script to clean up datadirs (MarcoFalke)
 - #12954 `5a66642` util: Refactor logging code into a global object (jimpo)
-- #12769 `35eb9d6` Add systemd service to BGLd in debian package (ghost)
+- #12769 `35eb9d6` Add systemd service to bitcoind in debian package (ghost)
 - #13146 `0bc980b` rpcauth: Make it possible to provide a custom password (laanwj)
 - #13148 `b62b437` logging: Fix potential use-after-free in logprintstr(…) (practicalswift)
 - #13214 `0612d96` Enable Travis checking for two Python linting rules we are currently not violating (practicalswift)
@@ -840,7 +840,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13228 `d792e47` Add script to detect circular dependencies between source modules (sipa)
 - #13320 `e08c130` Ensure gitian-build.sh uses bash (jhfrontz)
 - #13301 `e4082d5` lint: Add linter to error on `#include <*.cpp>` (Empact)
-- #13374 `56f6936` utils and libraries: checking for BGL address in translations (kaplanmaxe)
+- #13374 `56f6936` utils and libraries: checking for bitcoin address in translations (kaplanmaxe)
 - #13230 `7c32b41` Simplify include analysis by enforcing the developer guide's include syntax (practicalswift)
 - #13450 `32bf4c6` Add linter: Enforce the source code file naming convention described in the developer notes (practicalswift)
 - #13479 `fa2ea37` contrib: Fix cve-2018-12356 by hardening the regex (loganaden)
@@ -848,7 +848,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13494 `d67eff8` Follow-up to #13454: Fix broken build by exporting `LC_ALL=C` (practicalswift)
 - #13510 `03f3925` Scripts and tools: Obsolete #!/bin/bash shebang (DesWurstes)
 - #13577 `c9eb8d1` logging: Avoid nstart may be used uninitialized in appinitmain warning (mruddy)
-- #13603 `453ae5e` BGL-tx: Stricter check for valid integers (domob1812)
+- #13603 `453ae5e` bitcoin-tx: Stricter check for valid integers (domob1812)
 - #13118 `c05c93c` RPCAuth Detection in Logs (Linrono)
 - #13647 `4027ec1` Scripts and tools: Fix `BIND_NOW` check in security-check.py (conradoplg)
 - #13692 `f5d166a` contrib: Clone core repo in gitian-build (MarcoFalke)
@@ -872,7 +872,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13441 `4a7e64f` Prevent shared conf files from failing with different available options in different binaries (achow101)
 - #13471 `5eca4e8` For AVX2 code, also check for AVX, XSAVE, and OS support (sipa)
 - #13503 `c655b2c` Document FreeBSD quirk. Fix FreeBSD build: Use std::min<int>(…) to allow for compilation under certain FreeBSD versions (practicalswift)
-- #13725 `07ce278` Fix BGL-cli --version (Empact)
+- #13725 `07ce278` Fix bitcoin-cli --version (Empact)
 
 ### Documentation
 - #12306 `216f9a4` Improvements to UNIX documentation (axvr)
@@ -898,7 +898,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #12800 `2d97611` Add note about our preference for scoped enumerations ("enum class") (practicalswift)
 - #12798 `174d016` Refer to witness reserved value as spec. in the BIP (MarcoFalke)
 - #12759 `d3908e2` Improve formatting of developer notes (eklitzke)
-- #12877 `2b54155` Use BGLd in Tor documentation (knoxcard)
+- #12877 `2b54155` Use bitcoind in Tor documentation (knoxcard)
 - #12896 `b15485e` Fix conflicting statements about initialization in developer notes (practicalswift)
 - #12850 `319991d` add qrencode to brew install instructions (buddilla)
 - #12007 `cd8e45b` Clarify the meaning of fee delta not being a fee rate in prioritisetransaction RPC (honzik666)
@@ -915,7 +915,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13165 `627c376` Mention good first issue list in CONTRIBUTING.md (fanquake)
 - #13295 `fb77310` Update OpenBSD build instructions for OpenBSD 6.3 (practicalswift)
 - #13340 `3a8e3f4` remove leftover check-doc documentation (fanquake)
-- #13346 `60f0358` update BGL-dot-org links in release-process.md (fanquake)
+- #13346 `60f0358` update bitcoin-dot-org links in release-process.md (fanquake)
 - #13372 `f014933` split FreeBSD build instructions out of build-unix.md (steverusso)
 - #13366 `861de3b` Rename “OS X” to the newer “macOS” convention (giulio92)
 - #13369 `f8bcef3` update transifex doc link (mess110)
@@ -935,7 +935,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13625 `7146672` Add release notes for -printtoconsole and -debuglogfile changes (satwo)
 - #13718 `f7f574d` Specify preferred Python string formatting technique (masonicboom)
 - #12764 `10b9a81` Remove field in getblocktemplate help that has never been used (conscott)
-- #13742 `d2186b3` Adjust BGLcore.org links (MarcoFalke)
+- #13742 `d2186b3` Adjust bitcoincore.org links (MarcoFalke)
 - #13706 `94dd89e` Minor improvements to release-process.md (MitchellCash)
 - #13775 `ef4fac0` Remove newlines from error message (practicalswift)
 - #13803 `feb7dd9` add note to contributor docs about warranted PR's (kallewoof)
@@ -948,7 +948,7 @@ Support for Python 2 has been discontinued for all test files and tools.
 - #13895 `1cd5f2c` fix GetWarnings docs to reflect behavior (Empact)
 - #13911 `3e3a50a` Revert translated string change, clarify wallet log messages (PierreRochard)
 - #13908 `d6faea4` upgrade rescan time warning from minutes to >1 hour (masonicboom)
-- #13905 `73a09b4` fixed BGL-cli -help output for help2man (hebasto)
+- #13905 `73a09b4` fixed bitcoin-cli -help output for help2man (hebasto)
 - #14100 `2936dbc` Change documentation for =0 for non-boolean options (laanwj)
 - #14096 `465a583` Add reference documentation for descriptors language (sipa)
 - #12757 `0c5f67b` Clarify include guard naming convention (practicalswift)
@@ -1102,4 +1102,4 @@ And to those that reported security issues:
 
 - awemany (for CVE-2018-17144, previously credited as "anonymous reporter")
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.17.0.md
+++ b/doc/release-notes/release-notes-0.17.0.md
@@ -7,7 +7,7 @@ and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.17.1.md
+++ b/doc/release-notes/release-notes-0.17.1.md
@@ -11,7 +11,7 @@ and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.17.1.md
+++ b/doc/release-notes/release-notes-0.17.1.md
@@ -1,29 +1,29 @@
-BGL Core version 0.17.1 is now available from:
+Bitcoin Core version 0.17.1 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.17.1/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.17.1/>
 
 or through BitTorrent:
 
-    magnet:?xt=urn:btih:c56c87ccfaa8e6fbccc90d549121e61efd97cb6f&dn=BGL-core-0.17.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969    
+    magnet:?xt=urn:btih:c56c87ccfaa8e6fbccc90d549121e61efd97cb6f&dn=bitcoin-core-0.17.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969    
 
 This is a new minor version release, with various bugfixes
 and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
 If your node has a txindex, the txindex db will be migrated the first time you run 0.17.0 or newer, which may take up to a few hours. Your node will not be functional until this migration completes.
 
@@ -50,10 +50,10 @@ processing the entire blockchain.
 Compatibility
 ==============
 
-BGL Core is extensively tested on multiple operating systems using
+Bitcoin Core is extensively tested on multiple operating systems using
 the Linux kernel, macOS 10.10+, and Windows 7 and newer (Windows XP is not supported).
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.
 
 From 0.17.0 onwards macOS <10.10 is no longer supported. 0.17.0 is built using Qt 5.9.x, which doesn't
@@ -68,7 +68,7 @@ Notable changes
 The `listtransactions` RPC `account` parameter which was deprecated in 0.17.0
 and renamed to `dummy` has been un-deprecated and renamed again to `label`.
 
-When BGL is configured with the `-deprecatedrpc=accounts` setting, specifying
+When bitcoin is configured with the `-deprecatedrpc=accounts` setting, specifying
 a label/account/dummy argument will return both outgoing and incoming
 transactions. Without the `-deprecatedrpc=accounts` setting, it will only return
 incoming transactions (because it used to be possible to create transactions
@@ -112,7 +112,7 @@ confusion.
 
 ### Build system
 - #14647 `7edebed` Remove illegal spacing in darwin.mk (ch4ot1c)
-- #14698 `ec71f06` Add BGL-tx.exe into Windows installer (ken2812221)
+- #14698 `ec71f06` Add bitcoin-tx.exe into Windows installer (ken2812221)
 
 ### Tests and QA
 - #13965 `29899ec` Fix extended functional tests fail (ken2812221)
@@ -165,4 +165,4 @@ Thanks to everyone who directly contributed to this release:
 - Walter
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.18.0.md
+++ b/doc/release-notes/release-notes-0.18.0.md
@@ -7,7 +7,7 @@ fixes and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.18.0.md
+++ b/doc/release-notes/release-notes-0.18.0.md
@@ -1,17 +1,17 @@
-BGL Core version 0.18.0 is now available from:
+Bitcoin Core version 0.18.0 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.18.0/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.18.0/>
 
 This is a new major version release, including new features, various bug
 fixes and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
@@ -19,7 +19,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait until it has
 completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-`/Applications/BGL-Qt` (on Mac) or `BGLd`/`BGL-qt` (on
+`/Applications/Bitcoin-Qt` (on Mac) or `bitcoind`/`bitcoin-qt` (on
 Linux).
 
 The first time you run version 0.15.0 or newer, your chainstate database
@@ -35,16 +35,16 @@ wallet versions are still supported.
 Compatibility
 ==============
 
-BGL Core is supported and extensively tested on operating systems
+Bitcoin Core is supported and extensively tested on operating systems
 using the Linux kernel, macOS 10.10+, and Windows 7 and newer. It is not
-recommended to use BGL Core on unsupported systems.
+recommended to use Bitcoin Core on unsupported systems.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 as frequently tested on them.
 
 From 0.17.0 onwards, macOS <10.10 is no longer supported. 0.17.0 is
 built using Qt 5.9.x, which doesn't support versions of macOS older than
-10.10. Additionally, BGL Core does not yet change appearance when
+10.10. Additionally, Bitcoin Core does not yet change appearance when
 macOS "dark mode" is activated.
 
 In addition to previously-supported CPU platforms, this release's
@@ -52,11 +52,11 @@ pre-compiled distribution also provides binaries for the RISC-V
 platform.
 
 If you are using the `systemd` unit configuration file located at
-`contrib/init/BGLd.service`, it has been changed to use
-`/var/lib/BGLd` as the data directory instead of
-`~BGL/.BGL`. When switching over to the new configuration file,
-please make sure that the filesystem on which `/var/lib/BGLd` will
-exist has enough space (check using `df -h /var/lib/BGLd`), and
+`contrib/init/bitcoind.service`, it has been changed to use
+`/var/lib/bitcoind` as the data directory instead of
+`~bitcoin/.bitcoin`. When switching over to the new configuration file,
+please make sure that the filesystem on which `/var/lib/bitcoind` will
+exist has enough space (check using `df -h /var/lib/bitcoind`), and
 optionally copy over your existing data directory. See the [systemd init
 file section](#systemd-init-file) for more details.
 
@@ -95,7 +95,7 @@ Configuration option changes
   messages that ZMQ will queue in memory (the "high water mark") before
   dropping additional messages.  The default value is 1,000, the same as
   was used for previous releases.  See the [ZMQ
-  documentation](https://github.com/BGL/BGL/blob/master/doc/zmq.md#usage)
+  documentation](https://github.com/bitcoin/bitcoin/blob/master/doc/zmq.md#usage)
   for details.
 
 - The `rpcallowip` option can no longer be used to automatically listen
@@ -119,16 +119,16 @@ Configuration option changes
   disconnect/ban behavior will not cause a node that is whitelisting
   another to be dropped by peers.  Users can still explicitly enable
   this behavior with the command line option (and may want to consider
-  [contacting](https://BGLcore.org/en/contact/) the BGL Core
+  [contacting](https://bitcoincore.org/en/contact/) the Bitcoin Core
   project to let us know about their use-case, as this feature could be
   deprecated in the future).
 
 systemd init file
 -----------------
 
-The systemd init file (`contrib/init/BGLd.service`) has been changed
-to use `/var/lib/BGLd` as the data directory instead of
-`~BGL/.BGL`. This change makes BGL Core more consistent with
+The systemd init file (`contrib/init/bitcoind.service`) has been changed
+to use `/var/lib/bitcoind` as the data directory instead of
+`~bitcoin/.bitcoin`. This change makes Bitcoin Core more consistent with
 other services, and makes the systemd init config more consistent with
 existing Upstart and OpenRC configs.
 
@@ -138,33 +138,33 @@ See [`systemd.exec(5)`](https://www.freedesktop.org/software/systemd/man/systemd
 for more details.
 
 When using the provided init files under `contrib/init`, overriding the
-`datadir` option in `/etc/BGL/BGL.conf` will have no effect.
+`datadir` option in `/etc/bitcoin/bitcoin.conf` will have no effect.
 This is because the command line arguments specified in the init files
 take precedence over the options specified in
-`/etc/BGL/BGL.conf`.
+`/etc/bitcoin/bitcoin.conf`.
 
 
 Documentation
 -------------
 
-- A new short [document](https://github.com/BGL/BGL/blob/master/doc/JSON-RPC-interface.md)
+- A new short [document](https://github.com/bitcoin/bitcoin/blob/master/doc/JSON-RPC-interface.md)
   about the JSON-RPC interface describes cases where the results of an
   RPC might contain inconsistencies between data sourced from different
   subsystems, such as wallet state and mempool state.  A note is added
-  to the [REST interface documentation](https://github.com/BGL/BGL/blob/master/doc/REST-interface.md)
+  to the [REST interface documentation](https://github.com/bitcoin/bitcoin/blob/master/doc/REST-interface.md)
   indicating that the same rules apply.
 
 - Further information is added to the [JSON-RPC
-  documentation](https://github.com/BGL/BGL/blob/master/doc/JSON-RPC-interface.md)
+  documentation](https://github.com/bitcoin/bitcoin/blob/master/doc/JSON-RPC-interface.md)
   about how to secure this interface.
 
-- A new [document](https://github.com/BGL/BGL/blob/master/doc/BGL-conf.md)
-  about the `BGL.conf` file describes how to use it to configure
-  BGL Core.
+- A new [document](https://github.com/bitcoin/bitcoin/blob/master/doc/bitcoin-conf.md)
+  about the `bitcoin.conf` file describes how to use it to configure
+  Bitcoin Core.
 
-- A new document introduces BGL Core's BIP174 [Partially-Signed
-  BGL Transactions
-  (PSBT)](https://github.com/BGL/BGL/blob/master/doc/psbt.md)
+- A new document introduces Bitcoin Core's BIP174 [Partially-Signed
+  Bitcoin Transactions
+  (PSBT)](https://github.com/bitcoin/bitcoin/blob/master/doc/psbt.md)
   interface, which is used to allow multiple programs to collaboratively
   work to create, sign, and broadcast new transactions.  This is useful
   for offline (cold storage) wallets, multisig wallets, coinjoin
@@ -172,7 +172,7 @@ Documentation
   to interact to generate a complete transaction.
 
 - The [output script
-  descriptor](https://github.com/BGL/BGL/blob/master/doc/descriptors.md)
+  descriptor](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md)
   documentation has been updated with information about new features in
   this still-developing language for describing the output scripts that
   a wallet or other program wants to receive notifications for, such as
@@ -185,15 +185,15 @@ Build system changes
 --------------------
 
 - A new `--disable-bip70` option may be passed to `./configure` to
-  prevent BGL-Qt from being built with support for the BIP70 payment
+  prevent Bitcoin-Qt from being built with support for the BIP70 payment
   protocol or from linking libssl.  As the payment protocol has exposed
-  BGL Core to libssl vulnerabilities in the past, builders who don't
+  Bitcoin Core to libssl vulnerabilities in the past, builders who don't
   need BIP70 support are encouraged to use this option to reduce their
   exposure to future vulnerabilities.
 
 - The minimum required version of Qt (when building the GUI) has been
   increased from 5.2 to 5.5.1 (the [depends
-  system](https://github.com/BGL/BGL/blob/master/depends/README.md)
+  system](https://github.com/bitcoin/bitcoin/blob/master/depends/README.md)
   provides 5.9.7)
 
 New RPCs
@@ -211,7 +211,7 @@ New RPCs
   they've been running.
 
 - `deriveaddresses` returns one or more addresses corresponding to an
-  [output descriptor](https://github.com/BGL/BGL/blob/master/doc/descriptors.md).
+  [output descriptor](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).
 
 - `getdescriptorinfo` accepts a descriptor and returns information about
   it, including its computed checksum.
@@ -278,7 +278,7 @@ in the Low-level Changes section below.
   ignored or are inconsistent, if there are any.
 
 - `getaddressinfo` now returns an additional `solvable` boolean field
-  when BGL Core knows enough about the address's scriptPubKey,
+  when Bitcoin Core knows enough about the address's scriptPubKey,
   optional redeemScript, and optional witnessScript in order for the
   wallet to be able to generate an unsigned input spending funds sent to
   that address.
@@ -292,7 +292,7 @@ in the Low-level Changes section below.
 - `importprivkey` will preserve previously-set labels for addresses or
   public keys corresponding to the private key being imported.  For
   example, if you imported a watch-only address with the label "cold
-  wallet" in earlier releases of BGL Core, subsequently importing
+  wallet" in earlier releases of Bitcoin Core, subsequently importing
   the private key would default to resetting the address's label to the
   default empty-string label ("").  In this release, the previous label
   of "cold wallet" will be retained.  If you optionally specify any
@@ -320,7 +320,7 @@ in the Low-level Changes section below.
   origin information imported through `importmulti` will have their key
   origin information stored in the wallet for use with creating PSBTs.
   More information about descriptors can be found
-  [here](https://github.com/BGL/BGL/blob/master/doc/descriptors.md).
+  [here](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).
 
 - `listunspent` has been modified so that it also returns
   `witnessScript`, the witness script in the case of a P2WSH or
@@ -343,7 +343,7 @@ Deprecated or removed RPCs
 - The 'account' API is removed after being deprecated in v0.17.  The
   'label' API was introduced in v0.17 as a replacement for accounts.
   See the [release notes from
-  v0.17](https://github.com/BGL/BGL/blob/master/doc/release-notes/release-notes-0.17.0.md#label-and-account-apis-for-wallet)
+  v0.17](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.17.0.md#label-and-account-apis-for-wallet)
   for a full description of the changes from the 'account' API to the
   'label' API.
 
@@ -359,7 +359,7 @@ Deprecated or removed RPCs
   require or use the wallet component. Calling `generatetoaddress` with
   an address returned by the `getnewaddress` RPC gives the same
   functionality as the old `generate` RPC.  To continue using `generate`
-  in this version, restart BGLd with the `-deprecatedrpc=generate`
+  in this version, restart bitcoind with the `-deprecatedrpc=generate`
   configuration option.
 
 - Be reminded that parts of the `validateaddress` command have been
@@ -406,7 +406,7 @@ Graphical User Interface (GUI)
 Tools
 -----
 
-- A new `BGL-wallet` tool is now distributed alongside BGL
+- A new `bitcoin-wallet` tool is now distributed alongside Bitcoin
   Core's other executables.  Without needing to use any RPCs, this tool
   can currently create a new wallet file or display some basic
   information about an existing wallet, such as whether the wallet is
@@ -416,24 +416,24 @@ Tools
 Planned changes
 ===============
 
-This section describes planned changes to BGL Core that may affect
-other BGL software and services.
+This section describes planned changes to Bitcoin Core that may affect
+other Bitcoin software and services.
 
-- Since version 0.16.0, BGL Core’s built-in wallet has defaulted to
+- Since version 0.16.0, Bitcoin Core’s built-in wallet has defaulted to
   generating P2SH-wrapped segwit addresses when users want to receive
   payments. These addresses are backwards compatible with all
-  widely-used software.  Starting with BGL Core 0.20 (expected about
-  a year after 0.18), BGL Core will default to native segwit
+  widely-used software.  Starting with Bitcoin Core 0.20 (expected about
+  a year after 0.18), Bitcoin Core will default to native segwit
   addresses (bech32) that provide additional fee savings and other
   benefits. Currently, many wallets and services already support sending
-  to bech32 addresses, and if the BGL Core project sees enough
+  to bech32 addresses, and if the Bitcoin Core project sees enough
   additional adoption, it will instead default to bech32 receiving
-  addresses in BGL Core 0.19 (approximately November 2019).
+  addresses in Bitcoin Core 0.19 (approximately November 2019).
   P2SH-wrapped segwit addresses will continue to be provided if the user
   requests them in the GUI or by RPC, and anyone who doesn’t want the
   update will be able to configure their default address type.
   (Similarly, pioneering users who want to change their default now may
-  set the `addresstype=bech32` configuration option in any BGL Core
+  set the `addresstype=bech32` configuration option in any Bitcoin Core
   release from 0.16.0 up.)
 
 Deprecated P2P messages
@@ -495,7 +495,7 @@ Network
   a misbehaving node will be disconnected to make room for nodes without
   a history of problems (unless the misbehaving node helps your node in
   some other way, such as by connecting to a part of the Internet from
-  which you don't have many other peers).  Previously, BGL Core
+  which you don't have many other peers).  Previously, Bitcoin Core
   banned the IP addresses of misbehaving peers for a period of time
   (default of 1 day); this was easily circumvented by attackers with
   multiple IP addresses. If you manually ban a peer, such as by using
@@ -514,18 +514,18 @@ Wallet
   software. Instead such wallets will be completely unloaded and
   reloaded to achieve the same effect.
 
-- A sub-project of BGL Core now provides Hardware Wallet Interaction
+- A sub-project of Bitcoin Core now provides Hardware Wallet Interaction
   (HWI) scripts that allow command-line users to use several popular
-  hardware key management devices with BGL Core.  See their [project
-  page](https://github.com/BGL-core/HWI#readme) for details.
+  hardware key management devices with Bitcoin Core.  See their [project
+  page](https://github.com/bitcoin-core/HWI#readme) for details.
 
 Security
 --------
 
 - This release changes the Random Number Generator (RNG) used from
-  OpenSSL to BGL Core's own implementation, although entropy
-  gathered by BGL Core is fed out to OpenSSL and then read back in
-  when the program needs strong randomness. This moves BGL Core a
+  OpenSSL to Bitcoin Core's own implementation, although entropy
+  gathered by Bitcoin Core is fed out to OpenSSL and then read back in
+  when the program needs strong randomness. This moves Bitcoin Core a
   little closer to no longer needing to depend on OpenSSL, a dependency
   that has caused security issues in the past.  The new implementation
   gathers entropy from multiple sources, including from hardware
@@ -534,7 +534,7 @@ Security
 Changes for particular platforms
 --------------------------------
 
-- On macOS, BGL Core now opts out of application CPU throttling
+- On macOS, Bitcoin Core now opts out of application CPU throttling
   ("app nap") during initial blockchain download, when catching up from
   over 100 blocks behind the current chain tip, or when reindexing chain
   data. This helps prevent these operations from taking an excessively
@@ -589,9 +589,9 @@ Changes for particular platforms
 - #14023 Remove accounts RPCs (jnewbery)
 - #13825 Kill accounts (jnewbery)
 - #10605 Add AssertLockHeld assertions in CWallet::ListCoins (ryanofsky)
-- #12490 Remove deprecated wallet rpc features from `BGL_server` (jnewbery)
+- #12490 Remove deprecated wallet rpc features from `bitcoin_server` (jnewbery)
 - #14138 Set `encrypted_batch` to nullptr after delete. Avoid double free in the case of NDEBUG (practicalswift)
-- #14168 Remove `ENABLE_WALLET` from `libBGL_server.a` (jnewbery)
+- #14168 Remove `ENABLE_WALLET` from `libbitcoin_server.a` (jnewbery)
 - #12493 Reopen CDBEnv after encryption instead of shutting down (achow101)
 - #14282 Remove `-usehd` option (jnewbery)
 - #14146 Remove trailing separators from `-walletdir` arg (PierreRochard)
@@ -623,7 +623,7 @@ Changes for particular platforms
 - #14711 Remove uses of chainActive and mapBlockIndex in wallet code (ryanofsky)
 - #15279 Clarify rescanblockchain doc (MarcoFalke)
 - #15292 Remove `boost::optional`-related false positive -Wmaybe-uninitialized warnings on GCC compiler (hebasto)
-- #13926 [Tools] BGL-wallet - a tool for creating and managing wallets offline (jnewbery)
+- #13926 [Tools] bitcoin-wallet - a tool for creating and managing wallets offline (jnewbery)
 - #11911 Free BerkeleyEnvironment instances when not in use (ryanofsky)
 - #15235 Do not import private keys to wallets with private keys disabled (achow101)
 - #15263 Descriptor expansions only need pubkey entries for PKH/WPKH (sipa)
@@ -709,7 +709,7 @@ Changes for particular platforms
 - #13248 Make proxy icon from statusbar clickable (mess110)
 - #12818 TransactionView: highlight replacement tx after fee bump (Sjors)
 - #13529 Use new Qt5 connect syntax (promag)
-- #14162 Also log and print messages or questions like BGLd (MarcoFalke)
+- #14162 Also log and print messages or questions like bitcoind (MarcoFalke)
 - #14385 Avoid system harfbuzz and bz2 (theuni)
 - #14450 Fix QCompleter popup regression (hebasto)
 - #14177 Set C locale for amountWidget (hebasto)
@@ -717,7 +717,7 @@ Changes for particular platforms
 - #14554 Remove unused `adjustedTime` parameter (hebasto)
 - #14228 Enable system tray icon by default if available (hebasto)
 - #14608 Remove the "Pay only required fee…" checkbox (hebasto)
-- #14521 qt, docs: Fix `BGL-qt -version` output formatting (hebasto)
+- #14521 qt, docs: Fix `bitcoin-qt -version` output formatting (hebasto)
 - #13966 When private key is disabled, only show watch-only balance (ken2812221)
 - #14828 Remove hidden columns in coin control dialog (promag)
 - #14783 Fix `boost::signals2::no_slots_error` in early calls to InitWarning (promag)
@@ -730,7 +730,7 @@ Changes for particular platforms
 - #14375 Correct misleading "overridden options" label (hebasto)
 - #15007 Notificator class refactoring (hebasto)
 - #14784 Use `WalletModel*` instead of the wallet name as map key (promag)
-- #11625 Add BGLApplication & RPCConsole tests (ryanofsky)
+- #11625 Add BitcoinApplication & RPCConsole tests (ryanofsky)
 - #14517 Fix start with the `-min` option (hebasto)
 - #13216 implements concept for different disk sizes on intro (marcoagner)
 - #15114 Replace remaining 0 with nullptr (Empact)
@@ -766,7 +766,7 @@ Changes for particular platforms
 - #14183 Remove unused Qt 4 dependencies (ken2812221)
 - #14127 Avoid getifaddrs when unavailable (greenaddress)
 - #14184 Scripts and tools: increased timeout downloading (cisba)
-- #14204 Move `interfaces/*` to `libBGL_server` (laanwj)
+- #14204 Move `interfaces/*` to `libbitcoin_server` (laanwj)
 - #14208 Actually remove `ENABLE_WALLET` (jnewbery)
 - #14212 Remove libssl from LDADD unless GUI (MarcoFalke)
 - #13578 Upgrade zeromq to 4.2.5 and avoid deprecated zeromq API functions (mruddy)
@@ -786,19 +786,19 @@ Changes for particular platforms
 - #14849 Qt 5.9.7 (fanquake)
 - #15020 Add names to Travis jobs (gkrizek)
 - #15047 Allow to configure --with-sanitizers=fuzzer (MarcoFalke)
-- #15154 Configure: BGL-tx doesn't need libevent, so don't pull it in (luke-jr)
+- #15154 Configure: bitcoin-tx doesn't need libevent, so don't pull it in (luke-jr)
 - #15175 Drop macports support (Empact)
 - #15308 Restore compatibility with older boost (Empact)
 - #15407 msvc: Fix silent merge conflict between #13926 and #14372 part II (ken2812221)
-- #15388 Makefile.am: add rule for src/BGL-wallet (Sjors)
+- #15388 Makefile.am: add rule for src/bitcoin-wallet (Sjors)
 - #15393 Bump minimum Qt version to 5.5.1 (Sjors)
 - #15285 Prefer Python 3.4 even if newer versions are present on the system (Sjors)
 - #15398 msvc: Add rapidcheck property tests (ken2812221)
 - #15431 msvc: scripted-diff: Remove NDEBUG pre-define in project file (ken2812221)
 - #15549 gitian: Improve error handling (laanwj)
 - #15548 use full version string in setup.exe (MarcoFalke)
-- #11526 Visual Studio build configuration for BGL Core (sipsorcery)
-- #15110 build\_msvc: Fix the build problem in `libBGL_server` (Mr-Leshiy)
+- #11526 Visual Studio build configuration for Bitcoin Core (sipsorcery)
+- #15110 build\_msvc: Fix the build problem in `libbitcoin_server` (Mr-Leshiy)
 - #14372 msvc: build secp256k1 and leveldb locally (ken2812221)
 - #15325 msvc: Fix silent merge conflict between #13926 and #14372 (ken2812221)
 - #15391 Add compile time verification of assumptions we're currently making implicitly/tacitly (practicalswift)
@@ -808,7 +808,7 @@ Changes for particular platforms
 
 ### Tests and QA
 - #15405 appveyor: Clean cache when build configuration changes (Sjors)
-- #13953 Fix deprecation in BGL-util-test.py (isghe)
+- #13953 Fix deprecation in bitcoin-util-test.py (isghe)
 - #13963 Replace usage of tostring() with tobytes() (dongcarl)
 - #13964 ci: Add appveyor ci (ken2812221)
 - #13997 appveyor: fetch the latest port data (ken2812221)
@@ -824,7 +824,7 @@ Changes for particular platforms
 - #14088 Don't assert(…) with side effects (practicalswift)
 - #14086 appveyor: Use clcache to speed up build (ken2812221)
 - #13954 Warn (don't fail!) on spelling errors. Fix typos reported by codespell (practicalswift)
-- #12775 Integration of property based testing into BGL Core (Christewart)
+- #12775 Integration of property based testing into Bitcoin Core (Christewart)
 - #14119 Read reject reasons from debug log, not P2P messages (MarcoFalke)
 - #14189 Fix silent merge conflict in `wallet_importmulti` (MarcoFalke)
 - #13419 Speed up `knapsack_solver_test` by not recreating wallet 100 times (lucash-dev)
@@ -837,7 +837,7 @@ Changes for particular platforms
 - #14275 Write the notification message to different files to avoid race condition in `feature_notifications.py` (ken2812221)
 - #14306 appveyor: Move AppVeyor YAML to dot-file-style YAML (MitchellCash)
 - #14305 Enforce critical class instance attributes in functional tests, fix segwit test specificity (JustinTArthur)
-- #12246 Bugfix: Only run BGL-tx tests when BGL-tx is enabled (luke-jr)
+- #12246 Bugfix: Only run bitcoin-tx tests when bitcoin-tx is enabled (luke-jr)
 - #14316 Exclude all tests with difference parameters in `--exclude` list (ken2812221)
 - #14381 Add missing call to `skip_if_no_cli()` (practicalswift)
 - #14389 travis: Set codespell version to avoid breakage (MarcoFalke)
@@ -859,7 +859,7 @@ Changes for particular platforms
 - #14631 Move deterministic address import to `setup_nodes` (jnewbery)
 - #14630 test: Remove travis specific code (MarcoFalke)
 - #14528 travis: Compile once on xenial (MarcoFalke)
-- #14092 Dry run `bench_BGL` as part `make check` to allow for quick identification of assertion/sanitizer failures in benchmarking code (practicalswift)
+- #14092 Dry run `bench_bitcoin` as part `make check` to allow for quick identification of assertion/sanitizer failures in benchmarking code (practicalswift)
 - #14664 `example_test.py`: fixup coinbase height argument, derive number clearly (instagibbs)
 - #14522 Add invalid P2P message tests (jamesob)
 - #14619 Fix value display name in `test_runner` help text (merland)
@@ -903,7 +903,7 @@ Changes for particular platforms
 - #14969 Fix `cuckoocache_tests` TSAN failure introduced in 14935 (practicalswift)
 - #14964 Fix race in `mempool_accept` (MarcoFalke)
 - #14829 travis: Enable functional tests in the threadsanitizer (tsan) build job (practicalswift)
-- #14985 Remove `thread_local` from `test_BGL` (MarcoFalke)
+- #14985 Remove `thread_local` from `test_bitcoin` (MarcoFalke)
 - #15005 Bump timeout to run tests in travis thread sanitizer (MarcoFalke)
 - #15013 Avoid race in `p2p_timeouts` (MarcoFalke)
 - #14960 lint/format-strings: Correctly exclude escaped percent symbols (luke-jr)
@@ -980,8 +980,8 @@ Changes for particular platforms
 - #14097 validation: Log FormatStateMessage on ConnectBlock error in ConnectTip (MarcoFalke)
 - #13724 contrib: Support ARM and RISC-V symbol check (ken2812221)
 - #13159 Don't close old debug log file handle prematurely when trying to re-open (on SIGHUP) (practicalswift)
-- #14186 BGL-cli: don't translate command line options (HashUnlimited)
-- #14057 logging: Only log `using config file path_to_BGL.conf` message on startup if conf file exists (leishman)
+- #14186 bitcoin-cli: don't translate command line options (HashUnlimited)
+- #14057 logging: Only log `using config file path_to_bitcoin.conf` message on startup if conf file exists (leishman)
 - #14164 Update univalue subtree (MarcoFalke)
 - #14272 init: Remove deprecated args from hidden args (MarcoFalke)
 - #14494 Error if # is used in rpcpassword in conf (MeshCollider)
@@ -1001,7 +1001,7 @@ Changes for particular platforms
 - #14839 threads: Fix unitialized members in `sched_param` (fanquake)
 - #14955 Switch all RNG code to the built-in PRNG (sipa)
 - #15258 Scripts and tools: Fix `devtools/copyright_header.py` to always honor exclusions (Empact)
-- #12255 Update BGL.service to conform to init.md (dongcarl)
+- #12255 Update bitcoin.service to conform to init.md (dongcarl)
 - #15266 memory: Construct globals on first use (MarcoFalke)
 - #15347 Fix build after pr 15266 merged (hebasto)
 - #15351 Update linearize-hashes.py (OverlordQ)
@@ -1037,7 +1037,7 @@ Changes for particular platforms
 - #14428 Fix macOS files description in qt/README.md (hebasto)
 - #14390 release process: RPC documentation (karel-3d)
 - #14472 getblocktemplate: use SegWit in example (Sjors)
-- #14497 Add doc/BGL-conf.md (hebasto)
+- #14497 Add doc/bitcoin-conf.md (hebasto)
 - #14526 Document lint tests (fanquake)
 - #14511 Remove explicit storage requirement from README.md (merland)
 - #14600 Clarify commit message guidelines (merland)
@@ -1073,7 +1073,7 @@ Changes for particular platforms
 - #15272 Correct logging return type and RPC example (fanquake)
 - #15244 Gdb attaching to process during tests has non-sudo solution (instagibbs)
 - #15332 Small updates to `getrawtransaction` description (amitiuttarwar)
-- #15354 Add missing `BGL-wallet` tool manpages (MarcoFalke)
+- #15354 Add missing `bitcoin-wallet` tool manpages (MarcoFalke)
 - #15343 netaddress: Make IPv4 loopback comment more descriptive (dongcarl)
 - #15353 Minor textual improvements in `translation_strings_policy.md` (merland)
 - #15426 importmulti: add missing description of keypool option (harding)
@@ -1091,9 +1091,9 @@ Changes for particular platforms
 - #15754 getrpcinfo docs (benthecarman)
 - #15763 Update bips.md for 0.18.0 (sipa)
 - #15757 List new RPCs in psbt.md and descriptors.md (sipa)
-- #15765 correct BGLconsensus_version in shared-libraries.md (fanquake)
+- #15765 correct bitcoinconsensus_version in shared-libraries.md (fanquake)
 - #15792 describe onlynet option in doc/tor.md (jonatack)
-- #15802 mention creating application support BGL folder on OSX (JimmyMow)
+- #15802 mention creating application support bitcoin folder on OSX (JimmyMow)
 - #15799 Clarify RPC versioning (MarcoFalke)
 
 Credits
@@ -1122,7 +1122,7 @@ Thanks to everyone who directly contributed to this release:
 - Ben Carman
 - Ben Woosley
 - benthecarman
-- BGLhodler
+- bitcoinhodler
 - Carl Dong
 - Chakib Benziane
 - Chris Moore
@@ -1221,4 +1221,4 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 - Zain Iqbal Allarakhia
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.18.1.md
+++ b/doc/release-notes/release-notes-0.18.1.md
@@ -7,7 +7,7 @@ fixes and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.18.1.md
+++ b/doc/release-notes/release-notes-0.18.1.md
@@ -1,17 +1,17 @@
-BGL Core version 0.18.1 is now available from:
+Bitcoin Core version 0.18.1 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.18.1/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.18.1/>
 
 This is a new minor version release, including new features, various bug
 fixes and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
@@ -19,7 +19,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait until it has
 completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-`/Applications/BGL-Qt` (on Mac) or `BGLd`/`BGL-qt` (on
+`/Applications/Bitcoin-Qt` (on Mac) or `bitcoind`/`bitcoin-qt` (on
 Linux).
 
 The first time you run version 0.15.0 or newer, your chainstate database
@@ -35,16 +35,16 @@ wallet versions are still supported.
 Compatibility
 ==============
 
-BGL Core is supported and extensively tested on operating systems
+Bitcoin Core is supported and extensively tested on operating systems
 using the Linux kernel, macOS 10.10+, and Windows 7 and newer. It is not
-recommended to use BGL Core on unsupported systems.
+recommended to use Bitcoin Core on unsupported systems.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 as frequently tested on them.
 
 From 0.17.0 onwards, macOS <10.10 is no longer supported. 0.17.0 is
 built using Qt 5.9.x, which doesn't support versions of macOS older than
-10.10. Additionally, BGL Core does not yet change appearance when
+10.10. Additionally, Bitcoin Core does not yet change appearance when
 macOS "dark mode" is activated.
 
 Known issues
@@ -91,7 +91,7 @@ not to use coin control features with multiple wallets loaded.
 
 ### Build system
 - #15985 Add test for GCC bug 90348 (sipa)
-- #15947 Install BGL-wallet manpage (domob1812)
+- #15947 Install bitcoin-wallet manpage (domob1812)
 - #15983 build with -fstack-reuse=none (MarcoFalke)
 
 ### Tests and QA
@@ -133,4 +133,4 @@ Thanks to everyone who directly contributed to this release:
 - tecnovert
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.19.0.1.md
+++ b/doc/release-notes/release-notes-0.19.0.1.md
@@ -7,7 +7,7 @@ improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BGL/BGL/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
 To receive security and update notifications, please subscribe to:
 

--- a/doc/release-notes/release-notes-0.19.0.1.md
+++ b/doc/release-notes/release-notes-0.19.0.1.md
@@ -1,48 +1,48 @@
-BGL Core version 0.19.0.1 is now available from:
+Bitcoin Core version 0.19.0.1 is now available from:
 
-  <https://BGLcore.org/bin/BGL-core-0.19.0.1/>
+  <https://bitcoincore.org/bin/bitcoin-core-0.19.0.1/>
 
 This release includes new features, various bug fixes and performance
 improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/BitgesellOfficial/bitgesell/issues>
+  <https://github.com/bitcoin/bitcoin/issues>
 
 To receive security and update notifications, please subscribe to:
 
-  <https://BGLcore.org/en/list/announcements/join/>
+  <https://bitcoincore.org/en/list/announcements/join/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/BGL-Qt` (on Mac)
-or `BGLd`/`BGL-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
 
-Upgrading directly from a version of BGL Core that has reached its EOL is
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
 possible, but might take some time if the datadir needs to be migrated.  Old
-wallet versions of BGL Core are generally supported.
+wallet versions of Bitcoin Core are generally supported.
 
 Compatibility
 ==============
 
-BGL Core is supported and extensively tested on operating systems using
+Bitcoin Core is supported and extensively tested on operating systems using
 the Linux kernel, macOS 10.10+, and Windows 7 and newer. It is not recommended
-to use BGL Core on unsupported systems.
+to use Bitcoin Core on unsupported systems.
 
-BGL Core should also work on most other Unix-like systems but is not
+Bitcoin Core should also work on most other Unix-like systems but is not
 as frequently tested on them.
 
 From 0.17.0 onwards, macOS <10.10 is no longer supported. 0.17.0 is
 built using Qt 5.9.x, which doesn't support versions of macOS older than
-10.10. Additionally, BGL Core does not yet change appearance when
+10.10. Additionally, Bitcoin Core does not yet change appearance when
 macOS "dark mode" is activated.
 
 Users running macOS Catalina may need to "right-click" and then choose "Open"
-to open the BGL Core .dmg. This is due to new signing requirements
-imposed by Apple, which the BGL Core project does not yet adhere too.
+to open the Bitcoin Core .dmg. This is due to new signing requirements
+imposed by Apple, which the Bitcoin Core project does not yet adhere too.
 
 Notable changes
 ===============
@@ -50,8 +50,8 @@ Notable changes
 New user documentation
 ----------------------
 
-- [Reduce memory](https://github.com/BGL/BGL/blob/master/doc/reduce-memory.md)
-  suggests configuration tweaks for running BGL Core on systems with
+- [Reduce memory](https://github.com/bitcoin/bitcoin/blob/master/doc/reduce-memory.md)
+  suggests configuration tweaks for running Bitcoin Core on systems with
   limited memory. (#16339)
 
 New RPCs
@@ -78,7 +78,7 @@ New settings
 
 - `-blockfilterindex` enables the creation of BIP158 block filters for
   the entire blockchain.  Filters will be created in the background and
-  currently use about 4 GiB of space.  Note: this version of BGL
+  currently use about 4 GiB of space.  Note: this version of Bitcoin
   Core does not serve block filters over the P2P network, although the
   local user may obtain block filters using the `getblockfilter` RPC.
   (#14121)
@@ -90,7 +90,7 @@ Updated settings
   provide peers connecting using the indicated interfaces or IP
   addresses.  If no permissions are specified with an address or CIDR
   network, the implicit default permissions are the same as previous
-  releases.  See the `BGLd -help` output for these two options for
+  releases.  See the `bitcoind -help` output for these two options for
   details about the available permissions. (#16248)
 
 - Users setting custom `dbcache` values can increase their setting slightly
@@ -197,7 +197,7 @@ GUI changes
   type may be changed with the `-addresstype` configuration option.
   (#15711, #16497)
 
-- In 0.18.0, a `./configure` flag was introduced to allow disabling BIP70 support in the GUI (support was enabled by default). In 0.19.0, this flag is now __disabled__ by default. If you want to compile BGL Core with BIP70 support in the GUI, you can pass `--enable-bip70` to `./configure`. (#15584)
+- In 0.18.0, a `./configure` flag was introduced to allow disabling BIP70 support in the GUI (support was enabled by default). In 0.19.0, this flag is now __disabled__ by default. If you want to compile Bitcoin Core with BIP70 support in the GUI, you can pass `--enable-bip70` to `./configure`. (#15584)
 
 Deprecated or removed configuration options
 -------------------------------------------
@@ -217,7 +217,7 @@ Deprecated or removed RPCs
 
 - `bumpfee` has a new `fee_rate` option as a replacement for the deprecated `totalFee`. (#16727)
 
-- `generate` is now removed after being deprecated in BGL Core 0.18.
+- `generate` is now removed after being deprecated in Bitcoin Core 0.18.
   Use the `generatetoaddress` RPC instead. (#15492)
 
 P2P changes
@@ -226,12 +226,12 @@ P2P changes
 - BIP 61 reject messages were deprecated in v0.18. They are now disabled
   by default, but can be enabled by setting the `-enablebip61` command
   line option.  BIP 61 reject messages will be removed entirely in a
-  future version of BGL Core. (#14054)
+  future version of Bitcoin Core. (#14054)
 
-- To eliminate well-known denial-of-service vectors in BGL Core,
+- To eliminate well-known denial-of-service vectors in Bitcoin Core,
   especially for nodes with spinning disks, the default value for the
   `-peerbloomfilters` configuration option has been changed to false.
-  This prevents BGL Core from sending the BIP111 NODE_BLOOM service
+  This prevents Bitcoin Core from sending the BIP111 NODE_BLOOM service
   flag, accepting BIP37 bloom filters, or serving merkle blocks or
   transactions matching a bloom filter.  Users who still want to provide
   bloom filter support may either set the configuration option to true
@@ -240,17 +240,17 @@ P2P changes
   `-whitebind` configuration options described elsewhere in these
   release notes.  For the near future, lightweight clients using public
   BIP111/BIP37 nodes should still be able to connect to older versions
-  of BGL Core and nodes that have manually enabled BIP37 support,
+  of Bitcoin Core and nodes that have manually enabled BIP37 support,
   but developers of such software should consider migrating to either
   using specific BIP37 nodes or an alternative transaction filtering
   system. (#16152)
 
-- By default, BGL Core will now make two additional outbound connections that are exclusively used for block-relay.  No transactions or addr messages will be processed on these connections. These connections are designed to add little additional memory or bandwidth resource requirements but should make some partitioning attacks more difficult to carry out. (#15759)
+- By default, Bitcoin Core will now make two additional outbound connections that are exclusively used for block-relay.  No transactions or addr messages will be processed on these connections. These connections are designed to add little additional memory or bandwidth resource requirements but should make some partitioning attacks more difficult to carry out. (#15759)
 
 Miscellaneous CLI Changes
 -------------------------
 
-- The `testnet` field in `BGL-cli -getinfo` has been renamed to
+- The `testnet` field in `bitcoin-cli -getinfo` has been renamed to
   `chain` and now returns the current network name as defined in BIP70
   (main, test, regtest). (#15566)
 
@@ -262,7 +262,7 @@ RPC
 
 - `getblockchaininfo` no longer returns a `bip9_softforks` object.
   Instead, information has been moved into the `softforks` object and
-  an additional `type` field describes how BGL Core determines
+  an additional `type` field describes how Bitcoin Core determines
   whether that soft fork is active (e.g. BIP9 or BIP90).  See the RPC
   help for details. (#16060)
 
@@ -301,7 +301,7 @@ Network
 -------
 
 - When fetching a transaction announced by multiple peers, previous versions of
-  BGL Core would sequentially attempt to download the transaction from each
+  Bitcoin Core would sequentially attempt to download the transaction from each
   announcing peer until the transaction is received, in the order that those
   peers' announcements were received.  In this release, the download logic has
   changed to randomize the fetch order across peers and to prefer sending
@@ -309,7 +309,7 @@ Network
   where inbound peers could prevent a node from getting a transaction.
   (#14897, #15834)
 
-- If a Tor hidden service is being used, BGL Core will be bound to
+- If a Tor hidden service is being used, Bitcoin Core will be bound to
   the standard port 8333 even if a different port is configured for
   clearnet connections.  This prevents leaking node identity through use
   of identical non-default port numbers. (#15651)
@@ -333,7 +333,7 @@ Mempool and transaction relay
   segwit versions) are now accepted into the mempool, relayed, and
   mined.  Attempting to spend those outputs remains forbidden by policy
   ("non-standard").  When this change has been widely deployed, wallets
-  and services can accept any valid bech32 BGL address without
+  and services can accept any valid bech32 Bitcoin address without
   concern that transactions paying future segwit versions will become
   stuck in an unconfirmed state. (#15846)
 
@@ -362,7 +362,7 @@ Wallet
   and default to not use the former in coin selection.  When setting
   this flag on an existing wallet, rescanning the blockchain is required
   to correctly mark previously used destinations.  Together with "avoid
-  partial spends" (added in BGL Core v0.17.0), this can eliminate a
+  partial spends" (added in Bitcoin Core v0.17.0), this can eliminate a
   serious privacy issue where a malicious user can track spends by
   sending small payments to a previously-paid address that would then
   be included with unrelated inputs in future payments. (#13756)
@@ -424,7 +424,7 @@ Build system changes
 - #15834 Fix transaction relay bugs introduced in #14897 and expire transactions from peer in-flight map (sdaftuar)
 - #15651 torcontrol: Use the default/standard network port for Tor hidden services, even if the internal port is set differently (luke-jr)
 - #16188 Document what happens to getdata of unknown type (MarcoFalke)
-- #15649 Add ChaCha20Poly1305@BGL AEAD (jonasschnelli)
+- #15649 Add ChaCha20Poly1305@Bitcoin AEAD (jonasschnelli)
 - #16152 Disable bloom filtering by default (TheBlueMatt)
 - #15993 Drop support of the insecure miniUPnPc versions (hebasto)
 - #16197 Use mockable time for tx download (MarcoFalke)
@@ -443,7 +443,7 @@ Build system changes
 - #15508 Refactor analyzepsbt for use outside RPC code (gwillen)
 - #15747 Remove plethora of Get*Balance (MarcoFalke)
 - #15728 Refactor relay transactions (jnewbery)
-- #15639 BGL-wallet tool: Drop libBGL_server.a dependency (ryanofsky)
+- #15639 bitcoin-wallet tool: Drop libbitcoin_server.a dependency (ryanofsky)
 - #15853 Remove unused import checkpoints.h (MarcoFalke)
 - #15780 add cachable amounts for caching credit/debit values (kallewoof)
 - #15778 Move maxtxfee from node to wallet (jnewbery)
@@ -569,7 +569,7 @@ Build system changes
 - #16291 Stop translating PACKAGE_NAME (MarcoFalke)
 - #16380 Remove unused bits from the service flags enum (MarcoFalke)
 - #16379 Fix autostart filenames on Linux for testnet/regtest (hebasto)
-- #16366 init: Use InitError for all errors in BGLd/qt (MarcoFalke)
+- #16366 init: Use InitError for all errors in bitcoind/qt (MarcoFalke)
 - #16436 Do not create payment server if -disablewallet option provided (hebasto)
 - #16514 Remove unused RPCConsole::tabFocus (promag)
 - #16497 Generate bech32 addresses by default (take 2, fixup) (MarcoFalke)
@@ -618,7 +618,7 @@ Build system changes
 - #15919 Remove unused OpenSSL includes to make it more clear where OpenSSL is used (practicalswift)
 - #15978 .gitignore: Don't ignore depends patches (dongcarl)
 - #15939 gitian: Remove windows 32 bit build (MarcoFalke)
-- #15239 scripts and tools: Move non-linux build source tarballs to "BGL-binaries/version" directory (hebasto)
+- #15239 scripts and tools: Move non-linux build source tarballs to "bitcoin-binaries/version" directory (hebasto)
 - #14047 Add HKDF_HMAC256_L32 and method to negate a private key (jonasschnelli)
 - #16051 add patch to common dependencies (fanquake)
 - #16049 switch to secure download of all dependencies (Kemu)
@@ -630,7 +630,7 @@ Build system changes
 - #16235 Cleaned up and consolidated msbuild files (no code changes) (sipsorcery)
 - #16246 MSVC: Fix error in debug mode (Fix #16245) (NicolasDorier)
 - #16183 xtrans: Configure flags cleanup (dongcarl)
-- #16258 [MSVC]: Create the config.ini as part of BGLd build (NicolasDorier)
+- #16258 [MSVC]: Create the config.ini as part of bitcoind build (NicolasDorier)
 - #16271 remove -Wall from rapidcheck build flags (fanquake)
 - #16309 [MSVC] allow user level project customization (NicolasDorier)
 - #16308 [MSVC] Copy build output to src/ automatically after build (NicolasDorier)
@@ -641,7 +641,7 @@ Build system changes
 - #16408 Prune X packages (dongcarl)
 - #16386 disable unused Qt features (fanquake)
 - #16424 Treat -Wswitch as error when --enable-werror (MarcoFalke)
-- #16441 remove qt libjpeg check from BGL_qt.m4 (fanquake)
+- #16441 remove qt libjpeg check from bitcoin_qt.m4 (fanquake)
 - #16434 Specify AM_CPPFLAGS for ZMQ (domob1812)
 - #16534 add Qt Creator Makefile.am.user to .gitignore (Bushstar)
 - #16573 disable building libsecp256k1 benchmarks (fanquake)
@@ -654,7 +654,7 @@ Build system changes
 - #16654 build: update RapidCheck Makefile (jonatack)
 - #16370 cleanup package configure flags (fanquake)
 - #16746 msbuild: Ignore linker warning (sipsorcery)
-- #16750 msbuild: adds bench_BGL to auto generated project files (sipsorcery)
+- #16750 msbuild: adds bench_bitcoin to auto generated project files (sipsorcery)
 - #16810 guix: Remove ssp spec file hack (dongcarl)
 - #16477 skip deploying plugins we dont use in macdeployqtplus (fanquake)
 - #16413 Bump QT to LTS release 5.9.8 (THETCR)
@@ -688,16 +688,16 @@ Build system changes
 - #15771 Prevent concurrency issues reading .cookie file (promag)
 - #15693 travis: Switch to ubuntu keyserver to avoid timeouts (MarcoFalke)
 - #15629 init: Throw error when network specific config is ignored (MarcoFalke)
-- #15773 Add BGLTestFramework::sync_* methods (MarcoFalke)
+- #15773 Add BitcoinTestFramework::sync_* methods (MarcoFalke)
 - #15797 travis: Bump second timeout to 33 minutes, add rationale (MarcoFalke)
 - #15788 Unify testing setups for fuzz, bench, and unit tests (MarcoFalke)
-- #15352 Reduce noise level in test_BGL output (practicalswift)
+- #15352 Reduce noise level in test_bitcoin output (practicalswift)
 - #15779 Add wallet_balance benchmark (MarcoFalke)
 - #15843 fix outdated include in blockfilter_index_tests (jamesob)
 - #15866 Add missing syncwithvalidationinterfacequeue to wallet_import_rescan (MarcoFalke)
 - #15697 Make swap_magic_bytes in p2p_invalid_messages atomic (MarcoFalke)
 - #15895 Avoid re-reading config.ini unnecessarily (luke-jr)
-- #15896 feature_filelock, interface_BGL_cli: Use PACKAGE_NAME in messages rather than hardcoding BGL Core (luke-jr)
+- #15896 feature_filelock, interface_bitcoin_cli: Use PACKAGE_NAME in messages rather than hardcoding Bitcoin Core (luke-jr)
 - #15897 QA/mininode: Send all headers upfront in send_blocks_and_test to avoid sending an unconnected one (luke-jr)
 - #15696 test_runner: Move feature_pruning to base tests (MarcoFalke)
 - #15869 Add settings merge test to prevent regresssions (ryanofsky)
@@ -751,7 +751,7 @@ Build system changes
 - #16505 Changes verbosity of msbuild from quiet to normal in the appveyor script (sipsorcery)
 - #16293 Make test cases separate functions (MarcoFalke)
 - #16470 Fail early on disconnect in mininode.wait_for_* (MarcoFalke)
-- #16277 Suppress output in test_BGL for expected errors (gertjaap)
+- #16277 Suppress output in test_bitcoin for expected errors (gertjaap)
 - #16493 Fix test failures (MarcoFalke)
 - #16538 Add missing sync_blocks to feature_pruning (MarcoFalke)
 - #16509 Adapt test framework for chains other than "regtest" (MarcoFalke)
@@ -851,7 +851,7 @@ Build system changes
 - #16556 Fix systemd service file configuration directory setup (setpill)
 - #15615 Add log output during initial header sync (jonasschnelli)
 - #16774 Avoid unnecessary "Synchronizing blockheaders" log messages (jonasschnelli)
-- #16489 log: harmonize BGLd logging (jonatack)
+- #16489 log: harmonize bitcoind logging (jonatack)
 - #16577 util: Cbufferedfile fixes and unit test (LarryRuane)
 - #16984 util: Make thread names shorter (hebasto)
 - #17038 Don't rename main thread at process level (laanwj)
@@ -859,11 +859,11 @@ Build system changes
 - #17095 util: Filter control characters out of log messages (laanwj)
 - #17085 init: Change fallback locale to C.UTF-8 (laanwj)
 - #16957 9% less memory: make SaltedOutpointHasher noexcept (martinus)
-- #17449 fix uninitialized variable nMinerConfirmationWindow (BGLVBR)
+- #17449 fix uninitialized variable nMinerConfirmationWindow (bitcoinVBR)
 
 ### Documentation
 - #15514 Update Transifex links (fanquake)
-- #15513 add "sections" info to example BGL.conf (fanquake)
+- #15513 add "sections" info to example bitcoin.conf (fanquake)
 - #15530 Move wallet lock annotations to header (MarcoFalke)
 - #15562 remove duplicate clone step in build-windows.md (fanquake)
 - #15565 remove release note fragments (fanquake)
@@ -873,7 +873,7 @@ Build system changes
 - #15611 Add Gitian key for droark (droark)
 - #15626 Update ACK description in CONTRIBUTING.md (jonatack)
 - #15603 Add more tips to productivity.md (gwillen)
-- #15683 Comment for seemingly duplicate LIBBGL_SERVER (Bushstar)
+- #15683 Comment for seemingly duplicate LIBBITCOIN_SERVER (Bushstar)
 - #15685 rpc-mining: Clarify error messages (MarcoFalke)
 - #15760 Clarify sendrawtransaction::maxfeerate==0 help (MarcoFalke)
 - #15659 fix findFork comment (r8921039)
@@ -891,7 +891,7 @@ Build system changes
 - #15777 Add doxygen comments for keypool classes (jnewbery)
 - #15820 Add productivity notes for dummy rebases (dongcarl)
 - #15922 Explain how to pass in non-fundamental types into functions (MarcoFalke)
-- #16080 build/doc: update BGL_config.h packages, release process (jonatack)
+- #16080 build/doc: update bitcoin_config.h packages, release process (jonatack)
 - #16047 analyzepsbt description in doc/psbt.md (jonatack)
 - #16039 add release note for 14954 (fanquake)
 - #16139 Add riscv64 to outputs list in release-process.md (JeremyRand)
@@ -915,7 +915,7 @@ Build system changes
 - #16484 update labels in CONTRIBUTING.md (MarcoFalke)
 - #16483 update Python command in msvc readme (sipsorcery)
 - #16504 Add release note for the deprecated totalFee option of bumpfee (promag)
-- #16448 add note on precedence of options in BGL.conf (fanquake)
+- #16448 add note on precedence of options in bitcoin.conf (fanquake)
 - #16536 Update and extend benchmarking.md (ariard)
 - #16530 Fix grammar and punctuation in developer notes (Tech1k)
 - #16574 Add historical release notes for 0.18.1 (laanwj)
@@ -933,19 +933,19 @@ Build system changes
 - #16629 Add documentation for the new whitelist permissions (NicolasDorier)
 - #16723 Update labels in CONTRIBUTING.md (hebasto)
 - #16461 Tidy up shadowing section (promag)
-- #16621 add default BGL.conf locations (GChuf)
+- #16621 add default bitcoin.conf locations (GChuf)
 - #16752 Delete stale URL in test README (michaelfolkson)
 - #14862 Declare BLOCK_VALID_HEADER reserved (MarcoFalke)
 - #16806 Add issue templates for bug and feature request (MarcoFalke)
 - #16857 Elaborate need to re-login on Debian-based after usermod for Tor group (clashicly)
-- #16863 Add a missing closing parenthesis in the BGL-wallet's help (darosior)
+- #16863 Add a missing closing parenthesis in the bitcoin-wallet's help (darosior)
 - #16757 CChainState return values (MarcoFalke)
 - #16847 add comments clarifying how local services are advertised (jamesob)
-- #16812 Fix whitespace errs in .md files, BGL.conf, and Info.plist.in (ch4ot1c)
+- #16812 Fix whitespace errs in .md files, bitcoin.conf, and Info.plist.in (ch4ot1c)
 - #16885 Update tx-size-small comment with relevant CVE disclosure (instagibbs)
 - #16900 Fix doxygen comment for SignTransaction in rpc/rawtransaction_util (MarcoFalke)
 - #16914 Update homebrew instruction for doxygen (Sjors)
-- #16912 Remove Doxygen intro from src/BGLd.cpp (ch4ot1c)
+- #16912 Remove Doxygen intro from src/bitcoind.cpp (ch4ot1c)
 - #16960 replace outdated OpenSSL comment in test README (fanquake)
 - #16968 Remove MSVC update step from translation process (laanwj)
 - #16953 Improve test READMEs (fjahr)
@@ -1086,4 +1086,4 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 - zenosage
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/BGL/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/bitcoin/bitcoin/).

--- a/doc/release-notes/release-notes-0.20.0.md
+++ b/doc/release-notes/release-notes-0.20.0.md
@@ -53,7 +53,7 @@ this release:
   `./configure`. This is the same as when checking out from git.
 
 - Instead of running `make` simply, you should instead run
-  `BGL_GENBUILD_NO_GIT=1 make`.
+  `BITCOIN_GENBUILD_NO_GIT=1 make`.
 
 Notable changes
 ===============
@@ -528,7 +528,7 @@ Build system
 - #17756 Remove `WINDOWS_BITS` from build system (fanquake)
 - #17769 Set `AC_PREREQ` to 2.69 (fanquake)
 - #17880 Add -Wdate-time to Werror flags (fanquake)
-- #17910 Remove double `LIBBGL_SERVER` linking (fanquake)
+- #17910 Remove double `LIBBITCOIN_SERVER` linking (fanquake)
 - #17928 Consistent use of package variable (Bushstar)
 - #17933 guix: Pin Guix using `guix time-machine` (dongcarl)
 - #17948 pass -fno-ident in Windows gitian descriptor (fanquake)
@@ -546,7 +546,7 @@ Build system
 - #18331 Use git archive as source tarball (hebasto)
 - #18397 Fix libevent linking for `bench_bitcoin` binary (hebasto)
 - #18426 scripts: `Previous_release`: improve behaviour on failed download (theStack)
-- #18429 Remove double `LIBBGL_SERVER` from bench-Makefile (brakmic)
+- #18429 Remove double `LIBBITCOIN_SERVER` from bench-Makefile (brakmic)
 - #18528 Create `test_fuzz` library from src/test/fuzz/fuzz.cpp (brakmic)
 - #18558 Fix boost detection for arch armv7l (hebasto)
 - #18598 gitian: Add missing automake package to gitian-win-signer.yml (achow101)

--- a/doc/release-notes/release-notes-0.20.1.md
+++ b/doc/release-notes/release-notes-0.20.1.md
@@ -53,7 +53,7 @@ this release:
   `./configure`. This is the same as when checking out from git.
 
 - Instead of running `make` simply, you should instead run
-  `BGL_GENBUILD_NO_GIT=1 make`.
+  `BITCOIN_GENBUILD_NO_GIT=1 make`.
 
 Notable changes
 ===============

--- a/doc/release-notes/release-notes-0.21.0.md
+++ b/doc/release-notes/release-notes-0.21.0.md
@@ -843,7 +843,7 @@ Tests
 - #19094 Only allow ASCII identifiers (laanwj)
 - #18820 Propagate well-known vars into depends (dongcarl)
 - #19173 turn on --enable-c++17 by --enable-fuzz (vasild)
-- #18297 Use pkg-config in BGL_QT_CONFIGURE for all hosts including Windows (hebasto)
+- #18297 Use pkg-config in BITCOIN_QT_CONFIGURE for all hosts including Windows (hebasto)
 - #19301 don't warn when doxygen isn't found (fanquake)
 - #19240 macOS toolchain simplification and bump (dongcarl)
 - #19356 Fix search for brew-installed BDB 4 on OS X (gwillen)

--- a/doc/release-notes/release-notes-0.3.12.md
+++ b/doc/release-notes/release-notes-0.3.12.md
@@ -7,7 +7,7 @@ Features:
 * Recovers and continues if an exception is caused by a message you received.  Other nodes shouldn't be able to cause an exception, and it hasn't happened before, but if a way is found to cause an exception, this would keep it from being used to stop network nodes.
 
 If you have json-rpc code that checks the contents of the error string, you need to change it to expect error objects of the form {"code":<number>,"message":<string>}, which is the standard.  See this thread:
-http://www.BGL.org/smf/index.php?topic=969.0
+http://www.bitcoin.org/smf/index.php?topic=969.0
 
 Download:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.3.12/
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.12/

--- a/doc/release-notes/release-notes-0.3.13.md
+++ b/doc/release-notes/release-notes-0.3.13.md
@@ -12,15 +12,15 @@ Gavin Andresen:
 * Clean shutdown on SIGTERM on Linux.
 
 Download:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.3.13/
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.13/
 
 (Thanks Laszlo for the Mac OSX build!)
 
 Note:
 The SSE2 auto-detect in the Linux 64-bit version doesn't work with AMD in 64-bit mode.  Please try this instead and let me know if it gets it right:
-http://www.BGL.org/download/BGL-0.3.13.1-specialbuild-linux64.tar.gz
+http://www.bitcoin.org/download/bitcoin-0.3.13.1-specialbuild-linux64.tar.gz
 
 You can still control the SSE2 use manually with -4way and -4way=0.
 
 Version 0.3.13.2 (SVN rev 161) has improvements for the case where you already had 0/unconfirmed transactions that you might have already spent.  Here's a Windows build of it:
-http://www.BGL.org/download/BGL-0.3.13.2-win32-setup.exe
+http://www.bitcoin.org/download/bitcoin-0.3.13.2-win32-setup.exe

--- a/doc/release-notes/release-notes-0.3.14.md
+++ b/doc/release-notes/release-notes-0.3.14.md
@@ -1,5 +1,5 @@
 Version 0.3.14 is now available
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.3.14/
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.14/
 
 Changes:
 * Key pool feature for safer wallet backup

--- a/doc/release-notes/release-notes-0.3.15.md
+++ b/doc/release-notes/release-notes-0.3.15.md
@@ -1,6 +1,6 @@
 * paytxfee switch is now per KB, so it adds the correct fee for large transactions
 * sending avoids using coins with less than 6 confirmations if it can
-* BGLMiner processes transactions in priority order based on age of dependencies
+* BitcoinMiner processes transactions in priority order based on age of dependencies
 * make sure generation doesn't start before block 74000 downloaded
 * bugfixes by Dean Gores
 * testnet, keypoololdest and paytxfee added to getinfo

--- a/doc/release-notes/release-notes-0.3.18.md
+++ b/doc/release-notes/release-notes-0.3.18.md
@@ -3,7 +3,7 @@ Changes:
 * IsStandard() check to only include known transaction types in blocks
 * Jgarzik's optimisation to speed up the initial block download a little
 
-The main addition in this release is the Accounts-Based JSON-RPC commands that Gavin's been working on (more details at http://www.BGL.org/smf/index.php?topic=1886.0).  
+The main addition in this release is the Accounts-Based JSON-RPC commands that Gavin's been working on (more details at http://www.bitcoin.org/smf/index.php?topic=1886.0).  
 * getaccountaddress
 * sendfrom
 * move

--- a/doc/release-notes/release-notes-0.3.20.2.md
+++ b/doc/release-notes/release-notes-0.3.20.2.md
@@ -3,13 +3,13 @@ worse as people upgraded, so I cherry-picked the bug fix and created a minor rel
 
 The Amazon Machine Images I used to do the builds are available:
 
-  ami-38a05251   BGL-v0.3.20.2 Mingw    (Windows; Administrator password 'BGL development')
-  ami-30a05259   BGL_0.3.20.2 Linux32
-  ami-8abc4ee3   BGL_0.3.20.2 Linux64
+  ami-38a05251   Bitcoin-v0.3.20.2 Mingw    (Windows; Administrator password 'bitcoin development')
+  ami-30a05259   Bitcoin_0.3.20.2 Linux32
+  ami-8abc4ee3   Bitcoin_0.3.20.2 Linux64
 
 (mac build will be done soon)
 
-If you have already downloaded version 0.3.20.1, please either add this to your BGL.conf file:
+If you have already downloaded version 0.3.20.1, please either add this to your bitcoin.conf file:
 
   maxsendbuffer=10000
   maxreceivebuffer=10000

--- a/doc/release-notes/release-notes-0.3.20.md
+++ b/doc/release-notes/release-notes-0.3.20.md
@@ -1,6 +1,6 @@
 Please checkout the git integration branch from:
 
-https://github.com/BGL/BGL
+https://github.com/BitgesellOfficial/bitgesell
 
 ... and help test.  The new features that need testing are:
 
@@ -19,4 +19,4 @@ Bug fixes that also need testing:
 
 This needs more testing on Windows!  Please drop me a quick private message, email, or IRC message if you are able to do some testing.  If you find bugs, please open an issue at:
 
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues

--- a/doc/release-notes/release-notes-0.3.20.md
+++ b/doc/release-notes/release-notes-0.3.20.md
@@ -1,20 +1,20 @@
 Please checkout the git integration branch from:
 
-https://github.com/BitgesellOfficial/bitgesell
+https://github.com/bitcoin/bitcoin
 
 ... and help test.  The new features that need testing are:
 
-* -nolisten : https://github.com/BGL/BGL/pull/11
+* -nolisten : https://github.com/bitcoin/bitcoin/pull/11
 * -rescan : scan block chain for missing wallet transactions
-* -printtoconsole : https://github.com/BGL/BGL/pull/37
-* RPC gettransaction details : https://github.com/BGL/BGL/pull/24
-* listtransactions new features : https://github.com/BGL/BGL/pull/10
+* -printtoconsole : https://github.com/bitcoin/bitcoin/pull/37
+* RPC gettransaction details : https://github.com/bitcoin/bitcoin/pull/24
+* listtransactions new features : https://github.com/bitcoin/bitcoin/pull/10
 
 Bug fixes that also need testing:
 
-* -maxconnections= : https://github.com/BGL/BGL/pull/42
-* RPC listaccounts minconf : https://github.com/BGL/BGL/pull/27
-* RPC move, add time to output : https://github.com/BGL/BGL/pull/21
+* -maxconnections= : https://github.com/bitcoin/bitcoin/pull/42
+* RPC listaccounts minconf : https://github.com/bitcoin/bitcoin/pull/27
+* RPC move, add time to output : https://github.com/bitcoin/bitcoin/pull/21
 * ...and several improvements to --help output.
 
 This needs more testing on Windows!  Please drop me a quick private message, email, or IRC message if you are able to do some testing.  If you find bugs, please open an issue at:

--- a/doc/release-notes/release-notes-0.3.21.md
+++ b/doc/release-notes/release-notes-0.3.21.md
@@ -1,19 +1,19 @@
-Binaries for BGL version 0.3.21 are available at:
-  https://sourceforge.net/projects/BGL/files/BGL/BGL-0.3.21/
+Binaries for Bitcoin version 0.3.21 are available at:
+  https://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.21/
 
 Changes and new features from the 0.3.20 release include:
 
-* Universal Plug and Play support.  Enable automatic opening of a port for incoming connections by running BGL or BGLd with the - -upnp=1 command line switch or using the Options dialog box.
+* Universal Plug and Play support.  Enable automatic opening of a port for incoming connections by running bitcoin or bitcoind with the - -upnp=1 command line switch or using the Options dialog box.
 
-* Support for full-precision BGL amounts.  You can now send, and BGL will display, BGL amounts smaller than 0.01.  However, sending fewer than 0.01 BGLs still requires a 0.01 BGL fee (so you can send 1.0001 BGLs without a fee, but you will be asked to pay a fee if you try to send 0.0001).
+* Support for full-precision bitcoin amounts.  You can now send, and bitcoin will display, bitcoin amounts smaller than 0.01.  However, sending fewer than 0.01 bitcoins still requires a 0.01 bitcoin fee (so you can send 1.0001 bitcoins without a fee, but you will be asked to pay a fee if you try to send 0.0001).
 
-* A new method of finding BGL nodes to connect with, via DNS A records. Use the -dnsseed option to enable.
+* A new method of finding bitcoin nodes to connect with, via DNS A records. Use the -dnsseed option to enable.
 
-For developers, changes to BGL's remote-procedure-call API:
+For developers, changes to bitcoin's remote-procedure-call API:
 
-* New rpc command "sendmany" to send BGLs to more than one address in a single transaction.
+* New rpc command "sendmany" to send bitcoins to more than one address in a single transaction.
 
-* Several bug fixes, including a serious intermittent bug that would sometimes cause BGLd to stop accepting rpc requests. 
+* Several bug fixes, including a serious intermittent bug that would sometimes cause bitcoind to stop accepting rpc requests. 
 
 * -logtimestamps option, to add a timestamp to each line in debug.log.
 

--- a/doc/release-notes/release-notes-0.3.22.md
+++ b/doc/release-notes/release-notes-0.3.22.md
@@ -1,4 +1,4 @@
-Download URL: https://sourceforge.net/projects/BGL/files/BGL/BGL-0.3.22/
+Download URL: https://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.22/
 
 This is largely a bugfix and TX fee schedule release.  We also hope to make 0.3.23 a quick release, to fix problems that the network has seen due to explosive growth in the past week.
 
@@ -7,7 +7,7 @@ Notable changes:
 * Non-standard transactions accepted on testnet
 * Source code tree reorganized (prep for autotools build)
 * Remove "Generate Coins" option from GUI, and remove 4way SSE miner.  Internal reference CPU miner remains available, but users are directed to external miners for best hash production.
-* IRC is overflowing.  Client now bootstraps to channels #BGL00 - #BGL99
+* IRC is overflowing.  Client now bootstraps to channels #bitcoin00 - #bitcoin99
 * DNS names now may be used with -addnode, -connect (requires -dns to enable)
 
 RPC changes:

--- a/doc/release-notes/release-notes-0.3.23.md
+++ b/doc/release-notes/release-notes-0.3.23.md
@@ -1,7 +1,7 @@
-Win32, Linux, MacOSX and source releases for BGL v0.3.23 have been uploaded to
-https://sourceforge.net/projects/BGL/files/BGL/BGL-0.3.23/
+Win32, Linux, MacOSX and source releases for bitcoin v0.3.23 have been uploaded to
+https://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.23/
 
-This is another quick bugfix release, trying to deal with the influx of new BGL users.
+This is another quick bugfix release, trying to deal with the influx of new bitcoin users.
 
 Main items of note:
 

--- a/doc/release-notes/release-notes-0.3.24.md
+++ b/doc/release-notes/release-notes-0.3.24.md
@@ -1,7 +1,7 @@
-BGL v0.3.24 is now available for download at
-https://sourceforge.net/projects/BGL/files/BGL/BGL-0.3.24/
+Bitcoin v0.3.24 is now available for download at
+https://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.3.24/
 
-This is another bug fix release.  We had hoped to have wallet encryption ready for release, but more urgent fixes for existing clients were needed -- most notably block download problems were getting severe.  Wallet encryption is ready for testing at https://github.com/BGL/BGL/pull/352 for the git-savvy, and hopefully will follow shortly in the next release, v0.4.
+This is another bug fix release.  We had hoped to have wallet encryption ready for release, but more urgent fixes for existing clients were needed -- most notably block download problems were getting severe.  Wallet encryption is ready for testing at https://github.com/bitcoin/bitcoin/pull/352 for the git-savvy, and hopefully will follow shortly in the next release, v0.4.
 
 Notable fixes in v0.3.24, and the main reasons for this release:
 
@@ -13,8 +13,8 @@ Notable changes in v0.3.24:
 
 C1) DNS seeding enabled by default.
 
-C2) UPNP enabled by default in the GUI client.  The percentage of BGL clients that accept incoming connections is quite small, and that is a problem.  This should help.  BGLd, and unofficial builds, are unchanged (though we encourage use of "-upnp" to help the network!)
+C2) UPNP enabled by default in the GUI client.  The percentage of bitcoin clients that accept incoming connections is quite small, and that is a problem.  This should help.  bitcoind, and unofficial builds, are unchanged (though we encourage use of "-upnp" to help the network!)
 
-C3) Initial unit testing framework.  BGL sorely needs automated tests, and this is a beginning.  Contributions welcome.
+C3) Initial unit testing framework.  Bitcoin sorely needs automated tests, and this is a beginning.  Contributions welcome.
 
 C4) Internal wallet code cleanup.  While invisible to an end user, this change provides the basis for v0.4's wallet encryption.

--- a/doc/release-notes/release-notes-0.4.0.md
+++ b/doc/release-notes/release-notes-0.4.0.md
@@ -1,24 +1,24 @@
-BGL version 0.4.0 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.4.0/
+Bitcoin version 0.4.0 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.4.0/
 
 The main feature in this release is wallet private key encryption;
 you can set a passphrase that must be entered before sending coins.
 See below for more information; if you decide to encrypt your wallet,
 WRITE DOWN YOUR PASSPHRASE AND PUT IT IN A SECURE LOCATION. If you
-forget or lose your wallet passphrase, you lose your BGLs.
-Previous versions of BGL are unable to read encrypted wallets,
+forget or lose your wallet passphrase, you lose your bitcoins.
+Previous versions of bitcoin are unable to read encrypted wallets,
 and will crash on startup if the wallet is encrypted.
 
-Also note: BGL version 0.4 uses a newer version of Berkeley DB
+Also note: bitcoin version 0.4 uses a newer version of Berkeley DB
 (bdb version 4.8) than previous versions (bdb 4.7). If you upgrade
-to version 0.4 and then revert back to an earlier version of BGL
+to version 0.4 and then revert back to an earlier version of bitcoin
 the it may be unable to start because bdb 4.7 cannot read bdb 4.8
 "log" files.
 
 
 Notable bug fixes from version 0.3.24:
 
-Fix several BGL-becomes-unresponsive bugs due to multithreading
+Fix several bitcoin-becomes-unresponsive bugs due to multithreading
 deadlocks.
 
 Optimize database writes for large (lots of inputs) transactions
@@ -27,44 +27,44 @@ Optimize database writes for large (lots of inputs) transactions
 
 Wallet Encryption
 
-BGL supports native wallet encryption so that people who steal your
-wallet file don't automatically get access to all of your BGLs.
+Bitcoin supports native wallet encryption so that people who steal your
+wallet file don't automatically get access to all of your Bitcoins.
 In order to enable this feature, choose "Encrypt Wallet" from the
 Options menu.  You will be prompted to enter a passphrase, which
 will be used as the key to encrypt your wallet and will be needed
-every time you wish to send BGLs.  If you lose this passphrase,
-you will lose access to spend all of the BGLs in your wallet,
-no one, not even the BGL developers can recover your BGLs.
+every time you wish to send Bitcoins.  If you lose this passphrase,
+you will lose access to spend all of the bitcoins in your wallet,
+no one, not even the Bitcoin developers can recover your Bitcoins.
 This means you are responsible for your own security, store your
 passphrase in a secure location and do not forget it.
 
-Remember that the encryption built into BGL only encrypts the
-actual keys which are required to send your BGLs, not the full
+Remember that the encryption built into bitcoin only encrypts the
+actual keys which are required to send your bitcoins, not the full
 wallet.  This means that someone who steals your wallet file will
 be able to see all the addresses which belong to you, as well as the
 relevant transactions, you are only protected from someone spending
 your coins.
 
 It is recommended that you backup your wallet file before you
-encrypt your wallet.  To do this, close the BGL client and
-copy the wallet.dat file from ~/.BGL/ on Linux, /Users/(user
-name)/Application Support/BGL/ on Mac OSX, and %APPDATA%/BGL/
-on Windows (that is /Users/(user name)/AppData/Roaming/BGL on
+encrypt your wallet.  To do this, close the Bitcoin client and
+copy the wallet.dat file from ~/.bitcoin/ on Linux, /Users/(user
+name)/Application Support/Bitcoin/ on Mac OSX, and %APPDATA%/Bitcoin/
+on Windows (that is /Users/(user name)/AppData/Roaming/Bitcoin on
 Windows Vista and 7 and /Documents and Settings/(user name)/Application
-Data/BGL on Windows XP).  Once you have copied that file to a
-safe location, reopen the BGL client and Encrypt your wallet.
+Data/Bitcoin on Windows XP).  Once you have copied that file to a
+safe location, reopen the Bitcoin client and Encrypt your wallet.
 If everything goes fine, delete the backup and enjoy your encrypted
 wallet.  Note that once you encrypt your wallet, you will never be
-able to go back to a version of the BGL client older than 0.4.
+able to go back to a version of the Bitcoin client older than 0.4.
 
 Keep in mind that you are always responsible for your own security.
 All it takes is a slightly more advanced wallet-stealing trojan which
 installs a keylogger to steal your wallet passphrase as you enter it
-in addition to your wallet file and you have lost all your BGLs.
+in addition to your wallet file and you have lost all your Bitcoins.
 Wallet encryption cannot keep you safe if you do not practice
 good security, such as running up-to-date antivirus software, only
-entering your wallet passphrase in the BGL client and using the
+entering your wallet passphrase in the Bitcoin client and using the
 same passphrase only as your wallet passphrase.
 
-See the doc/README file in the BGL source for technical details
+See the doc/README file in the bitcoin source for technical details
 of wallet encryption.

--- a/doc/release-notes/release-notes-0.4.1.md
+++ b/doc/release-notes/release-notes-0.4.1.md
@@ -1,5 +1,5 @@
-BGL version 0.4.1 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.4.1/
+Bitcoin version 0.4.1 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.4.1/
 
 This is a bugfix only release based on 0.4.0.
 
@@ -7,32 +7,32 @@ Please report bugs by replying to this forum thread.
 
 MAJOR BUG FIX  (CVE-2011-4447)
 
-The wallet encryption feature introduced in BGL version 0.4.0 did not sufficiently secure the private keys. An attacker who
+The wallet encryption feature introduced in Bitcoin version 0.4.0 did not sufficiently secure the private keys. An attacker who
 managed to get a copy of your encrypted wallet.dat file might be able to recover some or all of the unencrypted keys and steal the
 associated coins.
 
-If you have a previously encrypted wallet.dat, the first time you run wxBGL or BGLd the wallet will be rewritten, BGL will
+If you have a previously encrypted wallet.dat, the first time you run wxbitcoin or bitcoind the wallet will be rewritten, Bitcoin will
 shut down, and you will be prompted to restart it to run with the new, properly encrypted file.
 
 If you had a previously encrypted wallet.dat that might have been copied or stolen (for example, you backed it up to a public
-location) you should send all of your BGLs to yourself using a new BGL address and stop using any previously generated addresses.
+location) you should send all of your bitcoins to yourself using a new bitcoin address and stop using any previously generated addresses.
 
-Wallets encrypted with this version of BGL are written properly.
+Wallets encrypted with this version of Bitcoin are written properly.
 
-Technical note: the encrypted wallet's 'keypool' will be regenerated the first time you request a new BGL address; to be certain that the
+Technical note: the encrypted wallet's 'keypool' will be regenerated the first time you request a new bitcoin address; to be certain that the
 new private keys are properly backed up you should:
 
-1. Run BGL and let it rewrite the wallet.dat file
+1. Run Bitcoin and let it rewrite the wallet.dat file
 
-2. Run it again, then ask it for a new BGL address.
-wxBGL: new address visible on main window
-BGLd: run the 'walletpassphrase' RPC command to unlock the wallet,  then run the 'getnewaddress' RPC command.
+2. Run it again, then ask it for a new bitcoin address.
+wxBitcoin: new address visible on main window
+bitcoind: run the 'walletpassphrase' RPC command to unlock the wallet,  then run the 'getnewaddress' RPC command.
 
-3. If your encrypted wallet.dat may have been copied or stolen, send all of your BGLs to the new BGL address.
+3. If your encrypted wallet.dat may have been copied or stolen, send all of your bitcoins to the new bitcoin address.
 
-4. Shut down BGL, then backup the wallet.dat file.
-IMPORTANT: be sure to request a new BGL address before backing up, so that the 'keypool' is regenerated and backed up.
+4. Shut down Bitcoin, then backup the wallet.dat file.
+IMPORTANT: be sure to request a new bitcoin address before backing up, so that the 'keypool' is regenerated and backed up.
 
-"Security in depth" is always a good idea, so choosing a secure location for the backup and/or encrypting the backup before uploading it is recommended. And as in previous releases, if your machine is infected by malware there are several ways an attacker might steal your BGLs.
+"Security in depth" is always a good idea, so choosing a secure location for the backup and/or encrypting the backup before uploading it is recommended. And as in previous releases, if your machine is infected by malware there are several ways an attacker might steal your bitcoins.
 
 Thanks to Alan Reiner (etotheipi) for finding and reporting this bug.

--- a/doc/release-notes/release-notes-0.4.3.md
+++ b/doc/release-notes/release-notes-0.4.3.md
@@ -6,7 +6,7 @@ This is a bugfix-only release based on 0.4.0.
 Please note that the wxBGL GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
 
 Please report bugs for the daemon only using the issue tracker at github:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
 http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.4.3#.tar.gz

--- a/doc/release-notes/release-notes-0.4.3.md
+++ b/doc/release-notes/release-notes-0.4.3.md
@@ -1,21 +1,21 @@
-BGLd version 0.4.3 is now available for download at:
-http://luke.dashjr.org/programs/BGL/files/BGLd-0.4.3/ (until Gavin uploads to SourceForge)
+bitcoind version 0.4.3 is now available for download at:
+http://luke.dashjr.org/programs/bitcoin/files/bitcoind-0.4.3/ (until Gavin uploads to SourceForge)
 
 This is a bugfix-only release based on 0.4.0.
 
-Please note that the wxBGL GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
+Please note that the wxBitcoin GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
 
 Please report bugs for the daemon only using the issue tracker at github:
 https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
-http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.4.3#.tar.gz
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.4.3#.tar.gz
 
 BUG FIXES
 
 Cease locking memory used by non-sensitive information (this caused a huge performance hit on some platforms, especially noticable during initial blockchain download).
 Fixed some address-handling deadlocks (client freezes).
-No longer accept inbound connections over the internet when BGL is being used with Tor (identity leak).
+No longer accept inbound connections over the internet when Bitcoin is being used with Tor (identity leak).
 Use the correct base transaction fee of 0.0005 BTC for accepting transactions into mined blocks (since 0.4.0, it was incorrectly accepting 0.0001 BTC which was only meant to be relayed).
 Add new DNS seeds (maintained by Pieter Wuille and Luke Dashjr).
 

--- a/doc/release-notes/release-notes-0.4.4.md
+++ b/doc/release-notes/release-notes-0.4.4.md
@@ -6,7 +6,7 @@ This is a bugfix-only release based on 0.4.0.
 Please note that the wxBGL GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
 
 Please report bugs for the daemon only using the issue tracker at github:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
 http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.4.4#.tar.gz

--- a/doc/release-notes/release-notes-0.4.4.md
+++ b/doc/release-notes/release-notes-0.4.4.md
@@ -1,15 +1,15 @@
-BGL version 0.4.4 is now available for download at:
-http://luke.dashjr.org/programs/BGL/files/BGLd-0.4.4/
+Bitcoin version 0.4.4 is now available for download at:
+http://luke.dashjr.org/programs/bitcoin/files/bitcoind-0.4.4/
 
 This is a bugfix-only release based on 0.4.0.
 
-Please note that the wxBGL GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
+Please note that the wxBitcoin GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
 
 Please report bugs for the daemon only using the issue tracker at github:
 https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
-http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.4.4#.tar.gz
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.4.4#.tar.gz
 
 BUG FIXES
 
@@ -24,7 +24,7 @@ Several shutdown issues have been fixed.
 Check that keys stored in the wallet are valid at startup, and if not,
 report corruption.
 Various build fixes.
-If no password is specified to BGLd, recommend a secure password.
+If no password is specified to bitcoind, recommend a secure password.
 Update hard-coded fallback seed nodes, choosing recent ones with long uptime and versions at least 0.4.0.
 Add checkpoint at block 168,000.
 

--- a/doc/release-notes/release-notes-0.4.6.md
+++ b/doc/release-notes/release-notes-0.4.6.md
@@ -1,11 +1,11 @@
-BGLd version 0.4.6 is now available for download at:
+bitcoind version 0.4.6 is now available for download at:
 Windows: installer | zip (sig)
 Source: tar.gz
-BGLd and BGL-Qt version 0.6.0.7 are also tagged in git, but it is recommended to upgrade to 0.6.1.
+bitcoind and Bitcoin-Qt version 0.6.0.7 are also tagged in git, but it is recommended to upgrade to 0.6.1.
 
 These are bugfix-only releases.
 
-Please report bugs by replying to this forum thread. Note that the 0.4.x wxBGL GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
+Please report bugs by replying to this forum thread. Note that the 0.4.x wxBitcoin GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
 
 BUG FIXES
 
@@ -13,25 +13,25 @@ Version 0.6.0 allowed importing invalid "private keys", which would be unspendab
 Verify status of encrypt/decrypt calls to detect failed padding
 Check blocks for duplicate transactions earlier. Fixes #1167
 Upgrade Windows builds to OpenSSL 1.0.1b
-Set label when selecting an address that already has a label. Fixes #1080 (BGL-Qt)
+Set label when selecting an address that already has a label. Fixes #1080 (Bitcoin-Qt)
 JSON-RPC listtransactions's from/count handling is now fixed
 Optimize and fix multithreaded access, when checking whether we already know about transactions
 Fix potential networking deadlock
 Proper support for Growl 1.3 notifications
 Display an error, rather than crashing, if encoding a QR Code failed (0.6.0.7)
-Don't erroneously set "Display addresses" for users who haven't explicitly enabled it (BGL-Qt)
+Don't erroneously set "Display addresses" for users who haven't explicitly enabled it (Bitcoin-Qt)
 Some non-ASCII input in JSON-RPC expecting hexadecimal may have been misinterpreted rather than rejected
 Missing error condition checking added
-Do not show green tick unless all known blocks are downloaded. Fixes #921 (BGL-Qt)
+Do not show green tick unless all known blocks are downloaded. Fixes #921 (Bitcoin-Qt)
 Increase time ago of last block for "up to date" status from 30 to 90 minutes
-Show a message box when runaway exception happens (BGL-Qt)
+Show a message box when runaway exception happens (Bitcoin-Qt)
 Use a messagebox to display the error when -server is provided without providing a rpc password
-Show error message instead of exception crash when unable to bind RPC port (BGL-Qt)
-Correct sign message BGL address tooltip. Fixes #1050 (BGL-Qt)
+Show error message instead of exception crash when unable to bind RPC port (Bitcoin-Qt)
+Correct sign message bitcoin address tooltip. Fixes #1050 (Bitcoin-Qt)
 Removed "(no label)" from QR Code dialog titlebar if we have no label (0.6.0.7)
 Removed an ugly line break in tooltip for mature transactions (0.6.0.7)
-Add missing tooltip and key shortcut in settings dialog (part of #1088) (BGL-Qt)
+Add missing tooltip and key shortcut in settings dialog (part of #1088) (Bitcoin-Qt)
 Work around issue in boost::program_options that prevents from compiling in clang
 Fixed bugs occurring only on platforms with unsigned characters (such as ARM).
-Rename make_windows_icon.py to .sh as it is a shell script. Fixes #1099 (BGL-Qt)
+Rename make_windows_icon.py to .sh as it is a shell script. Fixes #1099 (Bitcoin-Qt)
 Various trivial internal corrections to types used for counting/size loops and warnings

--- a/doc/release-notes/release-notes-0.5.0.md
+++ b/doc/release-notes/release-notes-0.5.0.md
@@ -1,45 +1,45 @@
-BGL version 0.5.0 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.5.0/
+Bitcoin version 0.5.0 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.0/
 
 The major change for this release is a completely new graphical interface that uses the Qt user interface toolkit.
 
 This release include German, Spanish, Spanish-Castilian, Norwegian and Dutch translations. More translations are welcome; join the project at Transifex if you can help:
-https://www.transifex.net/projects/p/BGL/
+https://www.transifex.net/projects/p/bitcoin/
 
 Please report bugs using the issue tracker at github:
 https://github.com/BitgesellOfficial/bitgesell/issues
 
-For Ubuntu users, there is a new ppa maintained by Matt Corallo which you can add to your system so that it will automatically keep BGL up-to-date.  Just type "sudo apt-add-repository ppa:BGL/BGL" in your terminal, then install the BGL-qt package.
+For Ubuntu users, there is a new ppa maintained by Matt Corallo which you can add to your system so that it will automatically keep bitcoin up-to-date.  Just type "sudo apt-add-repository ppa:bitcoin/bitcoin" in your terminal, then install the bitcoin-qt package.
 
 MAJOR BUG FIX  (CVE-2011-4447)
 
-The wallet encryption feature introduced in BGL version 0.4.0 did not sufficiently secure the private keys. An attacker who
+The wallet encryption feature introduced in Bitcoin version 0.4.0 did not sufficiently secure the private keys. An attacker who
 managed to get a copy of your encrypted wallet.dat file might be able to recover some or all of the unencrypted keys and steal the
 associated coins.
 
-If you have a previously encrypted wallet.dat, the first time you run BGL-qt or BGLd the wallet will be rewritten, BGL will
+If you have a previously encrypted wallet.dat, the first time you run bitcoin-qt or bitcoind the wallet will be rewritten, Bitcoin will
 shut down, and you will be prompted to restart it to run with the new, properly encrypted file.
 
 If you had a previously encrypted wallet.dat that might have been copied or stolen (for example, you backed it up to a public
-location) you should send all of your BGLs to yourself using a new BGL address and stop using any previously generated addresses.
+location) you should send all of your bitcoins to yourself using a new bitcoin address and stop using any previously generated addresses.
 
-Wallets encrypted with this version of BGL are written properly.
+Wallets encrypted with this version of Bitcoin are written properly.
 
-Technical note: the encrypted wallet's 'keypool' will be regenerated the first time you request a new BGL address; to be certain that the
+Technical note: the encrypted wallet's 'keypool' will be regenerated the first time you request a new bitcoin address; to be certain that the
 new private keys are properly backed up you should:
 
-1. Run BGL and let it rewrite the wallet.dat file
+1. Run Bitcoin and let it rewrite the wallet.dat file
 
-2. Run it again, then ask it for a new BGL address.
-BGL-Qt: Address Book, then New Address...
-BGLd: run the 'walletpassphrase' RPC command to unlock the wallet,  then run the 'getnewaddress' RPC command.
+2. Run it again, then ask it for a new bitcoin address.
+Bitcoin-Qt: Address Book, then New Address...
+bitcoind: run the 'walletpassphrase' RPC command to unlock the wallet,  then run the 'getnewaddress' RPC command.
 
-3. If your encrypted wallet.dat may have been copied or stolen, send  all of your BGLs to the new BGL address.
+3. If your encrypted wallet.dat may have been copied or stolen, send  all of your bitcoins to the new bitcoin address.
 
-4. Shut down BGL, then backup the wallet.dat file.
-IMPORTANT: be sure to request a new BGL address before backing up, so that the 'keypool' is regenerated and backed up.
+4. Shut down Bitcoin, then backup the wallet.dat file.
+IMPORTANT: be sure to request a new bitcoin address before backing up, so that the 'keypool' is regenerated and backed up.
 
-"Security in depth" is always a good idea, so choosing a secure location for the backup and/or encrypting the backup before uploading it is recommended. And as in previous releases, if your machine is infected by malware there are several ways an attacker might steal your BGLs.
+"Security in depth" is always a good idea, so choosing a secure location for the backup and/or encrypting the backup before uploading it is recommended. And as in previous releases, if your machine is infected by malware there are several ways an attacker might steal your bitcoins.
 
 Thanks to Alan Reiner (etotheipi) for finding and reporting this bug.
 
@@ -51,7 +51,7 @@ MAJOR GUI CHANGES
 
 Icons at the bottom of the window that show how well connected you are to the network, with tooltips to display details.
 
-Drag and drop support for BGL: URIs on web pages.
+Drag and drop support for bitcoin: URIs on web pages.
 
 Export transactions as a .csv file.
 
@@ -63,7 +63,7 @@ getmemorypool : new RPC command, provides everything needed to construct a block
 
 listsinceblock : new RPC command, list transactions since given block
 
-signmessage/verifymessage : new RPC commands to sign a message with one of your private keys or verify that a message signed by the private key associated with a BGL address.
+signmessage/verifymessage : new RPC commands to sign a message with one of your private keys or verify that a message signed by the private key associated with a bitcoin address.
 
 GENERAL CHANGES
 

--- a/doc/release-notes/release-notes-0.5.0.md
+++ b/doc/release-notes/release-notes-0.5.0.md
@@ -7,7 +7,7 @@ This release include German, Spanish, Spanish-Castilian, Norwegian and Dutch tra
 https://www.transifex.net/projects/p/BGL/
 
 Please report bugs using the issue tracker at github:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 For Ubuntu users, there is a new ppa maintained by Matt Corallo which you can add to your system so that it will automatically keep BGL up-to-date.  Just type "sudo apt-add-repository ppa:BGL/BGL" in your terminal, then install the BGL-qt package.
 

--- a/doc/release-notes/release-notes-0.5.1.md
+++ b/doc/release-notes/release-notes-0.5.1.md
@@ -9,7 +9,7 @@ More translations are welcome; join the project at Transifex if you can help:
 https://www.transifex.net/projects/p/BGL/
 
 Please report bugs using the issue tracker at github:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 Project source code is hosted at github; we are no longer
 distributing .tar.gz files here, you can get them

--- a/doc/release-notes/release-notes-0.5.1.md
+++ b/doc/release-notes/release-notes-0.5.1.md
@@ -1,12 +1,12 @@
-BGL version 0.5.1 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.5.1/
+Bitcoin version 0.5.1 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.1/
 
 This is a bugfix-only release.
 
 This release includes 13 translations, including 5 new translations:
 Italian, Hungarian, Ukranian, Portuguese (Brazilian) and Simplified Chinese.
 More translations are welcome; join the project at Transifex if you can help:
-https://www.transifex.net/projects/p/BGL/
+https://www.transifex.net/projects/p/bitcoin/
 
 Please report bugs using the issue tracker at github:
 https://github.com/BitgesellOfficial/bitgesell/issues
@@ -14,14 +14,14 @@ https://github.com/BitgesellOfficial/bitgesell/issues
 Project source code is hosted at github; we are no longer
 distributing .tar.gz files here, you can get them
 directly from github:
-https://github.com/BGL/BGL/tarball/v0.5.1  # .tar.gz
-https://github.com/BGL/BGL/zipball/v0.5.1  # .zip
+https://github.com/bitcoin/bitcoin/tarball/v0.5.1  # .tar.gz
+https://github.com/bitcoin/bitcoin/zipball/v0.5.1  # .zip
 
 For Ubuntu users, there is a new ppa maintained by Matt Corallo which
 you can add to your system so that it will automatically keep
-BGL up-to-date.  Just type
-sudo apt-add-repository ppa:BGL/BGL
-in your terminal, then install the BGL-qt package.
+bitcoin up-to-date.  Just type
+sudo apt-add-repository ppa:bitcoin/bitcoin
+in your terminal, then install the bitcoin-qt package.
 
 
 BUG FIXES
@@ -29,15 +29,15 @@ BUG FIXES
 Re-enable SSL support for the JSON-RPC interface (it was unintentionally
 disabled for the 0.5.0 release binaries).
 
-The code that finds peers via "dns seeds" no longer stops BGL startup
+The code that finds peers via "dns seeds" no longer stops bitcoin startup
 if one of the dns seed machines is down.
 
 Tooltips on the transaction list view were rendering incorrectly (as black boxes
 or with a transparent background).
 
-Prevent a denial-of-service attack involving flooding a BGL node with
+Prevent a denial-of-service attack involving flooding a bitcoin node with
 orphan blocks.
 
 The wallet passphrase dialog now warns you if the caps lock key was pressed.
 
-Improved searching in addresses and labels in BGL-qt.
+Improved searching in addresses and labels in bitcoin-qt.

--- a/doc/release-notes/release-notes-0.5.2.md
+++ b/doc/release-notes/release-notes-0.5.2.md
@@ -1,5 +1,5 @@
-BGL version 0.5.2 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.5.2/
+Bitcoin version 0.5.2 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.2/
 
 This is a bugfix-only release based on 0.5.1.
 
@@ -7,7 +7,7 @@ Please report bugs using the issue tracker at github:
 https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
-http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.5.2#.tar.gz
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.5.2#.tar.gz
 
 BUG FIXES
 
@@ -15,7 +15,7 @@ Check all transactions in blocks after the last checkpoint (0.5.0 and 0.5.1 skip
 Cease locking memory used by non-sensitive information (this caused a huge performance hit on some platforms, especially noticable during initial blockchain download; this was
 not a security vulnerability).
 Fixed some address-handling deadlocks (client freezes).
-No longer accept inbound connections over the internet when BGL is being used with Tor (identity leak).
+No longer accept inbound connections over the internet when Bitcoin is being used with Tor (identity leak).
 Re-enable SSL support for the JSON-RPC interface (it was unintentionally disabled for the 0.5.0 and 0.5.1 release Linux binaries).
 Use the correct base transaction fee of 0.0005 BTC for accepting transactions into mined blocks (since 0.4.0, it was incorrectly accepting 0.0001 BTC which was only meant to be relayed).
 Don't show "IP" for transactions which are not necessarily IP transactions.

--- a/doc/release-notes/release-notes-0.5.2.md
+++ b/doc/release-notes/release-notes-0.5.2.md
@@ -4,7 +4,7 @@ http://sourceforge.net/projects/BGL/files/BGL/BGL-0.5.2/
 This is a bugfix-only release based on 0.5.1.
 
 Please report bugs using the issue tracker at github:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
 http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.5.2#.tar.gz

--- a/doc/release-notes/release-notes-0.5.3.md
+++ b/doc/release-notes/release-notes-0.5.3.md
@@ -1,5 +1,5 @@
-BGL version 0.5.3 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.5.3/
+Bitcoin version 0.5.3 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.3/
 
 This is a bugfix-only release based on 0.5.1.
 It also includes a few protocol updates.
@@ -8,12 +8,12 @@ Please report bugs using the issue tracker at github:
 https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
-http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.5.3#.tar.gz
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.5.3#.tar.gz
 
 PROTOCOL UPDATES
 
 BIP 30: Introduce a new network rule: "a block is not valid if it contains a transaction whose hash already exists in the block chain, unless all that transaction's outputs were already spent before said block" beginning on March 15, 2012, 00:00 UTC.
-On testnet, allow mining of min-difficulty blocks if 20 minutes have gone by without mining a regular-difficulty block. This is to make testing BGL easier, and will not affect normal mode.
+On testnet, allow mining of min-difficulty blocks if 20 minutes have gone by without mining a regular-difficulty block. This is to make testing Bitcoin easier, and will not affect normal mode.
 
 BUG FIXES
 
@@ -24,19 +24,19 @@ Resolved multiple bugs preventing long-term unlocking of encrypted wallets
 Only send local IP in "version" messages if it is globally routable (ie, not private), and try to get such an IP from UPnP if applicable.
 Reannounce UPnP port forwards every 20 minutes, to workaround routers expiring old entries, and allow the -upnp option to override any stored setting.
 Skip splash screen when -min is used, and fix Minimize to Tray function.
-Do not blank "label" in BGL-Qt "Send" tab, if the user has already entered something.
+Do not blank "label" in Bitcoin-Qt "Send" tab, if the user has already entered something.
 Correct various labels and messages.
 Various memory leaks and potential null pointer deferences have been fixed.
-Handle invalid BGL URIs using "BGL://" instead of "BGL:".
+Handle invalid Bitcoin URIs using "bitcoin://" instead of "bitcoin:".
 Several shutdown issues have been fixed.
 Revert to "global progress indication", as starting from zero every time was considered too confusing for many users.
 Check that keys stored in the wallet are valid at startup, and if not, report corruption.
 Enable accessible widgets on Windows, so that people with screen readers such as NVDA can make sense of it.
 Various build fixes.
-If no password is specified to BGLd, recommend a secure password.
-Automatically focus and scroll to new "Send coins" entries in BGL-Qt.
-Show a message box for --help on Windows, for BGL-Qt.
+If no password is specified to bitcoind, recommend a secure password.
+Automatically focus and scroll to new "Send coins" entries in Bitcoin-Qt.
+Show a message box for --help on Windows, for Bitcoin-Qt.
 Add missing "About Qt" menu option to show built-in Qt About dialog.
-Don't show "-daemon" as an option for BGL-Qt, since it isn't available.
+Don't show "-daemon" as an option for Bitcoin-Qt, since it isn't available.
 Update hard-coded fallback seed nodes, choosing recent ones with long uptime and versions at least 0.4.0.
 Add checkpoint at block 168,000.

--- a/doc/release-notes/release-notes-0.5.3.md
+++ b/doc/release-notes/release-notes-0.5.3.md
@@ -5,7 +5,7 @@ This is a bugfix-only release based on 0.5.1.
 It also includes a few protocol updates.
 
 Please report bugs using the issue tracker at github:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
 http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.5.3#.tar.gz

--- a/doc/release-notes/release-notes-0.5.4.md
+++ b/doc/release-notes/release-notes-0.5.4.md
@@ -1,5 +1,5 @@
-BGL version 0.5.4 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.5.4/
+Bitcoin version 0.5.4 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.5.4/
 NOTE: 0.5.4rc3 is being renamed to 0.5.4 final with no changes.
 
 This is a bugfix-only release in the 0.5.x series, plus a few protocol updates.
@@ -8,7 +8,7 @@ Please report bugs using the issue tracker at github:
 https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
-http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.5.4#.tar.gz
+http://gitorious.org/bitcoin/bitcoind-stable/archive-tarball/v0.5.4#.tar.gz
 
 PROTOCOL UPDATES
 
@@ -22,8 +22,8 @@ Fix broken testnet mining.
 Stop excess inventory relay during initial block download.
 When disconnecting a node, clear the received buffer so that we do not process any already received messages.
 Yet another attempt at implementing "minimize to tray" that works on all operating systems.
-Fix BGL-Qt notifications under Growl 1.3.
-Increase required age of BGL-Qt's "not up to date" status from 30 to 90 minutes.
+Fix Bitcoin-Qt notifications under Growl 1.3.
+Increase required age of Bitcoin-Qt's "not up to date" status from 30 to 90 minutes.
 Implemented missing verifications that led to crash on entering some wrong passphrases for encrypted wallets.
 Fix default filename suffixes in GNOME save dialog.
 Make the "Send coins" tab use the configured unit type, even on the first attempt.
@@ -31,7 +31,7 @@ Print detailed wallet loading errors to debug.log when it is corrupt.
 Allocate exactly the amount of space needed for signing transactions, instead of a fixed 10k buffer.
 Workaround for improbable memory access violation.
 Check wallet's minimum version before trying to load it.
-Remove wxBGL properly when installing BGL-Qt over it. (Windows)
+Remove wxBitcoin properly when installing Bitcoin-Qt over it. (Windows)
 Detail reorganization information better in debug log.
 Use a messagebox to display the error when -server is provided without configuring a RPC password.
 Testing suite build now honours provided CXXFLAGS.

--- a/doc/release-notes/release-notes-0.5.4.md
+++ b/doc/release-notes/release-notes-0.5.4.md
@@ -5,7 +5,7 @@ NOTE: 0.5.4rc3 is being renamed to 0.5.4 final with no changes.
 This is a bugfix-only release in the 0.5.x series, plus a few protocol updates.
 
 Please report bugs using the issue tracker at github:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 Stable source code is hosted at Gitorious:
 http://gitorious.org/BGL/BGLd-stable/archive-tarball/v0.5.4#.tar.gz

--- a/doc/release-notes/release-notes-0.5.5.md
+++ b/doc/release-notes/release-notes-0.5.5.md
@@ -1,11 +1,11 @@
-BGLd and BGL-Qt version 0.5.5 are now available for download at:
+bitcoind and Bitcoin-Qt version 0.5.5 are now available for download at:
 Windows: installer | zip (sig)
 Source: tar.gz
-BGLd and BGL-Qt version 0.6.0.7 are also tagged in git, but it is recommended to upgrade to 0.6.1.
+bitcoind and Bitcoin-Qt version 0.6.0.7 are also tagged in git, but it is recommended to upgrade to 0.6.1.
 
 These are bugfix-only releases.
 
-Please report bugs by replying to this forum thread. Note that the 0.4.x wxBGL GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
+Please report bugs by replying to this forum thread. Note that the 0.4.x wxBitcoin GUI client is no longer maintained nor supported. If someone would like to step up to maintain this, they should contact Luke-Jr.
 
 BUG FIXES
 
@@ -13,25 +13,25 @@ Version 0.6.0 allowed importing invalid "private keys", which would be unspendab
 Verify status of encrypt/decrypt calls to detect failed padding
 Check blocks for duplicate transactions earlier. Fixes #1167
 Upgrade Windows builds to OpenSSL 1.0.1b
-Set label when selecting an address that already has a label. Fixes #1080 (BGL-Qt)
+Set label when selecting an address that already has a label. Fixes #1080 (Bitcoin-Qt)
 JSON-RPC listtransactions's from/count handling is now fixed
 Optimize and fix multithreaded access, when checking whether we already know about transactions
 Fix potential networking deadlock
 Proper support for Growl 1.3 notifications
 Display an error, rather than crashing, if encoding a QR Code failed (0.6.0.7)
-Don't erroneously set "Display addresses" for users who haven't explicitly enabled it (BGL-Qt)
+Don't erroneously set "Display addresses" for users who haven't explicitly enabled it (Bitcoin-Qt)
 Some non-ASCII input in JSON-RPC expecting hexadecimal may have been misinterpreted rather than rejected
 Missing error condition checking added
-Do not show green tick unless all known blocks are downloaded. Fixes #921 (BGL-Qt)
+Do not show green tick unless all known blocks are downloaded. Fixes #921 (Bitcoin-Qt)
 Increase time ago of last block for "up to date" status from 30 to 90 minutes
-Show a message box when runaway exception happens (BGL-Qt)
+Show a message box when runaway exception happens (Bitcoin-Qt)
 Use a messagebox to display the error when -server is provided without providing a rpc password
-Show error message instead of exception crash when unable to bind RPC port (BGL-Qt)
-Correct sign message BGL address tooltip. Fixes #1050 (BGL-Qt)
+Show error message instead of exception crash when unable to bind RPC port (Bitcoin-Qt)
+Correct sign message bitcoin address tooltip. Fixes #1050 (Bitcoin-Qt)
 Removed "(no label)" from QR Code dialog titlebar if we have no label (0.6.0.7)
 Removed an ugly line break in tooltip for mature transactions (0.6.0.7)
-Add missing tooltip and key shortcut in settings dialog (part of #1088) (BGL-Qt)
+Add missing tooltip and key shortcut in settings dialog (part of #1088) (Bitcoin-Qt)
 Work around issue in boost::program_options that prevents from compiling in clang
 Fixed bugs occurring only on platforms with unsigned characters (such as ARM).
-Rename make_windows_icon.py to .sh as it is a shell script. Fixes #1099 (BGL-Qt)
+Rename make_windows_icon.py to .sh as it is a shell script. Fixes #1099 (Bitcoin-Qt)
 Various trivial internal corrections to types used for counting/size loops and warnings

--- a/doc/release-notes/release-notes-0.6.0.md
+++ b/doc/release-notes/release-notes-0.6.0.md
@@ -7,7 +7,7 @@ project at Transifex to help:
 https://www.transifex.net/projects/p/BGL/
 
 Please report bugs using the issue tracker at github:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 Project source code is hosted at github; we are no longer
 distributing .tar.gz files here, you can get them

--- a/doc/release-notes/release-notes-0.6.0.md
+++ b/doc/release-notes/release-notes-0.6.0.md
@@ -1,10 +1,10 @@
-BGL version 0.6.0 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.6.0/test/
+Bitcoin version 0.6.0 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.0/test/
 
 This release includes more than 20 language localizations.
 More translations are welcome; join the
 project at Transifex to help:
-https://www.transifex.net/projects/p/BGL/
+https://www.transifex.net/projects/p/bitcoin/
 
 Please report bugs using the issue tracker at github:
 https://github.com/BitgesellOfficial/bitgesell/issues
@@ -12,14 +12,14 @@ https://github.com/BitgesellOfficial/bitgesell/issues
 Project source code is hosted at github; we are no longer
 distributing .tar.gz files here, you can get them
 directly from github:
-https://github.com/BGL/BGL/tarball/v0.6.0  # .tar.gz
-https://github.com/BGL/BGL/zipball/v0.6.0  # .zip
+https://github.com/bitcoin/bitcoin/tarball/v0.6.0  # .tar.gz
+https://github.com/bitcoin/bitcoin/zipball/v0.6.0  # .zip
 
 For Ubuntu users, there is a ppa maintained by Matt Corallo which
 you can add to your system so that it will automatically keep
-BGL up-to-date.  Just type
-sudo apt-add-repository ppa:BGL/BGL
-in your terminal, then install the BGL-qt package.
+bitcoin up-to-date.  Just type
+sudo apt-add-repository ppa:bitcoin/bitcoin
+in your terminal, then install the bitcoin-qt package.
 
 
 KNOWN ISSUES
@@ -30,7 +30,7 @@ because database writes are queued to speed up download
 time.
 
 
-NEW FEATURES SINCE BGL VERSION 0.5
+NEW FEATURES SINCE BITCOIN VERSION 0.5
 
 Initial network synchronization should be much faster
 (one or two hours on a typical machine instead of ten or more
@@ -38,30 +38,30 @@ hours).
 
 Backup Wallet menu option.
 
-BGL-Qt can display and save QR codes for sending
+Bitcoin-Qt can display and save QR codes for sending
 and receiving addresses.
 
 New context menu on addresses to copy/edit/delete them.
 
 New Sign Message dialog that allows you to prove that you
-own a BGL address by creating a digital
+own a bitcoin address by creating a digital
 signature.
 
 New wallets created with this version will
 use 33-byte 'compressed' public keys instead of
 65-byte public keys, resulting in smaller
-transactions and less traffic on the BGL
+transactions and less traffic on the bitcoin
 network. The shorter keys are already supported
 by the network but wallet.dat files containing
 short keys are not compatible with earlier
-versions of BGL-Qt/BGLd.
+versions of Bitcoin-Qt/bitcoind.
 
 New command-line argument -blocknotify=<command>
 that will spawn a shell process to run <command> 
 when a new block is accepted.
 
 New command-line argument -splash=0 to disable
-BGL-Qt's initial splash screen
+Bitcoin-Qt's initial splash screen
 
 validateaddress JSON-RPC api command output includes
 two new fields for addresses in the wallet:
@@ -104,11 +104,11 @@ attacks were fixed.
 
 NOT YET IMPLEMENTED FEATURES
 
-Support for clicking on BGL: URIs and
-opening/launching BGL-Qt is available only on Linux,
+Support for clicking on bitcoin: URIs and
+opening/launching Bitcoin-Qt is available only on Linux,
 and only if you configure your desktop to launch
-BGL-Qt. All platforms support dragging and dropping
-BGL: URIs onto the BGL-Qt window to start
+Bitcoin-Qt. All platforms support dragging and dropping
+bitcoin: URIs onto the Bitcoin-Qt window to start
 payment.
 
 
@@ -117,7 +117,7 @@ PRELIMINARY SUPPORT FOR MULTISIGNATURE TRANSACTIONS
 This release has preliminary support for multisignature
 transactions-- transactions that require authorization
 from more than one person or device before they
-will be accepted by the BGL network.
+will be accepted by the bitcoin network.
 
 Prior to this release, multisignature transactions
 were considered 'non-standard' and were ignored;
@@ -125,13 +125,13 @@ with this release multisignature transactions are
 considered standard and will start to be relayed
 and accepted into blocks.
 
-It is expected that future releases of BGL-Qt
+It is expected that future releases of Bitcoin-Qt
 will support the creation of multisignature transactions,
 once enough of the network has upgraded so relaying
 and validating them is robust.
 
 For this release, creation and testing of multisignature
-transactions is limited to the BGL test network using
+transactions is limited to the bitcoin test network using
 the "addmultisigaddress" JSON-RPC api call.
 
 Short multisignature address support is included in this

--- a/doc/release-notes/release-notes-0.6.2.md
+++ b/doc/release-notes/release-notes-0.6.2.md
@@ -1,5 +1,5 @@
-BGL version 0.6.2 is now available for download at:
-http://sourceforge.net/projects/BGL/files/BGL/BGL-0.6.2/
+Bitcoin version 0.6.2 is now available for download at:
+http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.2/
 
 This is a bug-fix and code-cleanup release, with no major new features.
 
@@ -14,7 +14,7 @@ portable to different data directories by default. If you need a
 portable blkindex.dat file then run with the new -detachdb=1 option
 or the "Detach databases at shutdown" GUI preference.
 
-Fixed https://github.com/BGL/BGL/issues/1065, a bug that
+Fixed https://github.com/bitcoin/bitcoin/issues/1065, a bug that
 could cause long-running nodes to crash.
 
 Mac and Windows binaries are compiled against OpenSSL 1.0.1b (Linux

--- a/doc/release-notes/release-notes-0.6.2.md
+++ b/doc/release-notes/release-notes-0.6.2.md
@@ -4,7 +4,7 @@ http://sourceforge.net/projects/BGL/files/BGL/BGL-0.6.2/
 This is a bug-fix and code-cleanup release, with no major new features.
 
 Please report bugs using the github issue tracker at:
-https://github.com/BGL/BGL/issues
+https://github.com/BitgesellOfficial/bitgesell/issues
 
 
 NOTABLE CHANGES

--- a/doc/release-notes/release-notes-0.6.3.md
+++ b/doc/release-notes/release-notes-0.6.3.md
@@ -4,7 +4,7 @@ BGL version 0.6.3 is now available for download at:
 This is a bug-fix release, with no new features.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 CHANGE SUMMARY
 

--- a/doc/release-notes/release-notes-0.6.3.md
+++ b/doc/release-notes/release-notes-0.6.3.md
@@ -1,5 +1,5 @@
-BGL version 0.6.3 is now available for download at:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.6.3/
+Bitcoin version 0.6.3 is now available for download at:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.6.3/
 
 This is a bug-fix release, with no new features.
 
@@ -9,21 +9,21 @@ Please report bugs using the issue tracker at github:
 CHANGE SUMMARY
 
 Fixed a serious denial-of-service attack that could cause the
-BGL process to become unresponsive. Thanks to Sergio Lerner
+bitcoin process to become unresponsive. Thanks to Sergio Lerner
 for finding and responsibly reporting the problem. (CVE-2012-3789)
 
 Optimized the process of checking transaction signatures, to
 speed up processing of new block messages and make propagating
 blocks across the network faster.
 
-Fixed an obscure bug that could cause the BGL process to get
+Fixed an obscure bug that could cause the bitcoin process to get
 stuck on an invalid block-chain, if the invalid chain was
 hundreds of blocks long.
 
-BGL-Qt no longer automatically selects the first address
+Bitcoin-Qt no longer automatically selects the first address
 in the address book (Issue #1384).
 
-Fixed minimize-to-dock behavior of BGL-Qt on the Mac.
+Fixed minimize-to-dock behavior of Bitcoin-Qt on the Mac.
 
 Added a block checkpoint at block 185,333 to speed up initial
 blockchain download.

--- a/doc/release-notes/release-notes-0.7.0.md
+++ b/doc/release-notes/release-notes-0.7.0.md
@@ -5,7 +5,7 @@ We recommend that everybody running prior versions of BGLd/BGL-Qt
 upgrade to this release, except for users running Mac OSX 10.5.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 Project source code is hosted at github; you can get
 source-only tarballs/zipballs directly from there:

--- a/doc/release-notes/release-notes-0.7.0.md
+++ b/doc/release-notes/release-notes-0.7.0.md
@@ -1,7 +1,7 @@
-BGL version 0.7.0 is now available for download at:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.7.0/
+Bitcoin version 0.7.0 is now available for download at:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.0/
 
-We recommend that everybody running prior versions of BGLd/BGL-Qt
+We recommend that everybody running prior versions of bitcoind/Bitcoin-Qt
 upgrade to this release, except for users running Mac OSX 10.5.
 
 Please report bugs using the issue tracker at github:
@@ -9,16 +9,16 @@ Please report bugs using the issue tracker at github:
 
 Project source code is hosted at github; you can get
 source-only tarballs/zipballs directly from there:
-  https://github.com/BGL/BGL/tarball/v0.7.0  # .tar.gz
-  https://github.com/BGL/BGL/zipball/v0.7.0  # .zip
+  https://github.com/bitcoin/bitcoin/tarball/v0.7.0  # .tar.gz
+  https://github.com/bitcoin/bitcoin/zipball/v0.7.0  # .zip
 
 Ubuntu Linux users can use the "Personal Package Archive" (PPA)
 maintained by Matt Corallo to automatically keep 
-BGL up-to-date.  Just type
-  sudo apt-add-repository ppa:BGL/BGL
+bitcoin up-to-date.  Just type
+  sudo apt-add-repository ppa:bitcoin/bitcoin
   sudo apt-get update
-in your terminal, then install the BGL-qt package:
-  sudo apt-get install BGL-qt
+in your terminal, then install the bitcoin-qt package:
+  sudo apt-get install bitcoin-qt
 
 
 How to Upgrade
@@ -27,10 +27,10 @@ If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
 Code:
-/Applications/BGL-Qt
+/Applications/Bitcoin-Qt
 (on Mac) or
 Code:
-BGLd/BGL-qt
+bitcoind/bitcoin-qt
 (on Linux).
 
 If you were running on Linux with a version that might have been compiled
@@ -45,14 +45,14 @@ Incompatible Changes
   and 'getrawmempool' commands.
 * Remove deprecated RPC 'getblocknumber'
 
-BGL Improvement Proposals implemented
+Bitcoin Improvement Proposals implemented
 
 BIP 22 - 'getblocktemplate', 'submitblock' RPCs
 BIP 34 - block version 2, height in coinbase
 BIP 35 - 'mempool' message, extended 'getdata' message behavior
 
 
-Core BGL handling and blockchain database
+Core bitcoin handling and blockchain database
 
 * Reduced CPU usage, by eliminating some redundant hash calculations
 * Cache signature verifications, to eliminate redundant signature checks
@@ -109,7 +109,7 @@ Qt GUI
 * Add 2 labels to the overviewpage that display Wallet and Transaction status (obsolete or current)
 * Extend the optionsdialog (e.g. language selection) and re-work it to a tabbed UI
 * Merge sign/verify message into a single window with tabbed UI
-* Ensure a changed BGL unit immediately updates all GUI elements that use units
+* Ensure a changed bitcoin unit immediately updates all GUI elements that use units
 * Update QR Code dialog
 * Improve error reporting at startup
 * Fine-grained UI updates for a much smoother UI during block downloads
@@ -119,8 +119,8 @@ Qt GUI
 * Much better translations
 * Override progress bar design on platforms with segmented progress bars to assist with readability
 * Added 'immature balance' display on the overview page
-* (Windows only): enable ASLR and DEP for BGL-qt.exe
-* (Windows only): add meta-data to BGL-qt.exe (e.g. description)
+* (Windows only): enable ASLR and DEP for bitcoin-qt.exe
+* (Windows only): add meta-data to bitcoin-qt.exe (e.g. description)
 
 Internal codebase
 
@@ -131,7 +131,7 @@ Internal codebase
 Miscellaneous
 
 * Reopen debug.log upon SIGHUP
-* Bash programmable completion for BGLd(1)
+* Bash programmable completion for bitcoind(1)
 * On supported OS's, each thread is given a useful name
 
 

--- a/doc/release-notes/release-notes-0.7.1.md
+++ b/doc/release-notes/release-notes-0.7.1.md
@@ -4,7 +4,7 @@ BGL version 0.7.1 is now available from:
 This is a bug-fix minor release.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 Project source code is hosted at github; you can get
 source-only tarballs/zipballs directly from there:

--- a/doc/release-notes/release-notes-0.7.1.md
+++ b/doc/release-notes/release-notes-0.7.1.md
@@ -1,5 +1,5 @@
-BGL version 0.7.1 is now available from:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.7.1/
+Bitcoin version 0.7.1 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.1/
 
 This is a bug-fix minor release.
 
@@ -8,16 +8,16 @@ Please report bugs using the issue tracker at github:
 
 Project source code is hosted at github; you can get
 source-only tarballs/zipballs directly from there:
-  https://github.com/BGL/BGL/tarball/v0.7.1  # .tar.gz
-  https://github.com/BGL/BGL/zipball/v0.7.1  # .zip
+  https://github.com/bitcoin/bitcoin/tarball/v0.7.1  # .tar.gz
+  https://github.com/bitcoin/bitcoin/zipball/v0.7.1  # .zip
 
 Ubuntu Linux users can use the "Personal Package Archive" (PPA)
 maintained by Matt Corallo to automatically keep 
 up-to-date.  Just type:
-  sudo apt-add-repository ppa:BGL/BGL
+  sudo apt-add-repository ppa:bitcoin/bitcoin
   sudo apt-get update
-in your terminal, then install the BGL-qt package:
-  sudo apt-get install BGL-qt
+in your terminal, then install the bitcoin-qt package:
+  sudo apt-get install bitcoin-qt
 
 KNOWN ISSUES
 ------------
@@ -30,7 +30,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-/Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you were running on Linux with a version that might have been compiled
 with a different version of Berkeley DB (for example, if you were using an
@@ -75,7 +75,7 @@ Dependency changes
 Bug fixes
 ---------
 
-* Clicking on a BGL: URI on Windows should now launch BGL-Qt properly.
+* Clicking on a bitcoin: URI on Windows should now launch Bitcoin-Qt properly.
 
 * When running -testnet, use RPC port 18332 by default.
 

--- a/doc/release-notes/release-notes-0.7.2.md
+++ b/doc/release-notes/release-notes-0.7.2.md
@@ -4,7 +4,7 @@ BGL version 0.7.2 is now available from:
 This is a bug-fix minor release.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 --------------

--- a/doc/release-notes/release-notes-0.7.2.md
+++ b/doc/release-notes/release-notes-0.7.2.md
@@ -1,5 +1,5 @@
-BGL version 0.7.2 is now available from:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.7.2
+Bitcoin version 0.7.2 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.7.2
 
 This is a bug-fix minor release.
 
@@ -12,7 +12,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-/Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you were running on Linux with a version that might have been compiled
 with a different version of Berkeley DB (for example, if you were using an
@@ -40,7 +40,7 @@ Bug fixes
   database twice.
 
 * Fix use-after-free problems in initialization and shutdown, the latter of
-  which caused BGL-Qt to crash on Windows when exiting.
+  which caused Bitcoin-Qt to crash on Windows when exiting.
 
 * Correct library linking so building on Windows natively works.
 

--- a/doc/release-notes/release-notes-0.8.0.md
+++ b/doc/release-notes/release-notes-0.8.0.md
@@ -5,7 +5,7 @@ This is a major release designed to improve performance and handle the
 increasing volume of transactions on the network.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 --------------

--- a/doc/release-notes/release-notes-0.8.0.md
+++ b/doc/release-notes/release-notes-0.8.0.md
@@ -1,5 +1,5 @@
-BGL-Qt version 0.8.0 is now available from:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.8.0/
+Bitcoin-Qt version 0.8.0 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.0/
 
 This is a major release designed to improve performance and handle the
 increasing volume of transactions on the network.
@@ -13,7 +13,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-/Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 The first time you run after the upgrade a re-indexing process will be
 started that will take anywhere from 30 minutes to several hours,
@@ -31,7 +31,7 @@ details).
 Improvements
 ------------
 
-Mac and Windows binaries are signed with certificates owned by the BGL
+Mac and Windows binaries are signed with certificates owned by the Bitcoin
 Foundation, to be compatible with the new security features in OSX 10.8 and
 Windows 8.
 
@@ -61,7 +61,7 @@ contrib/spendfrom is a python-language command-line utility that demonstrates
 how to use the "raw transactions" JSON-RPC api to send coins received from particular
 addresses (also known as "coin control").
 
-New/changed settings (command-line or BGL.conf file)
+New/changed settings (command-line or bitcoin.conf file)
 --------------------------------------------------------
 
 dbcache : controls LevelDB memory usage.

--- a/doc/release-notes/release-notes-0.8.1.md
+++ b/doc/release-notes/release-notes-0.8.1.md
@@ -5,7 +5,7 @@ This is a maintenance release that adds a new network rule to avoid
 a chain-forking incompatibility with versions 0.7.2 and earlier.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 
 How to Upgrade

--- a/doc/release-notes/release-notes-0.8.1.md
+++ b/doc/release-notes/release-notes-0.8.1.md
@@ -1,5 +1,5 @@
-BGL-Qt/BGLd version 0.8.1 is now available from:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.8.1/
+Bitcoin-Qt/bitcoind version 0.8.1 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.1/
 
 This is a maintenance release that adds a new network rule to avoid
 a chain-forking incompatibility with versions 0.7.2 and earlier.
@@ -14,7 +14,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-/Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you
 run 0.8.1 your blockchain files will be re-indexed, which will take

--- a/doc/release-notes/release-notes-0.8.2.md
+++ b/doc/release-notes/release-notes-0.8.2.md
@@ -1,5 +1,5 @@
-BGL-Qt version 0.8.2 is now available from:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.8.2/
+Bitcoin-Qt version 0.8.2 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.2/
 
 This is a maintenance release that fixes many bugs and includes
 a few small new features.
@@ -13,7 +13,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-/Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you
 run 0.8.2 your blockchain files will be re-indexed, which will take
@@ -43,7 +43,7 @@ with code that automatically calculates and suggests appropriate fees in the
 0.9 release and note that if you set a fee policy significantly different from
 the rest of the network your transactions may never confirm.
 
-BGL-Qt changes
+Bitcoin-Qt changes
 
 * New icon and splash screen
 * Improve reporting of synchronization process
@@ -58,7 +58,7 @@ BGL-Qt changes
   to current translations
 
 MacOSX:
-* OSX support for click-to-pay (BGL:) links
+* OSX support for click-to-pay (bitcoin:) links
 * Fix GUI disappearing problem on MacOSX (issue #1522)
 
 Linux/Unix:
@@ -97,8 +97,8 @@ Wallet compatibility/rescuing
 
 Known Bugs
 
-* Entering the 'getblocktemplate' or 'getwork' RPC commands into the BGL-Qt debug
-console will cause BGL-Qt to crash. Run BGL-Qt with the -server command-line
+* Entering the 'getblocktemplate' or 'getwork' RPC commands into the Bitcoin-Qt debug
+console will cause Bitcoin-Qt to crash. Run Bitcoin-Qt with the -server command-line
 option to workaround.
 
 Thanks to everybody who contributed to the 0.8.2 release!

--- a/doc/release-notes/release-notes-0.8.2.md
+++ b/doc/release-notes/release-notes-0.8.2.md
@@ -5,7 +5,7 @@ This is a maintenance release that fixes many bugs and includes
 a few small new features.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 
 How to Upgrade

--- a/doc/release-notes/release-notes-0.8.3.md
+++ b/doc/release-notes/release-notes-0.8.3.md
@@ -5,7 +5,7 @@ This is a maintenance release to fix a denial-of-service attack that
 can cause nodes to crash.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 0.8.3 Release notes
 

--- a/doc/release-notes/release-notes-0.8.3.md
+++ b/doc/release-notes/release-notes-0.8.3.md
@@ -1,5 +1,5 @@
-BGL-Qt version 0.8.3 is now available from:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.8.3/
+Bitcoin-Qt version 0.8.3 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.3/
 
 This is a maintenance release to fix a denial-of-service attack that
 can cause nodes to crash.

--- a/doc/release-notes/release-notes-0.8.4.md
+++ b/doc/release-notes/release-notes-0.8.4.md
@@ -1,5 +1,5 @@
-BGL-Qt version 0.8.4 is now available from:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.8.4/
+Bitcoin-Qt version 0.8.4 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.4/
 
 This is a maintenance release to fix a critical bug and three
 security issues; we urge all users to upgrade.
@@ -14,7 +14,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-/Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you
 run 0.8.4 your blockchain files will be re-indexed, which will take
@@ -29,12 +29,12 @@ Security issues
 
 An attacker could send a series of messages that resulted in
 an integer division-by-zero error in the Bloom Filter handling
-code, causing the BGL-Qt or BGLd process to crash.
+code, causing the Bitcoin-Qt or bitcoind process to crash.
 Bloom filters were introduced with version 0.8, so versions 0.8.0
 through 0.8.3 are vulnerable to this critical denial-of-service attack.
 
 A constant-time algorithm is now used to check RPC password
-guess attempts; fixes https://github.com/BGL/BGL/issues/2838
+guess attempts; fixes https://github.com/bitcoin/bitcoin/issues/2838
 (CVE-2013-4165)
 
 Implement a better fix for the fill-memory-with-orphan-transactions
@@ -55,11 +55,11 @@ OSX: use 'FD_FULLSYNC' with LevelDB, which will (hopefully!)
 prevent the database corruption issues many people have
 experienced on OSX.
 
-Linux: clicking on BGL: links was broken if you were using
+Linux: clicking on bitcoin: links was broken if you were using
 a Gnome-based desktop.
 
 Fix a hang-at-shutdown bug that only affects users that compile
-their own version of BGL against Boost versions 1.50-1.52.
+their own version of Bitcoin against Boost versions 1.50-1.52.
 
 Other changes
 -------------

--- a/doc/release-notes/release-notes-0.8.4.md
+++ b/doc/release-notes/release-notes-0.8.4.md
@@ -5,7 +5,7 @@ This is a maintenance release to fix a critical bug and three
 security issues; we urge all users to upgrade.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 
 How to Upgrade

--- a/doc/release-notes/release-notes-0.8.5.md
+++ b/doc/release-notes/release-notes-0.8.5.md
@@ -5,7 +5,7 @@ This is a maintenance release to fix a critical bug;
 we urge all users to upgrade.
 
 Please report bugs using the issue tracker at github:
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 
 How to Upgrade

--- a/doc/release-notes/release-notes-0.8.5.md
+++ b/doc/release-notes/release-notes-0.8.5.md
@@ -1,5 +1,5 @@
-BGL-Qt version 0.8.5 is now available from:
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.8.5/
+Bitcoin-Qt version 0.8.5 is now available from:
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.5/
 
 This is a maintenance release to fix a critical bug;
 we urge all users to upgrade.
@@ -14,7 +14,7 @@ How to Upgrade
 If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-/Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you
 run 0.8.5 your blockchain files will be re-indexed, which will take

--- a/doc/release-notes/release-notes-0.8.6.md
+++ b/doc/release-notes/release-notes-0.8.6.md
@@ -6,7 +6,7 @@ This is a maintenance release to fix a critical bug; we urge all users to upgrad
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 --------------

--- a/doc/release-notes/release-notes-0.8.6.md
+++ b/doc/release-notes/release-notes-0.8.6.md
@@ -1,6 +1,6 @@
-BGL-Qt version 0.8.6 final is now available from:
+Bitcoin-Qt version 0.8.6 final is now available from:
 
-  http://sourceforge.net/projects/BGL/files/BGL/BGL-0.8.6/
+  http://sourceforge.net/projects/bitcoin/files/Bitcoin/bitcoin-0.8.6/
 
 This is a maintenance release to fix a critical bug; we urge all users to upgrade.
 
@@ -16,7 +16,7 @@ If you already downloaded 0.8.6rc1 you do not need to re-download. This release 
 If you are running an older version, shut it down. Wait
 until it has completely shut down (which might take a few minutes for older
 versions), then run the installer (on Windows) or just copy over
-/Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+/Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you
 run 0.8.6 your blockchain files will be re-indexed, which will take
@@ -47,7 +47,7 @@ your machine.
 
 - Additional debug.log logging for diagnosis of network problems, log timestamps by default
 
-- Fix BGL-Qt startup crash when clicking dock icon on OSX 
+- Fix Bitcoin-Qt startup crash when clicking dock icon on OSX 
 
 - Fix memory leaks in CKey::SetCompactSignature() and Key::SignCompact()
 
@@ -63,4 +63,4 @@ Warning
   Hence it is recommended to use a 64-bit executable if possible.
   A 64-bit executable for Windows is planned for 0.9.
 
-Note: Gavin Andresen's GPG signing key for SHA256SUMS.asc has been changed from  key id 1FC730C1 to sub key 7BF6E212 (see https://github.com/BGL/BGL.org/pull/279).
+Note: Gavin Andresen's GPG signing key for SHA256SUMS.asc has been changed from  key id 1FC730C1 to sub key 7BF6E212 (see https://github.com/bitcoin/bitcoin.org/pull/279).

--- a/doc/release-notes/release-notes-0.9.0.md
+++ b/doc/release-notes/release-notes-0.9.0.md
@@ -1,6 +1,6 @@
-BGL Core version 0.9.0 is now available from:
+Bitcoin Core version 0.9.0 is now available from:
 
-  https://BGL.org/bin/0.9.0/
+  https://bitcoin.org/bin/0.9.0/
 
 This is a new major version release, bringing both new features and
 bug fixes.
@@ -14,14 +14,14 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), uninstall all
-earlier versions of BGL, then run the installer (on Windows) or just copy
-over /Applications/BGL-Qt (on Mac) or BGLd/BGL-qt (on Linux).
+earlier versions of Bitcoin, then run the installer (on Windows) or just copy
+over /Applications/Bitcoin-Qt (on Mac) or bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
 0.9.0 your blockchain files will be re-indexed, which will take anywhere from 
 30 minutes to several hours, depending on the speed of your machine.
 
-On Windows, do not forget to uninstall all earlier versions of the BGL
+On Windows, do not forget to uninstall all earlier versions of the Bitcoin
 client first, especially if you are switching to the 64-bit version.
 
 Windows 64-bit installer
@@ -59,11 +59,11 @@ Also, the first time you run a 0.8.x release on a 0.9 wallet it will rescan
 the blockchain for missing spent coins, which will take a long time (tens
 of minutes on a typical machine).
 
-Rebranding to BGL Core
+Rebranding to Bitcoin Core
 ---------------------------
 
-To reduce confusion between BGL-the-network and BGL-the-software we
-have renamed the reference client to BGL Core.
+To reduce confusion between Bitcoin-the-network and Bitcoin-the-software we
+have renamed the reference client to Bitcoin Core.
 
 
 OP_RETURN and data in the block chain
@@ -74,7 +74,7 @@ blockchain.  This change is not an endorsement of storing data in the
 blockchain.  The OP_RETURN change creates a provably-prunable output,
 to avoid data storage schemes -- some of which were already deployed --
 that were storing arbitrary data such as images as forever-unspendable
-TX outputs, bloating BGL's UTXO database.
+TX outputs, bloating bitcoin's UTXO database.
 
 Storing arbitrary data in the blockchain is still a bad idea; it is less
 costly and far more efficient to store non-currency data elsewhere.
@@ -85,20 +85,20 @@ Autotools build system
 For 0.9.0 we switched to an autotools-based build system instead of individual
 (q)makefiles.
 
-Using the standard "./autogen.sh; ./configure; make" to build BGL-Qt and
-BGLd makes it easier for experienced open source developers to contribute 
+Using the standard "./autogen.sh; ./configure; make" to build Bitcoin-Qt and
+bitcoind makes it easier for experienced open source developers to contribute 
 to the project.
 
 Be sure to check doc/build-*.md for your platform before building from source.
 
-BGL-cli
+Bitcoin-cli
 -------------
 
-Another change in the 0.9 release is moving away from the BGLd executable
+Another change in the 0.9 release is moving away from the bitcoind executable
 functioning both as a server and as a RPC client. The RPC client functionality
-("tell the running BGL daemon to do THIS") was split into a separate
-executable, 'BGL-cli'. The RPC client code will eventually be removed from
-BGLd, but will be kept for backwards compatibility for a release or two.
+("tell the running bitcoin daemon to do THIS") was split into a separate
+executable, 'bitcoin-cli'. The RPC client code will eventually be removed from
+bitcoind, but will be kept for backwards compatibility for a release or two.
 
 `walletpassphrase` RPC
 -----------------------
@@ -197,13 +197,13 @@ Command-line options:
 - New option: -nospendzeroconfchange to never spend unconfirmed change outputs
 - New option: -zapwallettxes to rebuild the wallet's transaction information
 - Rename option '-tor' to '-onion' to better reflect what it does
-- Add '-disablewallet' mode to let BGLd run entirely without wallet (when
+- Add '-disablewallet' mode to let bitcoind run entirely without wallet (when
   built with wallet)
 - Update default '-rpcsslciphers' to include TLSv1.2
 - make '-logtimestamps' default on and rework help-message
 - RPC client option: '-rpcwait', to wait for server start
 - Remove '-logtodebugger'
-- Allow `-noserver` with BGLd
+- Allow `-noserver` with bitcoind
 
 Block-chain handling and storage:
 
@@ -254,7 +254,7 @@ Protocol and network:
 - Improve logging of failed connections
 - Bump protocol version to 70002
 - Add some additional logging to give extra network insight
-- Added new DNS seed from BGLstats.com
+- Added new DNS seed from bitcoinstats.com
 
 Validation:
 
@@ -295,18 +295,18 @@ GUI:
 - Add Coin Control Features
 - Improve receive coins workflow: make the 'Receive' tab into a form to request
   payments, and move historical address list functionality to File menu.
-- Rebrand to `BGL Core`
+- Rebrand to `Bitcoin Core`
 - Move initialization/shutdown to a thread. This prevents "Not responding"
   messages during startup. Also show a window during shutdown.
 - Don't regenerate autostart link on every client startup
-- Show and store message of normal BGL:URI
+- Show and store message of normal bitcoin:URI
 - Fix richtext detection hang issue on very old Qt versions
 - OS X: Make use of the 10.8+ user notification center to display Growl-like 
   notifications
 - OS X: Added NSHighResolutionCapable flag to Info.plist for better font
   rendering on Retina displays.
-- OS X: Fix BGL-qt startup crash when clicking dock icon
-- Linux: Fix Gnome BGL: URI handler
+- OS X: Fix bitcoin-qt startup crash when clicking dock icon
+- Linux: Fix Gnome bitcoin: URI handler
 
 Miscellaneous:
 
@@ -314,7 +314,7 @@ Miscellaneous:
 - Add '-regtest' mode, similar to testnet but private with instant block
   generation with 'setgenerate' RPC.
 - Add 'linearize.py' script to contrib, for creating bootstrap.dat
-- Add separate BGL-cli client
+- Add separate bitcoin-cli client
 
 Credits
 --------

--- a/doc/release-notes/release-notes-0.9.0.md
+++ b/doc/release-notes/release-notes-0.9.0.md
@@ -7,7 +7,7 @@ bug fixes.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 --------------

--- a/doc/release-notes/release-notes-0.9.1.md
+++ b/doc/release-notes/release-notes-0.9.1.md
@@ -13,7 +13,7 @@ hostile hosts.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 --------------

--- a/doc/release-notes/release-notes-0.9.1.md
+++ b/doc/release-notes/release-notes-0.9.1.md
@@ -1,13 +1,13 @@
-BGL Core version 0.9.1 is now available from:
+Bitcoin Core version 0.9.1 is now available from:
 
-  https://BGL.org/bin/0.9.1/
+  https://bitcoin.org/bin/0.9.1/
 
 This is a security update. It is recommended to upgrade to this release
 as soon as possible.
 
 It is especially important to upgrade if you currently have version
 0.9.0 installed and are using the graphical interface OR you are using
-BGLd from any pre-0.9.1 version, and have enabled SSL for RPC and
+bitcoind from any pre-0.9.1 version, and have enabled SSL for RPC and
 have configured allowip to allow rpc connections from potentially
 hostile hosts.
 
@@ -20,8 +20,8 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
 0.9.1 your blockchain files will be re-indexed, which will take anywhere from 
@@ -33,7 +33,7 @@ If you are upgrading from version 0.7.2 or earlier, the first time you run
 No code changes were made between 0.9.0 and 0.9.1. Only the dependencies were changed.
 
 - Upgrade OpenSSL to 1.0.1g. This release fixes the following vulnerabilities which can
-  affect the BGL Core software:
+  affect the Bitcoin Core software:
 
   - CVE-2014-0160 ("heartbleed")
     A missing bounds check in the handling of the TLS heartbeat extension can

--- a/doc/release-notes/release-notes-0.9.2.1.md
+++ b/doc/release-notes/release-notes-0.9.2.1.md
@@ -8,7 +8,7 @@ Upgrading to this release is recommended.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 --------------

--- a/doc/release-notes/release-notes-0.9.2.1.md
+++ b/doc/release-notes/release-notes-0.9.2.1.md
@@ -1,6 +1,6 @@
-BGL Core version 0.9.2.1 is now available from:
+Bitcoin Core version 0.9.2.1 is now available from:
 
-  https://BGL.org/bin/0.9.2.1/
+  https://bitcoin.org/bin/0.9.2.1/
 
 This is a new minor version release, bringing mostly bug fixes and some minor
 improvements. OpenSSL has been updated because of a security issue (CVE-2014-0224).
@@ -15,8 +15,8 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
 0.9.2.1 your blockchain files will be re-indexed, which will take anywhere from 
@@ -130,7 +130,7 @@ GUI:
 - Catch Windows shutdown events while client is running
 - Optionally add third party links to transaction context menu
 - Check for !pixmap() before trying to export QR code (avoids crashes when no QR code could be generated)
-- Fix "Start BGL on system login"
+- Fix "Start bitcoin on system login"
 
 Miscellaneous:
 

--- a/doc/release-notes/release-notes-0.9.2.md
+++ b/doc/release-notes/release-notes-0.9.2.md
@@ -8,7 +8,7 @@ Upgrading to this release is recommended.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 --------------

--- a/doc/release-notes/release-notes-0.9.2.md
+++ b/doc/release-notes/release-notes-0.9.2.md
@@ -1,6 +1,6 @@
-BGL Core version 0.9.2 is now available from:
+Bitcoin Core version 0.9.2 is now available from:
 
-  https://BGL.org/bin/0.9.2/
+  https://bitcoin.org/bin/0.9.2/
 
 This is a new minor version release, bringing mostly bug fixes and some minor
 improvements. OpenSSL has been updated because of a security issue (CVE-2014-0224).
@@ -15,8 +15,8 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
 0.9.2 your blockchain files will be re-indexed, which will take anywhere from 
@@ -130,7 +130,7 @@ GUI:
 - Catch Windows shutdown events while client is running
 - Optionally add third party links to transaction context menu
 - Check for !pixmap() before trying to export QR code (avoids crashes when no QR code could be generated)
-- Fix "Start BGL on system login"
+- Fix "Start bitcoin on system login"
 
 Miscellaneous:
 

--- a/doc/release-notes/release-notes-0.9.3.md
+++ b/doc/release-notes/release-notes-0.9.3.md
@@ -1,6 +1,6 @@
-BGL Core version 0.9.3 is now available from:
+Bitcoin Core version 0.9.3 is now available from:
 
-  https://BGL.org/bin/0.9.3/
+  https://bitcoin.org/bin/0.9.3/
 
 This is a new minor version release, bringing only bug fixes and updated
 translations. Upgrading to this release is recommended.
@@ -17,8 +17,8 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 If you are upgrading from version 0.7.2 or earlier, the first time you run
 0.9.3 your blockchain files will be re-indexed, which will take anywhere from 
@@ -70,7 +70,7 @@ GUI:
 Miscellaneous:
 - key.cpp: fail with a friendlier message on missing ssl EC support
 - Remove bignum dependency for scripts
-- Upgrade OpenSSL to 1.0.1i (see https://www.openssl.org/news/secadv_20140806.txt - just to be sure, no critical issues for BGL Core)
+- Upgrade OpenSSL to 1.0.1i (see https://www.openssl.org/news/secadv_20140806.txt - just to be sure, no critical issues for Bitcoin Core)
 - Upgrade miniupnpc to 1.9.20140701
 - Fix boost detection in build system on some platforms
 
@@ -98,4 +98,4 @@ Thanks to everyone who contributed to this release:
 - Wladimir J. van der Laan
 - Zak Wilcox
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.9.3.md
+++ b/doc/release-notes/release-notes-0.9.3.md
@@ -7,7 +7,7 @@ translations. Upgrading to this release is recommended.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 Upgrading and downgrading
 ==========================

--- a/doc/release-notes/release-notes-0.9.4.md
+++ b/doc/release-notes/release-notes-0.9.4.md
@@ -1,6 +1,6 @@
-BGL Core version 0.9.4 is now available from:
+Bitcoin Core version 0.9.4 is now available from:
 
-  https://BGL.org/bin/0.9.4/
+  https://bitcoin.org/bin/0.9.4/
 
 This is a new minor version release, bringing only bug fixes and updated
 translations. Upgrading to this release is recommended.
@@ -14,26 +14,26 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 OpenSSL Warning
 ================
 
 OpenSSL 1.0.0p / 1.0.1k was recently released and is being pushed out by
 various operating system maintainers. Review by Gregory Maxwell determined that
-this update is incompatible with the BGL system and could lead to consensus
+this update is incompatible with the Bitcoin system and could lead to consensus
 forks.
 
-BGL Core released binaries from https://BGL.org are unaffected,
+Bitcoin Core released binaries from https://bitcoin.org are unaffected,
 as are any built with the gitian deterministic build system.
 
 However, if you are running either
 
-- The Ubuntu PPA from https://launchpad.net/~BGL/+archive/ubuntu/BGL
-- A third-party or self-compiled BGL Core
+- The Ubuntu PPA from https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin
+- A third-party or self-compiled Bitcoin Core
 
-upgrade to BGL Core 0.9.4, which includes a workaround, **before** updating
+upgrade to Bitcoin Core 0.9.4, which includes a workaround, **before** updating
 OpenSSL.
 
 The incompatibility is due to the OpenSSL update changing the
@@ -92,4 +92,4 @@ Thanks to who contributed to this release, at least:
 - Sergio Demian Lerner
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-notes/release-notes-0.9.4.md
+++ b/doc/release-notes/release-notes-0.9.4.md
@@ -7,7 +7,7 @@ translations. Upgrading to this release is recommended.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 ===============

--- a/doc/release-notes/release-notes-0.9.5.md
+++ b/doc/release-notes/release-notes-0.9.5.md
@@ -8,7 +8,7 @@ recommended.
 
 Please report bugs using the issue tracker at github:
 
-  https://github.com/BGL/BGL/issues
+  https://github.com/BitgesellOfficial/bitgesell/issues
 
 How to Upgrade
 ===============

--- a/doc/release-notes/release-notes-0.9.5.md
+++ b/doc/release-notes/release-notes-0.9.5.md
@@ -1,6 +1,6 @@
-BGL Core version 0.9.5 is now available from:
+Bitcoin Core version 0.9.5 is now available from:
 
-  https://BGL.org/bin/0.9.5/
+  https://bitcoin.org/bin/0.9.5/
 
 This is a new minor version release, with the goal of backporting BIP66. There
 are also a few bug fixes and updated translations. Upgrading to this release is
@@ -15,8 +15,8 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over /Applications/BGL-Qt (on Mac) or
-BGLd/BGL-qt (on Linux).
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
 
 Notable changes
 ================
@@ -24,10 +24,10 @@ Notable changes
 Mining and relay policy enhancements
 ------------------------------------
 
-BGL Core's block templates are now for version 3 blocks only, and any mining
+Bitcoin Core's block templates are now for version 3 blocks only, and any mining
 software relying on its `getblocktemplate` must be updated in parallel to use
 libblkmaker either version 0.4.2 or any version from 0.5.1 onward.
-If you are solo mining, this will affect you the moment you upgrade BGL
+If you are solo mining, this will affect you the moment you upgrade Bitcoin
 Core, which must be done prior to BIP66 achieving its 951/1001 status.
 If you are mining with the stratum mining protocol: this does not affect you.
 If you are mining with the getblocktemplate protocol to a pool: this will affect
@@ -57,4 +57,4 @@ Thanks to who contributed to this release, at least:
 - Pieter Wuille
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/BGL/).
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -72,7 +72,7 @@ Check out the source code in the following directory hierarchy.
     git clone https://github.com/BGL-core/gitian.sigs.git
     git clone https://github.com/BGL-core/BGL-detached-sigs.git
     git clone https://github.com/devrandom/gitian-builder.git
-    git clone https://github.com/BGL/BGL.git
+    git clone https://github.com/BitgesellOfficial/bitgesell.git
 
 ### Write the release notes
 
@@ -365,7 +365,7 @@ BGL.org (see below for BGL.org update instructions).
 
       - Archive the release notes for the new version to `doc/release-notes/` (branch `master` and branch of the release)
 
-      - Create a [new GitHub release](https://github.com/BGL/BGL/releases/new) with a link to the archived release notes
+      - Create a [new GitHub release](https://github.com/BitgesellOfficial/bitgesell/releases/new) with a link to the archived release notes
 
 - Announce the release:
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -45,7 +45,7 @@ Release Process
 #### After branch-off (on the major release branch)
 
 - Update the versions.
-- Create a pinned meta-issue for testing the release candidate (see [this issue](https://github.com/BGL/BGL/issues/17079) for an example) and provide a link to it in the release announcements where useful.
+- Create a pinned meta-issue for testing the release candidate (see [this issue](https://github.com/bitcoin/bitcoin/issues/17079) for an example) and provide a link to it in the release announcements where useful.
 
 #### Before final release
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -317,12 +317,12 @@ BGL.org (see below for BGL.org update instructions).
 
 - Update other repositories and websites for new version
 
-  - BGLcore.org blog post
+  - bitgesell.ca blog post
 
-  - BGLcore.org maintained versions update:
-    [table](https://github.com/BGL-core/BGLcore.org/commits/master/_includes/posts/maintenance-table.md)
+  - bitgesell.ca maintained versions update:
+    [table](https://github.com/BGL-core/bitgesell.ca/commits/master/_includes/posts/maintenance-table.md)
 
-  - BGLcore.org RPC documentation update
+  - bitgesell.ca RPC documentation update
 
       - Install [golang](https://golang.org/doc/install)
 
@@ -371,7 +371,7 @@ BGL.org (see below for BGL.org update instructions).
 
   - BGL-dev and BGL-core-dev mailing list
 
-  - BGL Core announcements list https://BGLcore.org/en/list/announcements/join/
+  - BGL Core announcements list https://bitgesell.ca/en/list/announcements/join/
 
   - Update title of #BGL on Freenode IRC
 

--- a/share/setup-BGL-win.nsi
+++ b/share/setup-BGL-win.nsi
@@ -6,7 +6,7 @@ SetCompressor /SOLID lzma
 # General Symbol Definitions
 !define REGKEY "SOFTWARE\$(^Name)"
 !define COMPANY "BGL Core project"
-!define URL https://BGLcore.org/
+!define URL https://bitgesell.ca/
 
 # MUI Symbol Definitions
 !define MUI_ICON "..\share\pixmaps\BGL.ico"

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -15,7 +15,7 @@
 // many times micro-benchmarks of the database showed completely different
 // characteristics than e.g. reindex timings. But that's not a requirement of
 // every benchmark."
-// (https://github.com/BGL/BGL/issues/7883#issuecomment-224807484)
+// (https://github.com/bitcoin/bitcoin/issues/7883#issuecomment-224807484)
 static void CCoinsCaching(benchmark::Bench& bench)
 {
     const ECCVerifyHandle verify_handle;

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -26,7 +26,7 @@ static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<st
 // the hardest, as you need a wider selection of scenarios, just testing the
 // same one over and over isn't too useful. Generating random isn't useful
 // either for measurements."
-// (https://github.com/BGL/BGL/issues/7883#issuecomment-224807484)
+// (https://github.com/bitcoin/bitcoin/issues/7883#issuecomment-224807484)
 static void CoinSelection(benchmark::Bench& bench)
 {
     NodeContext node;

--- a/src/compat.h
+++ b/src/compat.h
@@ -96,7 +96,7 @@ typedef char* sockopt_arg_type;
 
 // Note these both should work with the current usage of poll, but best to be safe
 // WIN32 poll is broken https://daniel.haxx.se/blog/2012/10/10/wsapoll-is-broken/
-// __APPLE__ poll is broke https://github.com/BGL/BGL/pull/14336#issuecomment-437384408
+// __APPLE__ poll is broke https://github.com/bitcoin/bitcoin/pull/14336#issuecomment-437384408
 #if defined(__linux__)
 #define USE_POLL
 #endif

--- a/src/interfaces/README.md
+++ b/src/interfaces/README.md
@@ -2,13 +2,13 @@
 
 The following interfaces are defined here:
 
-* [`Chain`](chain.h) — used by wallet to access blockchain and mempool state. Added in [#14437](https://github.com/BGL/BGL/pull/14437), [#14711](https://github.com/BGL/BGL/pull/14711), [#15288](https://github.com/BGL/BGL/pull/15288), and [#10973](https://github.com/BGL/BGL/pull/10973).
+* [`Chain`](chain.h) — used by wallet to access blockchain and mempool state. Added in [#14437](https://github.com/bitcoin/bitcoin/pull/14437), [#14711](https://github.com/bitcoin/bitcoin/pull/14711), [#15288](https://github.com/bitcoin/bitcoin/pull/15288), and [#10973](https://github.com/bitcoin/bitcoin/pull/10973).
 
-* [`ChainClient`](chain.h) — used by node to start & stop `Chain` clients. Added in [#14437](https://github.com/BGL/BGL/pull/14437).
+* [`ChainClient`](chain.h) — used by node to start & stop `Chain` clients. Added in [#14437](https://github.com/bitcoin/bitcoin/pull/14437).
 
-* [`Node`](node.h) — used by GUI to start & stop BGL node. Added in [#10244](https://github.com/BGL/BGL/pull/10244).
+* [`Node`](node.h) — used by GUI to start & stop BGL node. Added in [#10244](https://github.com/bitcoin/bitcoin/pull/10244).
 
-* [`Wallet`](wallet.h) — used by GUI to access wallets. Added in [#10244](https://github.com/BGL/BGL/pull/10244).
+* [`Wallet`](wallet.h) — used by GUI to access wallets. Added in [#10244](https://github.com/bitcoin/bitcoin/pull/10244).
 
 * [`Handler`](handler.h) — returned by `handleEvent` methods on interfaces above and used to manage lifetimes of event handlers.
 

--- a/src/qt/BGLamountfield.h
+++ b/src/qt/BGLamountfield.h
@@ -22,7 +22,7 @@ class BGLAmountField: public QWidget
     Q_OBJECT
 
     // ugly hack: for some unknown reason CAmount (instead of qint64) does not work here as expected
-    // discussion: https://github.com/BGL/BGL/pull/5117
+    // discussion: https://github.com/bitcoin/bitcoin/pull/5117
     Q_PROPERTY(qint64 value READ value WRITE setValue NOTIFY valueChanged USER true)
 
 public:

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -94,10 +94,10 @@ bool static TestSplitHost(const std::string& test, const std::string& host, uint
 
 BOOST_AUTO_TEST_CASE(netbase_splithost)
 {
-    BOOST_CHECK(TestSplitHost("www.BGLcore.org", "www.BGLcore.org", -1));
-    BOOST_CHECK(TestSplitHost("[www.BGLcore.org]", "www.BGLcore.org", -1));
-    BOOST_CHECK(TestSplitHost("www.BGLcore.org:80", "www.BGLcore.org", 80));
-    BOOST_CHECK(TestSplitHost("[www.BGLcore.org]:80", "www.BGLcore.org", 80));
+    BOOST_CHECK(TestSplitHost("www.bitgesell.ca", "www.bitgesell.ca", -1));
+    BOOST_CHECK(TestSplitHost("[www.bitgesell.ca]", "www.bitgesell.ca", -1));
+    BOOST_CHECK(TestSplitHost("www.bitgesell.ca:80", "www.bitgesell.ca", 80));
+    BOOST_CHECK(TestSplitHost("[www.bitgesell.ca]:80", "www.bitgesell.ca", 80));
     BOOST_CHECK(TestSplitHost("127.0.0.1", "127.0.0.1", -1));
     BOOST_CHECK(TestSplitHost("127.0.0.1:8333", "127.0.0.1", 8333));
     BOOST_CHECK(TestSplitHost("[127.0.0.1]", "127.0.0.1", 0));

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -34,7 +34,7 @@ static const int64_t nMinDbCache = 4;
 static const int64_t nMaxBlockDBCache = 2;
 //! Max memory allocated to block tree DB specific cache, if -txindex (MiB)
 // Unlike for the UTXO database, for the txindex scenario the leveldb cache make
-// a meaningful difference: https://github.com/BGL/BGL/pull/8273#issuecomment-229601991
+// a meaningful difference: https://github.com/bitcoin/bitcoin/pull/8273#issuecomment-229601991
 static const int64_t nMaxTxIndexCache = 1024;
 //! Max memory allocated to all block filter index caches combined in MiB.
 static const int64_t max_filter_index_cache = 1024;

--- a/src/util/settings.h
+++ b/src/util/settings.h
@@ -23,7 +23,7 @@ namespace util {
 //!       get_int64(), get_bool(), isNum(), isBool(), isFalse(), isTrue() and
 //!       isNull() methods can be substituted if there's a need to move away
 //!       from UniValue. (An implementation with boost::variant was posted at
-//!       https://github.com/BGL/BGL/pull/15934/files#r337691812)
+//!       https://github.com/bitcoin/bitcoin/pull/15934/files#r337691812)
 using SettingsValue = UniValue;
 
 //! Stored settings. This struct combines settings from the command line, a

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -223,7 +223,7 @@ static util::SettingsValue InterpretOption(std::string& section, std::string& ke
  *
  * TODO: Add more meaningful error checks here in the future
  * See "here's how the flags are meant to behave" in
- * https://github.com/BGL/BGL/pull/16097#issuecomment-514627823
+ * https://github.com/bitcoin/bitcoin/pull/16097#issuecomment-514627823
  */
 static bool CheckValid(const std::string& key, const util::SettingsValue& val, unsigned int flags, std::string& error)
 {

--- a/test/README.md
+++ b/test/README.md
@@ -263,11 +263,11 @@ Use the `-v` option for verbose output.
 
 | Lint test | Dependency | Version [used by CI](../ci/lint/04_install.sh) | Installation
 |-----------|:----------:|:-------------------------------------------:|--------------
-| [`lint-python.sh`](lint/lint-python.sh) | [flake8](https://gitlab.com/pycqa/flake8) | [3.8.3](https://github.com/BGL/BGL/pull/19348) | `pip3 install flake8==3.8.3`
-| [`lint-python.sh`](lint/lint-python.sh) | [mypy](https://github.com/python/mypy) | [0.781](https://github.com/BGL/BGL/pull/19348) | `pip3 install mypy==0.781`
-| [`lint-shell.sh`](lint/lint-shell.sh) | [ShellCheck](https://github.com/koalaman/shellcheck) | [0.7.1](https://github.com/BGL/BGL/pull/19348) | [details...](https://github.com/koalaman/shellcheck#installing)
+| [`lint-python.sh`](lint/lint-python.sh) | [flake8](https://gitlab.com/pycqa/flake8) | [3.8.3](https://github.com/bitcoin/bitcoin/pull/19348) | `pip3 install flake8==3.8.3`
+| [`lint-python.sh`](lint/lint-python.sh) | [mypy](https://github.com/python/mypy) | [0.781](https://github.com/bitcoin/bitcoin/pull/19348) | `pip3 install mypy==0.781`
+| [`lint-shell.sh`](lint/lint-shell.sh) | [ShellCheck](https://github.com/koalaman/shellcheck) | [0.7.1](https://github.com/bitcoin/bitcoin/pull/19348) | [details...](https://github.com/koalaman/shellcheck#installing)
 | [`lint-shell.sh`](lint/lint-shell.sh) | [yq](https://github.com/kislyuk/yq) | default | `pip3 install yq`
-| [`lint-spelling.sh`](lint/lint-spelling.sh) | [codespell](https://github.com/codespell-project/codespell) | [2.0.0](https://github.com/BGL/BGL/pull/19348) | `pip3 install codespell==2.0.0`
+| [`lint-spelling.sh`](lint/lint-spelling.sh) | [codespell](https://github.com/codespell-project/codespell) | [2.0.0](https://github.com/bitcoin/bitcoin/pull/19348) | `pip3 install codespell==2.0.0`
 
 Please be aware that on Linux distributions all dependencies are usually available as packages, but could be outdated.
 

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -5,7 +5,7 @@
 """Test logic for skipping signature validation on old blocks.
 
 Test logic for skipping signature validation on blocks which we've assumed
-valid (https://github.com/BGL/BGL/pull/9484)
+valid (https://github.com/bitcoin/bitcoin/pull/9484)
 
 We build a chain that includes and invalid signature for one of the
 transactions:

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -122,7 +122,7 @@ class NotificationsTest(BGLTestFramework):
 
             # Generate bump transaction, sync mempools, and check for bump1
             # notification. In the future, per
-            # https://github.com/BGL/BGL/pull/9371, it might be better
+            # https://github.com/bitcoin/bitcoin/pull/9371, it might be better
             # to have notifications for both tx1 and bump1.
             bump1 = self.nodes[0].bumpfee(tx1)["txid"]
             assert_equal(bump1 in self.nodes[0].getrawmempool(), True)


### PR DESCRIPTION
### Description
Many URLs in documentation and comments have been broken by a mass search-replace of the word `bitcoin` with the word `BGL`.  This PR does the following:
- Manually fixes the majority of those links, especially with regard to links that should point to this repository.
- Reinstates valid links to old bitcoin repo pull requests, issues, comments etc.
- Updates links to BGLcore.org to point to bitgesell.ca (this is currently taken care of by a redirect, but it makes sense to use the primary address directly).  However, note that many of these are still broken as they originally point to functionality on bitcoincore.org that has not been replicated on bitgesell.ca.
- Reinstates the original content of pre-BGL-fork release notes for older bitcoin versions; the search-replace turned many of these into nonsense, as well as breaking all their links.  However, the address for the issue tracker in each release note has been updated to point to the up-to-date issue tracker at this repo.

### BTC/BGL PR reward address
ETH/USDT: 0x50b92AB67A3D3DE8c3506D9287893D9a52655486
