### PR TITLE
Fix mining_basic, p2p_invalid_block and p2p_unrequested_block functional test cases

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3082,7 +3082,8 @@ CBlockIndex* BlockManager::GetLastCheckpoint(const CCheckpointData& data)
 
 bool nBitsNotIn(uint32_t nBits) {
     // These numbers are computed from UintToArith256(params.powLimit).GetCompact() for each chain
-	if (nBits == 553705471 || nBits == 521142271 || nBits == 503543726) {
+    // regtest 0x207fffff == 545259519
+	if (nBits == 553705471 || nBits == 521142271 || nBits == 503543726 || nBits == 545259519) {
 		return false;
 	}
 	return true;
@@ -3105,6 +3106,8 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     // Check proof of work
     const Consensus::Params& consensusParams = params.GetConsensus();
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams)) {
+        LogPrintf("ERROR: %s nBits %d vs %d\n", __func__, block.nBits, GetNextWorkRequired(pindexPrev, &block, consensusParams));
+            
         if (nBitsNotIn(block.nBits)) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-diffbits", "incorrect proof of work");
         }

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -29,6 +29,8 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
 )
+from test_framework.wallet import MiniWallet
+
 
 VERSIONBITS_TOP_BITS = 0x20000000
 VERSIONBITS_DEPLOYMENT_TESTDUMMY_BIT = 28
@@ -51,14 +53,11 @@ class MiningTest(BGLTestFramework):
         self.setup_clean_chain = True
         self.supports_cli = False
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def mine_chain(self):
         self.log.info('Create some old blocks')
         for t in range(TIME_GENESIS_BLOCK, TIME_GENESIS_BLOCK + 200 * 600, 600):
             self.nodes[0].setmocktime(t)
-            self.generate(self.nodes[0], 1, sync_fun=self.no_op)
+            self.generate(self.wallet, 1, sync_fun=self.no_op)
         mining_info = self.nodes[0].getmininginfo()
         assert_equal(mining_info['blocks'], 200)
         assert_equal(mining_info['currentblocktx'], 0)
@@ -75,8 +74,9 @@ class MiningTest(BGLTestFramework):
         self.connect_nodes(0, 1)
 
     def run_test(self):
-        self.mine_chain()
         node = self.nodes[0]
+        self.wallet = MiniWallet(node)
+        self.mine_chain()
 
         def assert_submitblock(block, result_str_1, result_str_2=None):
             block.solve()
@@ -95,7 +95,7 @@ class MiningTest(BGLTestFramework):
         assert_equal(mining_info['pooledtx'], 0)
 
         self.log.info("getblocktemplate: Test default witness commitment")
-        txid = int(node.sendtoaddress(node.getnewaddress(), 1), 16)
+        txid = int(self.wallet.send_self_transfer(from_node=node)['wtxid'], 16)
         tmpl = node.getblocktemplate(NORMAL_GBT_REQUEST_PARAMS)
 
         # Check that default_witness_commitment is present.


### PR DESCRIPTION
### Description
The goal of this pull request is to solve failing mining_basic.py functional test case. It contains update from Bitcoin core to use miniwallet and my BGL specific bugfix for nBits PoW value in validation.cpp to match chainparams.cpp genesis block for regtest network. The nBits bugfix fixes also p2p_invalid_block and p2p_unrequested_blocks functional test cases.

### Notes

#### mining_basic

