### PR TITLE
Fix feature_proxy functional test case

### DIFF
--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -146,13 +146,14 @@ class ProxyTest(BGLTestFramework):
 
         if test_onion:
             addr = "BGLostk4e4re.onion:8333"
+            addr = "35k2va6vyw4oo5ly2quvcszgdqr56kcnfgcqpnpcffut4jn3mhhwgbid.onion:18333"
             self.log.debug("Test: outgoing onion connection through node for address {}".format(addr))
             node.addnode(addr, "onetry")
             cmd = proxies[2].queue.get()
             assert isinstance(cmd, Socks5Command)
             assert_equal(cmd.atyp, AddressType.DOMAINNAME)
-            assert_equal(cmd.addr, b"BGLostk4e4re.onion")
-            assert_equal(cmd.port, 8333)
+            assert_equal(cmd.addr, b"35k2va6vyw4oo5ly2quvcszgdqr56kcnfgcqpnpcffut4jn3mhhwgbid.onion")
+            assert_equal(cmd.port, 18333)
             if not auth:
                 assert_equal(cmd.username, None)
                 assert_equal(cmd.password, None)


### PR DESCRIPTION
### Description
Goal of this pull request is to fix failing feature_proxy.py functional test case.

### Notes
The node matches first tor/onion v3 node in contrib/seeds/nodes_test.txt

```
test/functional/feature_proxy.py
2022-12-20T12:29:25.048000Z TestFramework (INFO): Initializing test directory /tmp/BGL_func_test_ya5fh9ux
2022-12-20T12:29:25.786000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'15.61.23.23'),1234,None,None)
2022-12-20T12:29:25.791000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'1233:3432:2434:2343:3234:2345:6546:4534'),5443,None,None)
2022-12-20T12:29:25.795000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'35k2va6vyw4oo5ly2quvcszgdqr56kcnfgcqpnpcffut4jn3mhhwgbid.onion'),18333,None,None)
2022-12-20T12:29:25.800000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'node.noumenon'),8333,None,None)
2022-12-20T12:29:25.805000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'15.61.23.23'),1234,None,None)
2022-12-20T12:29:25.810000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'1233:3432:2434:2343:3234:2345:6546:4534'),5443,None,None)
2022-12-20T12:29:25.815000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'35k2va6vyw4oo5ly2quvcszgdqr56kcnfgcqpnpcffut4jn3mhhwgbid.onion'),18333,None,None)
2022-12-20T12:29:25.819000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'node.noumenon'),8333,None,None)
2022-12-20T12:29:25.825000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'15.61.23.23'),1234,bytearray(b'0'),bytearray(b'0'))
2022-12-20T12:29:25.830000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'1233:3432:2434:2343:3234:2345:6546:4534'),5443,bytearray(b'1'),bytearray(b'1'))
2022-12-20T12:29:25.835000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'35k2va6vyw4oo5ly2quvcszgdqr56kcnfgcqpnpcffut4jn3mhhwgbid.onion'),18333,bytearray(b'2'),bytearray(b'2'))
2022-12-20T12:29:25.840000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'node.noumenon'),8333,bytearray(b'3'),bytearray(b'3'))
2022-12-20T12:29:25.845000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'15.61.23.23'),1234,None,None)
2022-12-20T12:29:25.850000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'1233:3432:2434:2343:3234:2345:6546:4534'),5443,None,None)
2022-12-20T12:29:25.854000Z TestFramework.socks5 (INFO): Proxy: Socks5Command(1,3,bytearray(b'node.noumenon'),8333,None,None)
2022-12-20T12:29:25.913000Z TestFramework (INFO): Stopping nodes
2022-12-20T12:29:26.128000Z TestFramework (INFO): Cleaning up /tmp/BGL_func_test_ya5fh9ux on exit
2022-12-20T12:29:26.128000Z TestFramework (INFO): Tests successful
```