### PR TITLE
Fix rpc_createmultisig functional test case

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -980,6 +980,10 @@ static RPCHelpMan addmultisigaddress()
                         {RPCResult::Type::STR, "address", "The value of the new multisig address"},
                         {RPCResult::Type::STR_HEX, "redeemScript", "The string value of the hex-encoded redemption script"},
                         {RPCResult::Type::STR, "descriptor", "The descriptor for this multisig"},
+                        {RPCResult::Type::ARR, "warnings", /* optional */ true, "Any warnings resulting from the creation of this multisig",
+                        {
+                            {RPCResult::Type::STR, "", ""},
+                        }},
                     }
                 },
                 RPCExamples{
@@ -1037,6 +1041,14 @@ static RPCHelpMan addmultisigaddress()
     result.pushKV("address", EncodeDestination(dest));
     result.pushKV("redeemScript", HexStr(inner));
     result.pushKV("descriptor", descriptor->ToString());
+
+    UniValue warnings(UniValue::VARR);
+    if (!request.params[3].isNull() && OutputTypeFromDestination(dest) != output_type) {
+        // Only warns if the user has explicitly chosen an address type we cannot generate
+        warnings.push_back("Unable to make chosen address type, please ensure no uncompressed public keys are present.");
+    }
+    if (warnings.size()) result.pushKV("warnings", warnings);
+
     return result;
 },
     };

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -82,13 +82,23 @@ class RpcCreateMultiSigTest(BGLTestFramework):
         for keys in itertools.permutations([pk0, pk1, pk2]):
             # Results should be the same as this legacy one
             legacy_addr = node0.createmultisig(2, keys, 'legacy')['address']
-            assert_equal(legacy_addr, wmulti0.addmultisigaddress(2, keys, '', 'legacy')['address'])
+
+            if self.is_bdb_compiled():
+                result = wmulti0.addmultisigaddress(2, keys, '', 'legacy')
+                assert_equal(legacy_addr, result['address'])
+                assert 'warnings' not in result
 
             # Generate addresses with the segwit types. These should all make legacy addresses
-            assert_equal(legacy_addr, wmulti0.createmultisig(2, keys, 'bech32')['address'])
-            assert_equal(legacy_addr, wmulti0.createmultisig(2, keys, 'p2sh-segwit')['address'])
-            assert_equal(legacy_addr, wmulti0.addmultisigaddress(2, keys, '', 'bech32')['address'])
-            assert_equal(legacy_addr, wmulti0.addmultisigaddress(2, keys, '', 'p2sh-segwit')['address'])
+            err_msg = ["Unable to make chosen address type, please ensure no uncompressed public keys are present."]
+
+            for addr_type in ['bech32', 'p2sh-segwit']:
+                result = self.nodes[0].createmultisig(nrequired=2, keys=keys, address_type=addr_type)
+                assert_equal(legacy_addr, result['address'])
+
+                if self.is_bdb_compiled():
+                    result = wmulti0.addmultisigaddress(nrequired=2, keys=keys, address_type=addr_type)
+                    assert_equal(legacy_addr, result['address'])
+                    assert_equal(result['warnings'], err_msg)
 
         self.log.info('Testing sortedmulti descriptors with BIP 67 test vectors')
         with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data/rpc_bip67.json'), encoding='utf-8') as f:


### PR DESCRIPTION
### Description
Goal of this pull request is to fix failing rpc_createmultisig.py functional test case.

Cherry-picked and manually merged changes from Bitcoin core.

### Notes
```$ test/functional/rpc_createmultisig.py
2022-12-19T12:39:57.353000Z TestFramework (INFO): Initializing test directory /tmp/BGL_func_test_4u5hqr2w
2022-12-19T12:39:58.429000Z TestFramework (INFO): Check that addmultisigaddress fails when the private keys are missing
2022-12-19T12:39:58.517000Z TestFramework (INFO): Generating blocks ...
2022-12-19T12:39:59.067000Z TestFramework (INFO): n/m=2/3 bech32 size=336 vsize=146 weight=582
2022-12-19T12:39:59.252000Z TestFramework (INFO): n/m=2/3 p2sh-segwit size=371 vsize=181 weight=722
2022-12-19T12:39:59.441000Z TestFramework (INFO): n/m=2/3 legacy size=334 vsize=334 weight=1336
2022-12-19T12:39:59.620000Z TestFramework (INFO): n/m=3/3 bech32 size=408 vsize=164 weight=654
2022-12-19T12:39:59.789000Z TestFramework (INFO): n/m=3/3 p2sh-segwit size=443 vsize=199 weight=794
2022-12-19T12:39:59.938000Z TestFramework (INFO): n/m=3/3 legacy size=408 vsize=408 weight=1632
2022-12-19T12:40:00.106000Z TestFramework (INFO): n/m=2/5 bech32 size=404 vsize=163 weight=650
2022-12-19T12:40:00.287000Z TestFramework (INFO): n/m=2/5 p2sh-segwit size=439 vsize=198 weight=790
2022-12-19T12:40:00.467000Z TestFramework (INFO): n/m=2/5 legacy size=404 vsize=404 weight=1616
2022-12-19T12:40:00.654000Z TestFramework (INFO): n/m=3/5 bech32 size=476 vsize=181 weight=722
2022-12-19T12:40:00.840000Z TestFramework (INFO): n/m=3/5 p2sh-segwit size=511 vsize=216 weight=862
2022-12-19T12:40:01.020000Z TestFramework (INFO): n/m=3/5 legacy size=476 vsize=476 weight=1904
2022-12-19T12:40:01.252000Z TestFramework (INFO): Mixed compressed and uncompressed multisigs are not allowed
2022-12-19T12:40:01.600000Z TestFramework (INFO): Testing sortedmulti descriptors with BIP 67 test vectors
2022-12-19T12:40:01.669000Z TestFramework (INFO): Stopping nodes
2022-12-19T12:40:01.932000Z TestFramework (INFO): Cleaning up /tmp/BGL_func_test_4u5hqr2w on exit
2022-12-19T12:40:01.932000Z TestFramework (INFO): Tests successful
```
