### PR TITLE
test/functional/wallet_resendwallettransactions: Fix failing test case

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -170,6 +170,7 @@ static void WalletTxToJSON(const CWallet& wallet, const CWalletTx& wtx, UniValue
     }
     uint256 hash = wtx.GetHash();
     entry.pushKV("txid", hash.GetHex());
+    entry.pushKV("wtxid", wtx.GetWitnessHash().GetHex());
     UniValue conflicts(UniValue::VARR);
     for (const uint256& conflict : wallet.GetTxConflicts(wtx))
         conflicts.push_back(conflict.GetHex());
@@ -1397,6 +1398,7 @@ static const std::vector<RPCResult> TransactionDescriptionString()
            {RPCResult::Type::NUM, "blockindex", /* optional */ true, "The index of the transaction in the block that includes it."},
            {RPCResult::Type::NUM_TIME, "blocktime", /* optional */ true, "The block time expressed in " + UNIX_EPOCH_TIME + "."},
            {RPCResult::Type::STR_HEX, "txid", "The transaction id."},
+           {RPCResult::Type::STR_HEX, "wtxid", "The hash of serialized transaction, including witness data."},
            {RPCResult::Type::ARR, "walletconflicts", "Conflicting transaction ids.",
            {
                {RPCResult::Type::STR_HEX, "txid", "The transaction id."},

--- a/src/wallet/transaction.h
+++ b/src/wallet/transaction.h
@@ -265,6 +265,7 @@ public:
     bool isConfirmed() const { return m_confirm.status == CWalletTx::CONFIRMED; }
     void setConfirmed() { m_confirm.status = CWalletTx::CONFIRMED; }
     const uint256& GetHash() const { return tx->GetHash(); }
+    const uint256& GetWitnessHash() const { return tx->GetWitnessHash(); }
     bool IsCoinBase() const { return tx->IsCoinBase(); }
 
     // Disable copying of CWalletTx objects to prevent bugs where instances get

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -670,7 +670,7 @@ class WalletTest(BGLTestFramework):
                                  "category": baz["category"],
                                  "vout":     baz["vout"]}
         expected_fields = frozenset({'amount', 'bip125-replaceable', 'confirmations', 'details', 'fee',
-                                     'hex', 'time', 'timereceived', 'trusted', 'txid', 'walletconflicts'})
+                                     'hex', 'time', 'timereceived', 'trusted', 'txid', 'wtxid', 'walletconflicts'})
         verbose_field = "decoded"
         expected_verbose_fields = expected_fields | {verbose_field}
 

--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -29,6 +29,9 @@ class ResendWalletTransactionsTest(BGLTestFramework):
 
         self.log.info("Create a new transaction and wait until it's broadcast")
         txid = node.sendtoaddress(node.getnewaddress(), 1)
+        # Bitgesell wallet broadcasts WTX transactions with the hash of serialized transaction,
+        # including witness data. msg_inv(inv=[CInv(type=WTX hash=xxx)]) where hash is wtx.
+        txid = node.gettransaction(txid)["wtxid"]
 
         # Wallet rebroadcast is first scheduled 1 sec after startup (see
         # nNextResend in ResendWalletTransactions()). Tell scheduler to call


### PR DESCRIPTION
### Description
This pull request fixes failing wallet_resendwallettransactions functional test case.

Bitgesell wallet broadcasts WTX transactions by default with hash of the serialized transaction, including witness data.

msg_inv(inv=[CInv(type=WTX hash=xxx)]) where hash is wtx.

This test case was the most tricky wallet_* functional test case for me to fix as I spent several hours on comparing Bitcoin wallet refactorings vs the current Bitgesell implementation, adding debug logs to messages and decoding RPC data, but finally was able to find the root cause.

### Notes
With this pull request and the previous `wallet_*` tests related pull requests:

https://github.com/BitgesellOfficial/bitgesell/pull/97
https://github.com/BitgesellOfficial/bitgesell/pull/98
https://github.com/BitgesellOfficial/bitgesell/pull/99
https://github.com/BitgesellOfficial/bitgesell/pull/100
https://github.com/BitgesellOfficial/bitgesell/pull/101
https://github.com/BitgesellOfficial/bitgesell/pull/102
https://github.com/BitgesellOfficial/bitgesell/pull/103

all Bitgesell wallet functional tests are passing, this can be verified by rebasing all the pull requests against current master branch, rebuilding and executing:
 
