### PR TITLE
Fuzzer improvements (janus branch)

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -606,7 +606,7 @@ public:
         Clear();
     }
 
-    ~CAddrMan()
+    virtual ~CAddrMan()
     {
         nKey.SetNull();
     }

--- a/src/rpc/external_signer.cpp
+++ b/src/rpc/external_signer.cpp
@@ -34,7 +34,7 @@ static RPCHelpMan enumeratesigners()
             HelpExampleCli("enumeratesigners", "")
             + HelpExampleRpc("enumeratesigners", "")
         },
-        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+        [&]([[maybe_unused]] const RPCHelpMan& self, [[maybe_unused]] const JSONRPCRequest& request) -> UniValue
         {
             const std::string command = gArgs.GetArg("-signer", "");
             if (command == "") throw JSONRPCError(RPC_MISC_ERROR, "Error: restart bitcoind with -signer=<cmd>");

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -132,7 +132,7 @@ class TestLockedPageAllocator: public LockedPageAllocator
 {
 public:
     TestLockedPageAllocator(int count_in, int lockedcount_in): count(count_in), lockedcount(lockedcount_in) {}
-    void* AllocateLocked(size_t len, bool *lockingSuccess) override
+    void* AllocateLocked([[maybe_unused]] size_t len, bool *lockingSuccess) override
     {
         *lockingSuccess = false;
         if (count > 0) {
@@ -147,7 +147,7 @@ public:
         }
         return nullptr;
     }
-    void FreeLocked(void* addr, size_t len) override
+    void FreeLocked([[maybe_unused]] void* addr, [[maybe_unused]] size_t len) override
     {
     }
     size_t GetLimit() override

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -217,7 +217,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         CheckFilterLookups(filter_index, block_index, chainA_last_header);
     }
 
-    // Reorg back to chain A.
+     // Reorg back to chain A.
      for (size_t i = 2; i < 4; i++) {
          const auto& block = chainA[i];
          BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
@@ -283,7 +283,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
     BOOST_CHECK(!InitBlockFilterIndex(BlockFilterType::BASIC, 1 << 20, true, false));
 
     int iter_count = 0;
-    ForEachBlockFilterIndex([&iter_count](BlockFilterIndex& _index) { iter_count++; });
+    ForEachBlockFilterIndex([&iter_count]([[maybe_unused]] BlockFilterIndex& _index) { iter_count++; });
     BOOST_CHECK_EQUAL(iter_count, 1);
 
     BOOST_CHECK(DestroyBlockFilterIndex(BlockFilterType::BASIC));

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -28,7 +28,7 @@ struct FakeCheck {
     {
         return true;
     }
-    void swap(FakeCheck& x){};
+    void swap([[maybe_unused]] FakeCheck& x){};
 };
 
 struct FakeCheckCheckCompletion {
@@ -38,7 +38,7 @@ struct FakeCheckCheckCompletion {
         n_calls.fetch_add(1, std::memory_order_relaxed);
         return true;
     }
-    void swap(FakeCheckCheckCompletion& x){};
+    void swap([[maybe_unused]] FakeCheckCheckCompletion& x){};
 };
 
 struct FailingCheck {
@@ -79,7 +79,7 @@ struct MemoryCheck {
         return true;
     }
     MemoryCheck(){};
-    MemoryCheck(const MemoryCheck& x)
+    MemoryCheck([[maybe_unused]] const MemoryCheck& x)
     {
         // We have to do this to make sure that destructor calls are paired
         //

--- a/src/test/fuzz/FuzzedDataProvider.h
+++ b/src/test/fuzz/FuzzedDataProvider.h
@@ -256,7 +256,7 @@ T FuzzedDataProvider::ConsumeFloatingPointInRange(T min, T max) {
     // The diff |max - min| would overflow the given floating point type. Use
     // the half of the diff as the range and consume a bool to decide whether
     // the result is in the first of the second part of the diff.
-    range = (max / 2.0) - (min / 2.0);
+    range = (max / static_cast<T>(2.0)) - (min / static_cast<T>(2.0));
     if (ConsumeBool()) {
       result += range;
     }

--- a/src/test/fuzz/checkqueue.cpp
+++ b/src/test/fuzz/checkqueue.cpp
@@ -26,7 +26,7 @@ struct DumbCheck {
         return result;
     }
 
-    void swap(DumbCheck& x)
+    void swap([[maybe_unused]] DumbCheck& x)
     {
     }
 };

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -65,7 +65,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 }
 
 // This function is used by libFuzzer
-extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
+extern "C" int LLVMFuzzerInitialize([[maybe_unused]] int* argc, [[maybe_unused]] char*** argv)
 {
     initialize();
     return 0;

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -72,7 +72,7 @@ extern "C" int LLVMFuzzerInitialize([[maybe_unused]] int* argc, [[maybe_unused]]
 }
 
 #if defined(PROVIDE_FUZZ_MAIN_FUNCTION)
-int main(int argc, char** argv)
+int main()
 {
     initialize();
     static const auto& test_one_input = *Assert(g_test_one_input);

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -29,22 +29,22 @@ public:
     {
     }
 
-    bool CheckECDSASignature(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override
+    bool CheckECDSASignature([[maybe_unused]] const std::vector<unsigned char>& scriptSig, [[maybe_unused]] const std::vector<unsigned char>& vchPubKey, [[maybe_unused]] const CScript& scriptCode, [[maybe_unused]] SigVersion sigversion) const override
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }
 
-    bool CheckSchnorrSignature(Span<const unsigned char> sig, Span<const unsigned char> pubkey, SigVersion sigversion, const ScriptExecutionData& execdata, ScriptError* serror = nullptr) const override
+    bool CheckSchnorrSignature([[maybe_unused]] Span<const unsigned char> sig, [[maybe_unused]] Span<const unsigned char> pubkey, [[maybe_unused]] SigVersion sigversion, [[maybe_unused]] const ScriptExecutionData& execdata, [[maybe_unused]] ScriptError* serror = nullptr) const override
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }
 
-    bool CheckLockTime(const CScriptNum& nLockTime) const override
+    bool CheckLockTime([[maybe_unused]] const CScriptNum& nLockTime) const override
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }
 
-    bool CheckSequence(const CScriptNum& nSequence) const override
+    bool CheckSequence([[maybe_unused]] const CScriptNum& nSequence) const override
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }

--- a/src/test/fuzz/tx_pool.cpp
+++ b/src/test/fuzz/tx_pool.cpp
@@ -55,7 +55,7 @@ struct TransactionsDelta final : public CValidationInterface {
         Assert(m_added.insert(tx).second);
     }
 
-    void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t /* mempool_sequence */) override
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, [[maybe_unused]] MemPoolRemovalReason reason, uint64_t /* mempool_sequence */) override
     {
         Assert(m_removed.insert(tx).second);
     }

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -22,10 +22,17 @@ FuzzedSock::~FuzzedSock()
     Reset();
 }
 
