### PR TITLE
Fix feature_block functional test case

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3082,7 +3082,8 @@ CBlockIndex* BlockManager::GetLastCheckpoint(const CCheckpointData& data)
 
 bool nBitsNotIn(uint32_t nBits) {
     // These numbers are computed from UintToArith256(params.powLimit).GetCompact() for each chain
-	if (nBits == 553705471 || nBits == 521142271 || nBits == 503543726) {
+    // regtest 0x207fffff == 545259519
+	if (nBits == 553705471 || nBits == 521142271 || nBits == 503543726 || nBits == 545259519) {
 		return false;
 	}
 	return true;
@@ -3105,6 +3106,8 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
     // Check proof of work
     const Consensus::Params& consensusParams = params.GetConsensus();
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams)) {
+        LogPrintf("ERROR: %s nBits %d vs %d\n", __func__, block.nBits, GetNextWorkRequired(pindexPrev, &block, consensusParams));
+            
         if (nBitsNotIn(block.nBits)) {
             return state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, "bad-diffbits", "incorrect proof of work");
         }


### PR DESCRIPTION
### Description
Goal of this pull request is to fix feature_block functional test.

The test case needed two adjustments compared to Bitcoin implementation. BGL max block weight is ten times smaller than Bitcoin, and even that consensus defines the same maximum number of SIGOPS in the block, due to signatures and transactions overhead, measured empirically using bisection, the real maximum number of numTxes in sigops test for BGL is ~9 times less than the Bitcoin. The exact maximum measured for block 39 is 371 numTxes for the maximum value block size 399784 bytes.

Also adjusted overspend test to spend 201 BGL instead of 51 as defined for Bitcoin regtest.
Note: one commit with nBits fix for regtest PoW is shared with https://github.com/BitgesellOfficial/bitgesell/pull/112 otherwise the test case would not run correctly. During second merge the duplicated commit will be therefore skipped.