```
bitgesell$ test/functional/mining_basic.py 
2022-12-16T22:33:00.588000Z TestFramework (INFO): Initializing test directory /tmp/BGL_func_test_g0tnps97
2022-12-16T22:33:01.186000Z TestFramework (INFO): Create some old blocks
2022-12-16T22:33:10.309000Z TestFramework (INFO): test blockversion
2022-12-16T22:33:12.443000Z TestFramework (INFO): getmininginfo
2022-12-16T22:33:12.445000Z TestFramework (INFO): getblocktemplate: Test default witness commitment
2022-12-16T22:33:12.466000Z TestFramework (INFO): getblocktemplate: Test capability advertised
2022-12-16T22:33:12.466000Z TestFramework (INFO): getblocktemplate: segwit rule must be set
2022-12-16T22:33:12.468000Z TestFramework (INFO): getblocktemplate: Test valid block
2022-12-16T22:33:12.470000Z TestFramework (INFO): submitblock: Test block decode failure
2022-12-16T22:33:12.471000Z TestFramework (INFO): getblocktemplate: Test bad input hash for coinbase transaction
2022-12-16T22:33:12.473000Z TestFramework (INFO): submitblock: Test invalid coinbase transaction
2022-12-16T22:33:12.474000Z TestFramework (INFO): getblocktemplate: Test truncated final transaction
2022-12-16T22:33:12.475000Z TestFramework (INFO): getblocktemplate: Test duplicate transaction
2022-12-16T22:33:12.489000Z TestFramework (INFO): getblocktemplate: Test invalid transaction
2022-12-16T22:33:12.494000Z TestFramework (INFO): getblocktemplate: Test nonfinal transaction
2022-12-16T22:33:12.498000Z TestFramework (INFO): getblocktemplate: Test bad tx count
2022-12-16T22:33:12.500000Z TestFramework (INFO): getblocktemplate: Test bad bits
2022-12-16T22:33:12.501000Z TestFramework (INFO): getblocktemplate: Test bad merkle root
2022-12-16T22:33:12.505000Z TestFramework (INFO): getblocktemplate: Test bad timestamps
2022-12-16T22:33:12.513000Z TestFramework (INFO): getblocktemplate: Test not best block
2022-12-16T22:33:12.517000Z TestFramework (INFO): submitheader tests
2022-12-16T22:33:12.838000Z TestFramework (INFO): Stopping nodes
2022-12-16T22:33:12.994000Z TestFramework (INFO): Cleaning up /tmp/BGL_func_test_g0tnps97 on exit
2022-12-16T22:33:12.994000Z TestFramework (INFO): Tests successful
```

#### p2p_invalid_block

```
test/functional/p2p_invalid_block.py --loglevel=INFO
2022-12-19T12:54:31.189000Z TestFramework (INFO): Initializing test directory /tmp/BGL_func_test_rwbwi2vk
2022-12-19T12:54:33.998000Z TestFramework (INFO): Create a new block with an anyone-can-spend coinbase
2022-12-19T12:54:34.102000Z TestFramework (INFO): Mature the block.
2022-12-19T12:54:34.270000Z TestFramework (INFO): Test merkle root malleability.
2022-12-19T12:54:34.376000Z TestFramework (INFO): Test duplicate input block.
2022-12-19T12:54:34.482000Z TestFramework (INFO): Test very broken block.
2022-12-19T12:54:34.585000Z TestFramework (INFO): Test accepting original block after rejecting its mutated version.
2022-12-19T12:54:34.638000Z TestFramework (INFO): Test inflation by duplicating input
2022-12-19T12:54:34.741000Z TestFramework (INFO): Test accepting identical block after rejecting it due to a future timestamp.
2022-12-19T12:54:34.953000Z TestFramework (INFO): Stopping nodes
2022-12-19T12:54:35.155000Z TestFramework (INFO): Cleaning up /tmp/BGL_func_test_rwbwi2vk on exit
2022-12-19T12:54:35.156000Z TestFramework (INFO): Tests successful
```

#### p2p_unrequested_blocks

```
test/functional/p2p_unrequested_blocks.py --loglevel=INFO
2022-12-19T12:57:23.577000Z TestFramework (INFO): Initializing test directory /tmp/BGL_func_test_97ruriac
2022-12-19T12:57:24.416000Z TestFramework (INFO): First height 2 block accepted by node0; correctly rejected by node1
2022-12-19T12:57:24.524000Z TestFramework (INFO): Second height 2 block accepted, but not reorg'ed to
2022-12-19T12:57:24.579000Z TestFramework (INFO): Unrequested more-work block accepted
2022-12-19T12:57:25.370000Z TestFramework (INFO): Unrequested block that would complete more-work chain was ignored
2022-12-19T12:57:25.420000Z TestFramework (INFO): Inv at tip triggered getdata for unprocessed block
2022-12-19T12:57:25.626000Z TestFramework (INFO): Successfully reorged to longer chain
2022-12-19T12:57:27.131000Z TestFramework (INFO): Successfully synced nodes 1 and 0
2022-12-19T12:57:27.182000Z TestFramework (INFO): Stopping nodes
2022-12-19T12:57:27.387000Z TestFramework (INFO): Cleaning up /tmp/BGL_func_test_97ruriac on exit
2022-12-19T12:57:27.387000Z TestFramework (INFO): Tests successful

```