-FuzzedSock& FuzzedSock::operator=([[maybe_unused]] Sock&& other) [[noreturn]]
+#ifndef NDEBUG
+  // the assert(false ... ) will fail if debug mode, making this function never return
+  [[noreturn]]
+#endif // NDEBUG
+FuzzedSock& FuzzedSock::operator=([[maybe_unused]] Sock&& other)
 {
     assert(false && "Move of Sock into FuzzedSock not allowed.");
-    return *this;
+    #ifdef NDEBUG
+      // only reachable in release build
+      return *this;
+    #endif // NDEBUG
 }
 
 void FuzzedSock::Reset()

--- a/src/test/fuzz/util.cpp
+++ b/src/test/fuzz/util.cpp
@@ -22,7 +22,7 @@ FuzzedSock::~FuzzedSock()
     Reset();
 }
 
-FuzzedSock& FuzzedSock::operator=(Sock&& other)
+FuzzedSock& FuzzedSock::operator=([[maybe_unused]] Sock&& other) [[noreturn]]
 {
     assert(false && "Move of Sock into FuzzedSock not allowed.");
     return *this;
@@ -33,7 +33,7 @@ void FuzzedSock::Reset()
     m_socket = INVALID_SOCKET;
 }
 
-ssize_t FuzzedSock::Send(const void* data, size_t len, int flags) const
+ssize_t FuzzedSock::Send([[maybe_unused]] const void* data, size_t len, [[maybe_unused]] int flags) const
 {
     constexpr std::array send_errnos{
         EACCES,
@@ -152,7 +152,7 @@ int FuzzedSock::Connect(const sockaddr*, socklen_t) const
     return 0;
 }
 
-int FuzzedSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const
+int FuzzedSock::GetSockOpt([[maybe_unused]] int level, [[maybe_unused]] int opt_name, void* opt_val, socklen_t* opt_len) const
 {
     constexpr std::array getsockopt_errnos{
         ENOMEM,
@@ -171,7 +171,7 @@ int FuzzedSock::GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* op
     return 0;
 }
 
-bool FuzzedSock::Wait(std::chrono::milliseconds timeout, Event requested, Event* occurred) const
+bool FuzzedSock::Wait([[maybe_unused]] std::chrono::milliseconds timeout, Event requested, Event* occurred) const
 {
     constexpr std::array wait_errnos{
         EBADF,

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -579,6 +579,9 @@ public:
 
     ~FuzzedSock() override;
 
+    #ifndef NDEBUG
+      [[noreturn]]
+    #endif // NDEBUG
     FuzzedSock& operator=(Sock&& other) override;
 
     void Reset() override;

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -425,7 +425,7 @@ public:
         return random_bytes.size();
     }
 
-    static ssize_t write(void* cookie, const char* buf, size_t size)
+    static ssize_t write(void* cookie, [[maybe_unused]] const char* buf, size_t size)
     {
         FuzzedFileProvider* fuzzed_file = (FuzzedFileProvider*)cookie;
         SetFuzzedErrNo(fuzzed_file->m_fuzzed_data_provider);

--- a/src/test/fuzz/versionbits.cpp
+++ b/src/test/fuzz/versionbits.cpp
@@ -41,12 +41,12 @@ public:
         assert(0 <= m_min_activation_height);
     }
 
-    bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const override { return Condition(pindex->nVersion); }
-    int64_t BeginTime(const Consensus::Params& params) const override { return m_begin; }
-    int64_t EndTime(const Consensus::Params& params) const override { return m_end; }
-    int Period(const Consensus::Params& params) const override { return m_period; }
-    int Threshold(const Consensus::Params& params) const override { return m_threshold; }
-    int MinActivationHeight(const Consensus::Params& params) const override { return m_min_activation_height; }
+    bool Condition(const CBlockIndex* pindex, [[maybe_unused]] const Consensus::Params& params) const override { return Condition(pindex->nVersion); }
+    int64_t BeginTime([[maybe_unused]] const Consensus::Params& params) const override { return m_begin; }
+    int64_t EndTime([[maybe_unused]] const Consensus::Params& params) const override { return m_end; }
+    int Period([[maybe_unused]] const Consensus::Params& params) const override { return m_period; }
+    int Threshold([[maybe_unused]] const Consensus::Params& params) const override { return m_threshold; }
+    int MinActivationHeight([[maybe_unused]] const Consensus::Params& params) const override { return m_min_activation_height; }
 
     ThresholdState GetStateFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateFor(pindexPrev, dummy_params, m_cache); }
     int GetStateSinceHeightFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateSinceHeightFor(pindexPrev, dummy_params, m_cache); }

--- a/src/test/util/net.h
+++ b/src/test/util/net.h
@@ -78,7 +78,7 @@ public:
 
     ~StaticContentsSock() override { Reset(); }
 
-    StaticContentsSock& operator=(Sock&& other) override
+    StaticContentsSock& operator=([[maybe_unused]] Sock&& other) override
     {
         assert(false && "Move of Sock into MockSock not allowed.");
         return *this;
@@ -103,13 +103,13 @@ public:
 
     int Connect(const sockaddr*, socklen_t) const override { return 0; }
 
-    int GetSockOpt(int level, int opt_name, void* opt_val, socklen_t* opt_len) const override
+    int GetSockOpt([[maybe_unused]] int level, [[maybe_unused]] int opt_name, void* opt_val, socklen_t* opt_len) const override
     {
         std::memset(opt_val, 0x0, *opt_len);
         return 0;
     }
 
-    bool Wait(std::chrono::milliseconds timeout,
+    bool Wait([[maybe_unused]] std::chrono::milliseconds timeout,
               Event requested,
               Event* occurred = nullptr) const override
     {

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2275,10 +2275,10 @@ BOOST_AUTO_TEST_CASE(message_hash)
 
     const uint256 signature_hash = Hash(unsigned_tx);
     const uint256 message_hash1 = Hash(prefixed_message);
-    const uint256 message_hash2 = MessageHash(unsigned_tx);
+    //const uint256 message_hash2 = MessageHash(unsigned_tx);
 
-   // Commented out because MessageHash uses keccak algorithm, while Hash uses CSHA256
-   // BOOST_CHECK_EQUAL(message_hash1, message_hash2);
+    // Commented out because MessageHash uses keccak algorithm, while Hash uses CSHA256
+    // BOOST_CHECK_EQUAL(message_hash1, message_hash2);
     BOOST_CHECK_NE(message_hash1, signature_hash);
 }
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -36,7 +36,7 @@ struct TestSubscriber final : public CValidationInterface {
 
     explicit TestSubscriber(uint256 tip) : m_expected_tip(tip) {}
 
-    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
+    void UpdatedBlockTip(const CBlockIndex* pindexNew, [[maybe_unused]] const CBlockIndex* pindexFork, [[maybe_unused]] bool fInitialDownload) override
     {
         BOOST_CHECK_EQUAL(m_expected_tip, pindexNew->GetBlockHash());
     }

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
     BOOST_CHECK_CLOSE(c2.m_coinsdb_cache_size_bytes, max_cache * 0.95, 1);
 }
 
-auto NoMalleation = [](CAutoFile& file, SnapshotMetadata& meta){};
+auto NoMalleation = []([[maybe_unused]] CAutoFile& file, [[maybe_unused]] SnapshotMetadata& meta){};
 
 template<typename F = decltype(NoMalleation)>
 static bool
@@ -250,17 +250,17 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_activate_snapshot, TestChain100Setup)
             auto_infile >> coin;
     }));
     BOOST_REQUIRE(!CreateAndActivateUTXOSnapshot(
-        m_node, m_path_root, [](CAutoFile& auto_infile, SnapshotMetadata& metadata) {
+        m_node, m_path_root, []([[maybe_unused]] CAutoFile& auto_infile, SnapshotMetadata& metadata) {
             // Coins count is larger than coins in file
             metadata.m_coins_count += 1;
     }));
     BOOST_REQUIRE(!CreateAndActivateUTXOSnapshot(
-        m_node, m_path_root, [](CAutoFile& auto_infile, SnapshotMetadata& metadata) {
+        m_node, m_path_root, []([[maybe_unused]] CAutoFile& auto_infile, SnapshotMetadata& metadata) {
             // Coins count is smaller than coins in file
             metadata.m_coins_count -= 1;
     }));
     BOOST_REQUIRE(!CreateAndActivateUTXOSnapshot(
-        m_node, m_path_root, [](CAutoFile& auto_infile, SnapshotMetadata& metadata) {
+        m_node, m_path_root, []([[maybe_unused]] CAutoFile& auto_infile, SnapshotMetadata& metadata) {
             // Wrong hash
             metadata.m_base_blockhash = uint256::ONE;
     }));

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -133,8 +133,8 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     if (is_64_bit) {
         float usage_percentage = (float)view.DynamicMemoryUsage() / (MAX_COINS_CACHE_BYTES + (1 << 10));
         BOOST_TEST_MESSAGE("CoinsTip usage percentage: " << usage_percentage);
-        BOOST_CHECK(usage_percentage >= 0.9);
-        BOOST_CHECK(usage_percentage < 1);
+        BOOST_CHECK(usage_percentage >= 0.9f);
+        BOOST_CHECK(usage_percentage < 1.0f);
         BOOST_CHECK_EQUAL(
             chainstate.GetCoinsCacheSizeState(&tx_pool, MAX_COINS_CACHE_BYTES, 1 << 10),
             CoinsCacheSizeState::LARGE);

--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -57,7 +57,7 @@ public:
     {
         if (m_on_destroy) m_on_destroy();
     }
-    void BlockChecked(const CBlock& block, const BlockValidationState& state) override
+    void BlockChecked([[maybe_unused]] const CBlock& block, [[maybe_unused]] const BlockValidationState& state) override
     {
         if (m_on_call) m_on_call();
     }

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -34,11 +34,11 @@ private:
     mutable ThresholdConditionCache cache;
 
 public:
-    int64_t BeginTime(const Consensus::Params& params) const override { return TestTime(10000); }
-    int64_t EndTime(const Consensus::Params& params) const override { return TestTime(20000); }
-    int Period(const Consensus::Params& params) const override { return 1000; }
-    int Threshold(const Consensus::Params& params) const override { return 900; }
-    bool Condition(const CBlockIndex* pindex, const Consensus::Params& params) const override { return (pindex->nVersion & 0x100); }
+    int64_t BeginTime([[maybe_unused]] const Consensus::Params& params) const override { return TestTime(10000); }
+    int64_t EndTime([[maybe_unused]] const Consensus::Params& params) const override { return TestTime(20000); }
+    int Period([[maybe_unused]] const Consensus::Params& params) const override { return 1000; }
+    int Threshold([[maybe_unused]] const Consensus::Params& params) const override { return 900; }
+    bool Condition(const CBlockIndex* pindex, [[maybe_unused]] const Consensus::Params& params) const override { return (pindex->nVersion & 0x100); }
 
     ThresholdState GetStateFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateFor(pindexPrev, paramsDummy, cache); }
     int GetStateSinceHeightFor(const CBlockIndex* pindexPrev) const { return AbstractThresholdConditionChecker::GetStateSinceHeightFor(pindexPrev, paramsDummy, cache); }
@@ -47,19 +47,19 @@ public:
 class TestDelayedActivationConditionChecker : public TestConditionChecker
 {
 public:
-    int MinActivationHeight(const Consensus::Params& params) const override { return 15000; }
+    int MinActivationHeight([[maybe_unused]] const Consensus::Params& params) const override { return 15000; }
 };
 
 class TestAlwaysActiveConditionChecker : public TestConditionChecker
 {
 public:
-    int64_t BeginTime(const Consensus::Params& params) const override { return Consensus::BIP9Deployment::ALWAYS_ACTIVE; }
+    int64_t BeginTime([[maybe_unused]] const Consensus::Params& params) const override { return Consensus::BIP9Deployment::ALWAYS_ACTIVE; }
 };
 
 class TestNeverActiveConditionChecker : public TestConditionChecker
 {
 public:
-    int64_t BeginTime(const Consensus::Params& params) const override { return Consensus::BIP9Deployment::NEVER_ACTIVE; }
+    int64_t BeginTime([[maybe_unused]] const Consensus::Params& params) const override { return Consensus::BIP9Deployment::NEVER_ACTIVE; }
 };
 
 #define CHECKERS 6


### PR DESCRIPTION
### Description
Warnings I added in #54 and #56 highlight certain improvements to make to the newly added fuzzer on the janus/release-0.1.7 branch; the following changes silence these warnings and provide the following improvements:

- Added c++17 attributes to mark unused function parameters, improving clarity and making it easier to spot if parameters are unintentionally unused.
- Unused argv and argc parameters removed from fuzzer's main().
- Remove unused variable declaration in util_tests.
- Avoid implicit conversions that alter a value (float promotion to double), make those explicit conversions instead, or compare floats to float literals rather than floats to double literals.
- A copy assignment operator never returns in debug mode, as it contains an `assert(false ...)` - in this case, the function is now marked [[noreturn]] to clarify expectations.  The return call is now only present in the absence of the NDEBUG macro, where the assert would have no effect.
- CAddrMan had a non-virtual destructor, despite being a polymorphic base class - the d'tor is now marked virtual as it should be.

### BTC/BGL PR reward address
ETH/USDT: 0x50b92AB67A3D3DE8c3506D9287893D9a52655486