### PR TITLE
test/functional/wallet_listdescriptors: Set correct descriptor for BGL

### DIFF
--- a/test/functional/wallet_listdescriptors.py
+++ b/test/functional/wallet_listdescriptors.py
@@ -116,7 +116,7 @@ class ListDescriptorsTest(BGLTestFramework):
             'wallet_name': 'w4',
             'descriptors': [
                 {'active': False,
-                 'desc': 'combo(0227d85ba011276cf25b51df6a188b75e604b38770a462b2d0e9fb2fc839ef5d3f)#np574htj',
+                 'desc': 'combo(022a8ed5358832ab1218113501d19ee1cb02dc42f5713506fbd320c075fc866b88)#55wlgpc0',
                  'timestamp': 1296688602},
             ]
         }


### PR DESCRIPTION
### Description
This pull request fixes wallet_listdescriptors functional test case. The BGL regtest functional tests network is initialized with deterministic private keys defined in PRIV_KEYS mapping in the test framework.

The test case failed on descriptor and descriptor checksum calculated for Bitcoin network. Fix the test case by adjusting the correct value for BGL network.

### Notes
```
 test/functional/test_runner.py test/functional/wallet_listdescriptors.py 
Temporary test directory at /tmp/test_runner_20221108_200636
WARNING! The following scripts are not being run: ['rpc_estimatefee.py', 'wallet_bumpfee_totalfee_deprecation.py']. Check the test lists in test_runner.py.
Running Unit Tests for Test Framework Modules
..........
----------------------------------------------------------------------
Ran 10 tests in 0.843s

OK
Remaining jobs: [wallet_listdescriptors.py --descriptors]
1/1 - wallet_listdescriptors.py --descriptors passed, Duration: 2 s

TEST                                    | STATUS    | DURATION

wallet_listdescriptors.py --descriptors | ✓ Passed  | 2 s

ALL                                     | ✓ Passed  | 2 s (accumulated) 
Runtime: 2 s
```