### Notes
```
$ test/functional/feature_block.py --loglevel=INFO
2022-12-18T23:37:33.352000Z TestFramework (INFO): Initializing test directory /tmp/BGL_func_test_ms8y2wet
2022-12-18T23:37:34.535000Z TestFramework (INFO): Reject block with invalid tx: OutputMissing
2022-12-18T23:37:34.749000Z TestFramework (INFO): Reject block with invalid tx: InputMissing
2022-12-18T23:37:34.958000Z TestFramework (INFO): Reject block with invalid tx: BadInputOutpointIndex
2022-12-18T23:37:35.173000Z TestFramework (INFO): Reject block with invalid tx: DuplicateInput
2022-12-18T23:37:35.387000Z TestFramework (INFO): Reject block with invalid tx: PrevoutNullInput
2022-12-18T23:37:35.601000Z TestFramework (INFO): Reject block with invalid tx: NonexistentInput
2022-12-18T23:37:35.816000Z TestFramework (INFO): Reject block with invalid tx: SpendTooMuch
2022-12-18T23:37:36.030000Z TestFramework (INFO): Reject block with invalid tx: CreateNegative
2022-12-18T23:37:36.244000Z TestFramework (INFO): Reject block with invalid tx: CreateTooLarge
2022-12-18T23:37:36.459000Z TestFramework (INFO): Reject block with invalid tx: CreateSumTooLarge
2022-12-18T23:37:36.672000Z TestFramework (INFO): Reject block with invalid tx: TooManySigops
2022-12-18T23:37:36.899000Z TestFramework (INFO): Don't reorg to a chain of the same length
2022-12-18T23:37:37.005000Z TestFramework (INFO): Reorg to a longer chain
2022-12-18T23:37:37.222000Z TestFramework (INFO): Reorg back to the original chain
2022-12-18T23:37:37.331000Z TestFramework (INFO): Reject a chain with a double spend, even if it is longer
2022-12-18T23:37:37.652000Z TestFramework (INFO): Reject a block where the miner creates too much coinbase reward
2022-12-18T23:37:37.865000Z TestFramework (INFO): Reject a chain where the miner creates too much coinbase reward, even if the chain is longer
2022-12-18T23:37:38.186000Z TestFramework (INFO): Reject a chain where the miner creates too much coinbase reward, even if the chain is longer (on a forked chain)
2022-12-18T23:37:38.407000Z TestFramework (INFO): Accept a block with lots of checksigs
2022-12-18T23:37:38.528000Z TestFramework (INFO): Reject a block with too many checksigs
2022-12-18T23:37:38.750000Z TestFramework (INFO): Reject a block with a spend from a re-org'ed out tx
2022-12-18T23:37:38.957000Z TestFramework (INFO): Reject a block with a spend from a re-org'ed out tx (on a forked chain)
2022-12-18T23:37:39.273000Z TestFramework (INFO): Reject a block spending an immature coinbase.
2022-12-18T23:37:39.487000Z TestFramework (INFO): Reject a block spending an immature coinbase (on a forked chain)
2022-12-18T23:37:39.806000Z TestFramework (INFO): Accept a block of weight MAX_BLOCK_WEIGHT
2022-12-18T23:37:39.917000Z TestFramework (INFO): Reject a block of weight MAX_BLOCK_WEIGHT + 4
2022-12-18T23:37:40.239000Z TestFramework (INFO): Reject a block with coinbase input script size out of range
2022-12-18T23:37:40.981000Z TestFramework (INFO): Accept a block with the max number of OP_CHECKMULTISIG sigops
2022-12-18T23:37:41.091000Z TestFramework (INFO): Reject a block with too many OP_CHECKMULTISIG sigops
2022-12-18T23:37:41.307000Z TestFramework (INFO): Accept a block with the max number of OP_CHECKMULTISIGVERIFY sigops
2022-12-18T23:37:41.419000Z TestFramework (INFO): Reject a block with too many OP_CHECKMULTISIGVERIFY sigops
2022-12-18T23:37:41.632000Z TestFramework (INFO): Accept a block with the max number of OP_CHECKSIGVERIFY sigops
2022-12-18T23:37:41.750000Z TestFramework (INFO): Reject a block with too many OP_CHECKSIGVERIFY sigops
2022-12-18T23:37:41.970000Z TestFramework (INFO): Reject a block spending transaction from a block which failed to connect
2022-12-18T23:37:42.394000Z TestFramework (INFO): Check P2SH SIGOPS are correctly counted
2022-12-18T23:37:42.608000Z TestFramework (INFO): Reject a block with too many P2SH sigops
2022-12-18T23:37:43.989000Z TestFramework (INFO): Accept a block with the max number of P2SH sigops
2022-12-18T23:37:44.246000Z TestFramework (INFO): Build block 44 manually
2022-12-18T23:37:44.354000Z TestFramework (INFO): Reject a block with a non-coinbase as the first tx
2022-12-18T23:37:44.561000Z TestFramework (INFO): Reject a block with no transactions
2022-12-18T23:37:44.767000Z TestFramework (INFO): Reject a block with invalid work
2022-12-18T23:37:44.974000Z TestFramework (INFO): Reject a block with a timestamp >2 hours in the future
2022-12-18T23:37:45.027000Z TestFramework (INFO): Reject a block with invalid merkle hash
2022-12-18T23:37:45.234000Z TestFramework (INFO): Reject a block with incorrect POW limit
2022-12-18T23:37:45.441000Z TestFramework (INFO): Reject a block with two coinbase transactions
2022-12-18T23:37:45.648000Z TestFramework (INFO): Reject a block with duplicate transactions
2022-12-18T23:37:45.968000Z TestFramework (INFO): Reject a block with timestamp before MedianTimePast
2022-12-18T23:37:46.292000Z TestFramework (INFO): Accept a previously rejected future block at a later time
2022-12-18T23:37:46.408000Z TestFramework (INFO): Reject a block with a duplicate transaction in the Merkle Tree (but with a valid Merkle Root)
2022-12-18T23:37:46.622000Z TestFramework (INFO): Reject a block with two duplicate transactions in the Merkle Tree (but with a valid Merkle Root)
2022-12-18T23:37:47.035000Z TestFramework (INFO): Reject a block with a transaction with prevout.n out of range
2022-12-18T23:37:47.247000Z TestFramework (INFO): Reject a block with a transaction with outputs > inputs
2022-12-18T23:37:47.562000Z TestFramework (INFO): Reject a block with a transaction with a duplicate hash of a previous transaction (BIP30)
2022-12-18T23:37:47.880000Z TestFramework (INFO): Reject a block with a transaction with a nonfinal locktime
2022-12-18T23:37:48.087000Z TestFramework (INFO): Reject a block with a coinbase transaction with a nonfinal locktime
2022-12-18T23:37:48.294000Z TestFramework (INFO): Accept a valid block even if a bloated version of the block has previously been sent
2022-12-18T23:37:48.661000Z TestFramework (INFO): Accept a block with a transaction spending an output created in the same block
2022-12-18T23:37:48.770000Z TestFramework (INFO): Reject a block with a transaction spending an output created later in the same block
2022-12-18T23:37:48.983000Z TestFramework (INFO): Reject a block with a transaction double spending a transaction created in the same block
2022-12-18T23:37:49.197000Z TestFramework (INFO): Reject a block trying to claim too much subsidy in the coinbase transaction
2022-12-18T23:37:49.410000Z TestFramework (INFO): Accept a block claiming the correct subsidy in the coinbase transaction
2022-12-18T23:37:49.519000Z TestFramework (INFO): Reject a block containing a transaction spending from a non-existent input
2022-12-18T23:37:49.732000Z TestFramework (INFO): Reject a block containing a duplicate transaction but with the same Merkle root (Merkle tree malleability
2022-12-18T23:37:50.049000Z TestFramework (INFO): Reject a block containing too many sigops after a large script element
2022-12-18T23:37:50.271000Z TestFramework (INFO): Check sigops are counted correctly after an invalid script element
2022-12-18T23:37:50.703000Z TestFramework (INFO): Test transaction resurrection during a re-org
2022-12-18T23:37:51.245000Z TestFramework (INFO): Accept a block with invalid opcodes in dead execution paths
2022-12-18T23:37:51.358000Z TestFramework (INFO): Test re-orging blocks with OP_RETURN in them
2022-12-18T23:37:52.115000Z TestFramework (INFO): Test a re-org of one week's worth of blocks (1088 blocks)
2022-12-18T23:38:04.071000Z TestFramework (INFO): Reject a block with an invalid block header version
2022-12-18T23:38:04.535000Z TestFramework (INFO): Stopping nodes
2022-12-18T23:38:04.888000Z TestFramework (INFO): Cleaning up /tmp/BGL_func_test_ms8y2wet on exit
2022-12-18T23:38:04.889000Z TestFramework (INFO): Tests successful
```

