### PR TITLE
Bugfix/fix wallet transactiontime rescan test

### DIFF
--- a/test/functional/wallet_transactiontime_rescan.py
+++ b/test/functional/wallet_transactiontime_rescan.py
@@ -11,6 +11,7 @@ from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BGLTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_raises_rpc_error,
     set_node_times,
 )
 
@@ -156,6 +157,12 @@ class TransactionTimeRescanTest(BGLTestFramework):
             elif tx['address'] == wo3:
                 assert_equal(tx['blocktime'], cur_time + ten_days + ten_days + ten_days)
                 assert_equal(tx['time'], cur_time + ten_days + ten_days + ten_days)
+
+
+        self.log.info('Test handling of invalid parameters for rescanblockchain')
+        assert_raises_rpc_error(-8, "Invalid start_height", restorewo_wallet.rescanblockchain, -1, 10)
+        assert_raises_rpc_error(-8, "Invalid stop_height", restorewo_wallet.rescanblockchain, 1, -1)
+        assert_raises_rpc_error(-8, "stop_height must be greater than start_height", restorewo_wallet.rescanblockchain, 20, 10)
 
 
 if __name__ == '__main__':

--- a/test/functional/wallet_transactiontime_rescan.py
+++ b/test/functional/wallet_transactiontime_rescan.py
@@ -10,7 +10,8 @@ import time
 from test_framework.blocktools import COINBASE_MATURITY
 from test_framework.test_framework import BGLTestFramework
 from test_framework.util import (
-    assert_equal
+    assert_equal,
+    set_node_times,
 )
 
 
@@ -35,9 +36,7 @@ class TransactionTimeRescanTest(BGLTestFramework):
 
         # synchronize nodes and time
         self.sync_all()
-        minernode.setmocktime(cur_time)
-        usernode.setmocktime(cur_time)
-        restorenode.setmocktime(cur_time)
+        set_node_times(self.nodes, cur_time)
 
         # prepare miner wallet
         minernode.createwallet(wallet_name='default')
@@ -68,9 +67,7 @@ class TransactionTimeRescanTest(BGLTestFramework):
 
         # synchronize nodes and time
         self.sync_all()
-        minernode.setmocktime(cur_time + ten_days)
-        usernode.setmocktime(cur_time + ten_days)
-        restorenode.setmocktime(cur_time + ten_days)
+        set_node_times(self.nodes, cur_time + ten_days)
         # send 10 btc to user's first watch-only address
         self.log.info('Send 10 btc to user')
         miner_wallet.sendtoaddress(wo1, 10)
@@ -81,9 +78,7 @@ class TransactionTimeRescanTest(BGLTestFramework):
 
         # synchronize nodes and time
         self.sync_all()
-        minernode.setmocktime(cur_time + ten_days + ten_days)
-        usernode.setmocktime(cur_time + ten_days + ten_days)
-        restorenode.setmocktime(cur_time + ten_days + ten_days)
+        set_node_times(self.nodes, cur_time + ten_days + ten_days)
         # send 5 btc to our second watch-only address
         self.log.info('Send 5 btc to user')
         miner_wallet.sendtoaddress(wo2, 5)
@@ -94,9 +89,7 @@ class TransactionTimeRescanTest(BGLTestFramework):
 
         # synchronize nodes and time
         self.sync_all()
-        minernode.setmocktime(cur_time + ten_days + ten_days + ten_days)
-        usernode.setmocktime(cur_time + ten_days + ten_days + ten_days)
-        restorenode.setmocktime(cur_time + ten_days + ten_days + ten_days)
+        set_node_times(self.nodes, cur_time + ten_days + ten_days + ten_days)
         # send 1 btc to our third watch-only address
         self.log.info('Send 1 btc to user')
         miner_wallet.sendtoaddress(wo3, 1)

--- a/test/functional/wallet_transactiontime_rescan.py
+++ b/test/functional/wallet_transactiontime_rescan.py
@@ -119,6 +119,14 @@ class TransactionTimeRescanTest(BGLTestFramework):
         restorenode.createwallet(wallet_name='wo', disable_private_keys=True)
         restorewo_wallet = restorenode.get_wallet_rpc('wo')
 
+        # for descriptor wallets, the test framework maps the importaddress RPC to the
+        # importdescriptors RPC (with argument 'timestamp'='now'), which always rescans
+        # blocks of the past 2 hours, based on the current MTP timestamp; in order to avoid
+        # importing the last address (wo3), we advance the time further and generate 10 blocks
+        if self.options.descriptors:
+            set_node_times(self.nodes, cur_time + ten_days + ten_days + ten_days + ten_days)
+            self.generatetoaddress(minernode, 10, m1)
+
         restorewo_wallet.importaddress(wo1, rescan=False)
         restorewo_wallet.importaddress(wo2, rescan=False)
         restorewo_wallet.importaddress(wo3, rescan=False)


### PR DESCRIPTION
### Description
This pull request fixes wallet_transactiontime_rescan functional test case and brings last changes from bitcoin core.

### Notes
```
$ test/functional/test_runner.py test/functional/wallet_transactiontime_rescan.py 
Temporary test directory at /tmp/test_runner_20221108_212155
WARNING! The following scripts are not being run: ['rpc_estimatefee.py', 'wallet_bumpfee_totalfee_deprecation.py']. Check the test lists in test_runner.py.
Running Unit Tests for Test Framework Modules
..........
----------------------------------------------------------------------
Ran 10 tests in 0.863s

OK
Remaining jobs: [wallet_transactiontime_rescan.py]
1/1 - wallet_transactiontime_rescan.py passed, Duration: 7 s

TEST                             | STATUS    | DURATION

wallet_transactiontime_rescan.py | ✓ Passed  | 7 s

ALL                              | ✓ Passed  | 7 s (accumulated) 
```
