### PR TITLE
test/functional/p2p_segwit: Fix the test case by adjusting to BGL network parameters.

### DIFF
--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -881,7 +881,7 @@ class SegWitTest(BGLTestFramework):
         # This should give us plenty of room to tweak the spending tx's
         # virtual size.
         NUM_DROPS = 200  # 201 max ops per script!
-        NUM_OUTPUTS = 50
+        NUM_OUTPUTS = 5
 
         witness_script = CScript([OP_2DROP] * NUM_DROPS + [OP_TRUE])
         script_pubkey = script_to_p2wsh_script(witness_script)
@@ -922,8 +922,10 @@ class SegWitTest(BGLTestFramework):
         block.solve()
         assert_equal(block.get_weight(), MAX_BLOCK_WEIGHT + 1)
         # Make sure that our test case would exceed the old max-network-message
-        # limit
-        assert len(block.serialize()) > 2 * 1024 * 1024
+        # limit. For BGL this value is adjusted to MAX_BLOCK_WEIGHT / 2 since the
+        # Segwit is enabled by default and the serialized block size is less than
+        # len(block.get_weight())
+        assert len(block.serialize()) > MAX_BLOCK_WEIGHT / 2
 
         test_witness_block(self.nodes[0], self.test_node, block, accepted=False)
 
@@ -1999,7 +2001,7 @@ class SegWitTest(BGLTestFramework):
 
         self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(address_type='bech32'), 5)
         self.generate(self.nodes[0], 1)
-        unspent = next(u for u in self.nodes[0].listunspent() if u['spendable'] and u['address'].startswith('bcrt'))
+        unspent = next(u for u in self.nodes[0].listunspent() if u['spendable'] and u['address'].startswith('rbgl'))
 
         raw = self.nodes[0].createrawtransaction([{"txid": unspent['txid'], "vout": unspent['vout']}], {self.nodes[0].getnewaddress(): 1})
         tx = tx_from_hex(raw)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -35,7 +35,7 @@ from test_framework.siphash import siphash256
 from test_framework.util import assert_equal
 
 MAX_LOCATOR_SZ = 101
-MAX_BLOCK_WEIGHT = 4000000
+MAX_BLOCK_WEIGHT = 400000
 MAX_BLOOM_FILTER_SIZE = 36000
 MAX_BLOOM_HASH_FUNCS = 50
 


### PR DESCRIPTION
Fixes https://github.com/BitgesellOfficial/bitgesell/issues/66

Takes into account that BGL block size is 400000 (10x less than Bitcoin) and constructs blocks aligned with that limit, also verifies correct BGL Regtest network prefix.

```
1/1 - p2p_segwit.py passed, Duration: 78 s                                                                                                                  

TEST          | STATUS    | DURATION

p2p_segwit.py | ✓ Passed  | 78 s

ALL           | ✓ Passed  | 78 s (accumulated) 
Runtime: 78 s
```