### PR TITLE
wallet: Fix already-loading error message grammar

### DIFF
--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -34,7 +34,7 @@ def test_load_unload(node, name):
             node.loadwallet(name)
             node.unloadwallet(name)
         except JSONRPCException as e:
-            if e.error['code'] == -4 and 'Wallet already being loading' in e.error['message']:
+            if e.error['code'] == -4 and 'Wallet already loading' in e.error['message']:
                 got_loading_error = True
                 return
 


### PR DESCRIPTION
### Description
This pull request fixes wallet_multiwallet functional test case. The test case failed on mismatch of the expected error message grammar vs implementation in BGL core.

### Notes
```
test/functional/test_runner.py test/functional/wallet_multiwallet.py 
Temporary test directory at /tmp/test_runner_20221108_200954
WARNING! The following scripts are not being run: ['wallet_bumpfee_totalfee_deprecation.py', 'rpc_estimatefee.py']. Check the test lists in test_runner.py.
Running Unit Tests for Test Framework Modules
..........
----------------------------------------------------------------------
Ran 10 tests in 0.843s

OK
Remaining jobs: [wallet_multiwallet.py --legacy-wallet, wallet_multiwallet.py --descriptors, wallet_multiwallet.py --usecli]
1/3 - wallet_multiwallet.py --usecli passed, Duration: 15 s
Remaining jobs: [wallet_multiwallet.py --legacy-wallet, wallet_multiwallet.py --descriptors]
2/3 - wallet_multiwallet.py --descriptors passed, Duration: 38 s
Remaining jobs: [wallet_multiwallet.py --legacy-wallet]
3/3 - wallet_multiwallet.py --legacy-wallet passed, Duration: 41 s

TEST                                  | STATUS    | DURATION

wallet_multiwallet.py --descriptors   | ✓ Passed  | 38 s
wallet_multiwallet.py --legacy-wallet | ✓ Passed  | 41 s
wallet_multiwallet.py --usecli        | ✓ Passed  | 15 s

ALL                                   | ✓ Passed  | 94 s (accumulated) 
Runtime: 41 s
```