```
$ test/functional/test_runner.py test/functional/wallet_*

...

TEST                                               | STATUS    | DURATION

wallet_abandonconflict.py --descriptors            | ✓ Passed  | 11 s
wallet_abandonconflict.py --legacy-wallet          | ✓ Passed  | 9 s
wallet_address_types.py --descriptors              | ✓ Passed  | 15 s
wallet_address_types.py --legacy-wallet            | ✓ Passed  | 35 s
wallet_avoidreuse.py --descriptors                 | ✓ Passed  | 25 s
wallet_avoidreuse.py --legacy-wallet               | ✓ Passed  | 62 s
wallet_backup.py --descriptors                     | ✓ Passed  | 40 s
wallet_backup.py --legacy-wallet                   | ✓ Passed  | 59 s
wallet_balance.py --descriptors                    | ✓ Passed  | 7 s
wallet_balance.py --legacy-wallet                  | ✓ Passed  | 22 s
wallet_basic.py --descriptors                      | ✓ Passed  | 33 s
wallet_basic.py --legacy-wallet                    | ✓ Passed  | 40 s
wallet_bumpfee.py --descriptors                    | ✓ Passed  | 46 s
wallet_bumpfee.py --legacy-wallet                  | ✓ Passed  | 55 s
wallet_coinbase_category.py --descriptors          | ✓ Passed  | 1 s
wallet_coinbase_category.py --legacy-wallet        | ✓ Passed  | 2 s
wallet_create_tx.py --descriptors                  | ✓ Passed  | 5 s
wallet_create_tx.py --legacy-wallet                | ✓ Passed  | 22 s
wallet_createwallet.py --descriptors               | ✓ Passed  | 3 s
wallet_createwallet.py --legacy-wallet             | ✓ Passed  | 6 s
wallet_createwallet.py --usecli                    | ✓ Passed  | 7 s
wallet_descriptor.py --descriptors                 | ✓ Passed  | 4 s
wallet_disable.py --descriptors                    | ✓ Passed  | 1 s
wallet_disable.py --legacy-wallet                  | ✓ Passed  | 1 s
wallet_dump.py --legacy-wallet                     | ✓ Passed  | 11 s
wallet_encryption.py --descriptors                 | ✓ Passed  | 5 s
wallet_encryption.py --legacy-wallet               | ✓ Passed  | 6 s
wallet_fallbackfee.py --descriptors                | ✓ Passed  | 2 s
wallet_fallbackfee.py --legacy-wallet              | ✓ Passed  | 2 s
wallet_groups.py --descriptors                     | ✓ Passed  | 73 s
wallet_groups.py --legacy-wallet                   | ✓ Passed  | 88 s
wallet_hd.py --descriptors                         | ✓ Passed  | 6 s
wallet_hd.py --legacy-wallet                       | ✓ Passed  | 18 s
wallet_implicitsegwit.py --legacy-wallet           | ✓ Passed  | 7 s
wallet_import_rescan.py --legacy-wallet            | ✓ Passed  | 81 s
wallet_import_with_label.py --legacy-wallet        | ✓ Passed  | 2 s
wallet_importdescriptors.py --descriptors          | ✓ Passed  | 25 s
wallet_importmulti.py --legacy-wallet              | ✓ Passed  | 9 s
wallet_importprunedfunds.py --descriptors          | ✓ Passed  | 2 s
wallet_importprunedfunds.py --legacy-wallet        | ✓ Passed  | 3 s
wallet_keypool.py --descriptors                    | ✓ Passed  | 3 s
wallet_keypool.py --legacy-wallet                  | ✓ Passed  | 4 s
wallet_keypool_topup.py --descriptors              | ✓ Passed  | 8 s
wallet_keypool_topup.py --legacy-wallet            | ✓ Passed  | 26 s
wallet_labels.py --descriptors                     | ✓ Passed  | 2 s
wallet_labels.py --legacy-wallet                   | ✓ Passed  | 6 s
wallet_listdescriptors.py --descriptors            | ✓ Passed  | 2 s
wallet_listreceivedby.py --descriptors             | ✓ Passed  | 19 s
wallet_listreceivedby.py --legacy-wallet           | ✓ Passed  | 27 s
wallet_listsinceblock.py --descriptors             | ✓ Passed  | 12 s
wallet_listsinceblock.py --legacy-wallet           | ✓ Passed  | 15 s
wallet_listtransactions.py --descriptors           | ✓ Passed  | 12 s
wallet_listtransactions.py --legacy-wallet         | ✓ Passed  | 14 s
wallet_multisig_descriptor_psbt.py                 | ✓ Passed  | 2 s
wallet_multiwallet.py --descriptors                | ✓ Passed  | 41 s
wallet_multiwallet.py --legacy-wallet              | ✓ Passed  | 47 s
wallet_multiwallet.py --usecli                     | ✓ Passed  | 20 s
wallet_orphanedreward.py                           | ✓ Passed  | 5 s
wallet_reorgsrestore.py                            | ✓ Passed  | 6 s
wallet_resendwallettransactions.py --descriptors   | ✓ Passed  | 13 s
wallet_resendwallettransactions.py --legacy-wallet | ✓ Passed  | 10 s
wallet_send.py                                     | ✓ Passed  | 21 s
wallet_signer.py --descriptors                     | ✓ Passed  | 3 s
wallet_signmessagewithaddress.py                   | ✓ Passed  | 1 s
wallet_startup.py                                  | ✓ Passed  | 6 s
wallet_taproot.py                                  | ✓ Passed  | 29 s
wallet_transactiontime_rescan.py                   | ✓ Passed  | 8 s
wallet_txn_clone.py                                | ✓ Passed  | 3 s
wallet_txn_clone.py --mineblock                    | ✓ Passed  | 5 s
wallet_txn_clone.py --segwit                       | ✓ Passed  | 3 s
wallet_txn_doublespend.py --descriptors            | ✓ Passed  | 2 s
wallet_txn_doublespend.py --legacy-wallet          | ✓ Passed  | 3 s
wallet_txn_doublespend.py --mineblock              | ✓ Passed  | 5 s
wallet_watchonly.py --legacy-wallet                | ✓ Passed  | 2 s
wallet_watchonly.py --usecli --legacy-wallet       | ✓ Passed  | 3 s
wallet_upgradewallet.py --legacy-wallet            | ○ Skipped | 1 s

ALL                                                | ✓ Passed  | 1240 s (accumulated) 
Runtime: 323 s
```

I'd be grateful if you found time for the review fyi @madnadyka @wu-emma @janus 

### PR reward address
0x7e92476D69Ff1377a8b45176b1829C4A5566653a (ETH mainnet or Polygon)
