### PR TITLE
Fix feature_maxuploadtarget functional test case

### DIFF
--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -37,7 +37,7 @@ class MaxUploadTest(BGLTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [[
-            "-maxuploadtarget=800",
+            "-maxuploadtarget=800M",
             "-acceptnonstdtxn=1",
         ]]
         self.supports_cli = False

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -13,11 +13,19 @@ if uploadtarget has been reached.
 from collections import defaultdict
 import time
 
-from test_framework.messages import CInv, MSG_BLOCK, msg_getdata
+from test_framework.messages import (
+    CInv,
+    MSG_BLOCK,
+    msg_getdata,
+)
 from test_framework.p2p import P2PInterface
 from test_framework.test_framework import BGLTestFramework
-from test_framework.util import assert_equal, mine_large_block
+from test_framework.util import (
+    assert_equal,
+    mine_large_block,
+)
 from test_framework.wallet import MiniWallet
+
 
 class TestP2PConn(P2PInterface):
     def __init__(self):
@@ -41,12 +49,6 @@ class MaxUploadTest(BGLTestFramework):
             "-acceptnonstdtxn=1",
         ]]
         self.supports_cli = False
-
-        # Cache for utxos, as the listunspent may take a long time later in the test
-        self.utxo_cache = []
-
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
 
     def run_test(self):
         # Before we connect anything, we first set the time on the node

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -46,7 +46,7 @@ class MaxUploadTest(BGLTestFramework):
         self.num_nodes = 1
         self.extra_args = [[
             "-maxuploadtarget=800M",
-            "-acceptnonstdtxn=1",
+            "-datacarriersize=100000",
         ]]
         self.supports_cli = False
 

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -94,12 +94,11 @@ class MaxUploadTest(BGLTestFramework):
         getdata_request.inv.append(CInv(MSG_BLOCK, big_old_block))
 
         max_bytes_per_day = 800*1024*1024
-        daily_buffer = 144 * 4000000
+        daily_buffer = 144 * 400000
         max_bytes_available = max_bytes_per_day - daily_buffer
         success_count = max_bytes_available // old_block_size
-
         # 576MB will be reserved for relaying new blocks, so expect this to
-        # succeed for ~235 tries.
+        # succeed for ~8120 tries.
         for i in range(success_count):
             p2p_conns[0].send_and_ping(getdata_request)
             assert_equal(p2p_conns[0].block_receive_map[big_old_block], i+1)
@@ -107,7 +106,7 @@ class MaxUploadTest(BGLTestFramework):
         assert_equal(len(self.nodes[0].getpeerinfo()), 3)
         # At most a couple more tries should succeed (depending on how long
         # the test has been running so far).
-        for _ in range(3):
+        for _ in range(10):
             p2p_conns[0].send_message(getdata_request)
         p2p_conns[0].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -539,13 +539,8 @@ def mine_large_block(test_framework, mini_wallet, node):
     # generate a 66k transaction,
     # and 14 of them is close to the 1MB block limit
     txouts = gen_return_txouts()
-    from .messages import COIN
-    fee = 100 * int(node.getnetworkinfo()["relayfee"] * COIN)
-    for _ in range(14):
-        tx = mini_wallet.create_self_transfer(from_node=node, fee_rate=0, mempool_valid=False)['tx']
-        tx.vout[0].nValue -= fee
-        tx.vout.extend(txouts)
-        mini_wallet.sendrawtransaction(from_node=node, tx_hex=tx.serialize().hex())
+    fee = 100 * node.getnetworkinfo()["relayfee"]
+    create_lots_of_big_transactions(mini_wallet, node, fee, 14, txouts)
     test_framework.generate(node, 1)
 
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -539,8 +539,13 @@ def mine_large_block(test_framework, mini_wallet, node):
     # generate a 66k transaction,
     # and 14 of them is close to the 1MB block limit
     txouts = gen_return_txouts()
-    fee = 100 * node.getnetworkinfo()["relayfee"]
-    create_lots_of_big_transactions(mini_wallet, node, fee, 14, txouts)
+    from .messages import COIN
+    fee = 100 * int(node.getnetworkinfo()["relayfee"] * COIN)
+    for _ in range(14):
+        tx = mini_wallet.create_self_transfer(from_node=node, fee_rate=0, mempool_valid=False)['tx']
+        tx.vout[0].nValue -= fee
+        tx.vout.extend(txouts)
+        mini_wallet.sendrawtransaction(from_node=node, tx_hex=tx.serialize().hex())
     test_framework.generate(node, 1)
 
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -536,11 +536,10 @@ def create_lots_of_big_transactions(mini_wallet, node, fee, tx_batch_size, txout
 
 
 def mine_large_block(test_framework, mini_wallet, node):
-    # generate a 66k transaction,
-    # and 14 of them is close to the 1MB block limit
+    # generate a large block with 16 transactions close to the 400kB block limit
     txouts = gen_return_txouts()
     fee = 100 * node.getnetworkinfo()["relayfee"]
-    create_lots_of_big_transactions(mini_wallet, node, fee, 14, txouts)
+    create_lots_of_big_transactions(mini_wallet, node, fee, 16, txouts)
     test_framework.generate(node, 1)
 
 


### PR DESCRIPTION
### Description
This pull requests fixes feature_maxuploadtarget.py functional test case.

### Notes
The pull request contains sync with latest bitcoin core updates and I fixed myself values for BGL network. Since the block size is reduced 10x it is also expected that the number of iterations to reach the maxuploadtarget after requests are rejected increases. 

Note: this is a long running test case, therefore it took long to fix and verify. I triggered 5 times and average test execution takes ~ 7m37s. This is caused by the fact that around 8120 requests have to made until BGL node rejects new requests and disconnects.

