### PR TITLE
test/functional/wallet_txn_doublespend: Set correct expected coinbase

### DIFF
--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -99,7 +99,7 @@ class TxnMallTest(BGLTestFramework):
         # matured block, minus 40, minus 20, and minus transaction fees:
         expected = starting_balance + fund_foo_tx["fee"] + fund_bar_tx["fee"]
         if self.options.mine_block:
-            expected += 50
+            expected += 200
         expected += tx1["amount"] + tx1["fee"]
         expected += tx2["amount"] + tx2["fee"]
         assert_equal(self.nodes[0].getbalance(), expected)


### PR DESCRIPTION
### Description
This pull request fixes wallet_txn_doublespend functional test case. The default coinbase transaction nValue for BGL regtest network is 200 BGL. Correct the value to make the test case pass when --mineblock argument is provided.

### Notes
```
$ test/functional/test_runner.py test/functional/wallet_txn_doublespend.py 
Temporary test directory at /tmp/test_runner_20221108_201822
WARNING! The following scripts are not being run: ['wallet_bumpfee_totalfee_deprecation.py', 'rpc_estimatefee.py']. Check the test lists in test_runner.py.
Running Unit Tests for Test Framework Modules
..........
----------------------------------------------------------------------
Ran 10 tests in 0.838s

OK
Remaining jobs: [wallet_txn_doublespend.py --mineblock, wallet_txn_doublespend.py --legacy-wallet, wallet_txn_doublespend.py --descriptors]
1/3 - wallet_txn_doublespend.py --descriptors passed, Duration: 2 s
Remaining jobs: [wallet_txn_doublespend.py --mineblock, wallet_txn_doublespend.py --legacy-wallet]
2/3 - wallet_txn_doublespend.py --legacy-wallet passed, Duration: 2 s
Remaining jobs: [wallet_txn_doublespend.py --mineblock]
3/3 - wallet_txn_doublespend.py --mineblock passed, Duration: 4 s

TEST                                      | STATUS    | DURATION

wallet_txn_doublespend.py --descriptors   | ✓ Passed  | 2 s
wallet_txn_doublespend.py --legacy-wallet | ✓ Passed  | 2 s
wallet_txn_doublespend.py --mineblock     | ✓ Passed  | 4 s

ALL                                       | ✓ Passed  | 8 s (accumulated) 
Runtime: 4 s
```
