### PR TITLE
Fix interface_zmq functional test case

### DIFF
--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -157,7 +157,8 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
 
 void CZMQAbstractPublishNotifier::Shutdown()
 {
-    assert(psocket);
+    // Early return if Initialize was not called
+    if (!psocket) return;
 
     int count = mapPublishNotifiers.count(address);
 

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -17,7 +17,7 @@ from test_framework.blocktools import (
 from test_framework.test_framework import BGLTestFramework
 from test_framework.messages import (
     CTransaction,
-    hash256,
+    keccak256,
     tx_from_hex,
 )
 from test_framework.util import (
@@ -34,8 +34,8 @@ try:
 except ImportError:
     pass
 
-def hash256_reversed(byte_str):
-    return hash256(byte_str)[::-1]
+def keccak256_reversed(byte_str):
+    return keccak256(byte_str)[::-1]
 
 class ZMQSubscriber:
     def __init__(self, socket, topic):
@@ -205,7 +205,7 @@ class ZMQTest (BGLTestFramework):
 
             # Should receive the generated raw block.
             block = rawblock.receive()
-            assert_equal(genhashes[x], hash256_reversed(block[:80]).hex())
+            assert_equal(genhashes[x], keccak256_reversed(block[:80]).hex())
 
             # Should receive the generated block hash.
             hash = hashblock.receive().hex()
@@ -225,7 +225,10 @@ class ZMQTest (BGLTestFramework):
 
             # Should receive the broadcasted raw transaction.
             hex = rawtx.receive()
-            assert_equal(payment_txid, hash256_reversed(hex).hex())
+            tx = CTransaction()
+            tx.deserialize(BytesIO(hex))
+            tx.calc_sha256()
+            assert_equal(payment_txid, tx.hash)
 
             # Mining the block with this tx should result in second notification
             # after coinbase tx notification

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -174,6 +174,7 @@ class ZMQTest (BGLTestFramework):
         return subscribers
 
     def test_basic(self):
+
         # Invalid zmq arguments don't take down the node, see #17185.
         self.restart_node(0, ["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
 


### PR DESCRIPTION
### Description
The goal of this pull request is to fix interface_zmq functional test case.

### Notes
The test case needed two separate fixes: first was the bugfix from Bitcoin core https://github.com/bitcoin/bitcoin/issues/17185 , then my bugfix for Bitgesell, to verify against keccak256 and single sha256.

```
$ test/functional/interface_zmq.py
2022-12-20T13:03:41.840000Z TestFramework (INFO): Initializing test directory /tmp/BGL_func_test_06l12t_m
2022-12-20T13:03:44.361000Z TestFramework (INFO): Generate 5 blocks (and 5 coinbase txes)
2022-12-20T13:03:44.391000Z TestFramework (INFO): Wait for tx from second node
2022-12-20T13:03:45.532000Z TestFramework (INFO): Test the getzmqnotifications RPC
2022-12-20T13:03:45.534000Z TestFramework (INFO): Testing 'sequence' publisher
2022-12-20T13:03:46.444000Z TestFramework (INFO): Wait for tx from second node
2022-12-20T13:03:47.564000Z TestFramework (INFO): Testing sequence notifications with mempool sequence values
2022-12-20T13:03:47.564000Z TestFramework (INFO): Testing RBF notification
2022-12-20T13:03:49.821000Z TestFramework (INFO): Testing reorg notifications
2022-12-20T13:03:51.847000Z TestFramework (INFO): Evict mempool transaction by block conflict
2022-12-20T13:03:52.924000Z TestFramework (INFO): Testing 'mempool sync' usage of sequence notifier
2022-12-20T13:03:59.154000Z TestFramework (INFO): Testing IPv6
2022-12-20T13:04:00.001000Z TestFramework (INFO): Stopping nodes
2022-12-20T13:04:00.257000Z TestFramework (INFO): Cleaning up /tmp/BGL_func_test_06l12t_m on exit
2022-12-20T13:04:00.257000Z TestFramework (INFO): Tests successful
```

Hi @madnadyka @wu-emma @janus I'd be grateful if you found time for the review 

I opened a batch of new pull requests fixing functional tests including this one

https://github.com/BitgesellOfficial/bitgesell/pull/107
https://github.com/BitgesellOfficial/bitgesell/pull/108
https://github.com/BitgesellOfficial/bitgesell/pull/109
https://github.com/BitgesellOfficial/bitgesell/pull/110
https://github.com/BitgesellOfficial/bitgesell/pull/111
https://github.com/BitgesellOfficial/bitgesell/pull/112
https://github.com/BitgesellOfficial/bitgesell/pull/113
https://github.com/BitgesellOfficial/bitgesell/pull/114
https://github.com/BitgesellOfficial/bitgesell/pull/115
https://github.com/BitgesellOfficial/bitgesell/pull/116

After those pull request will be reviewed and merged there are last remaining failing tests (all of them not trivial or requiring a lot of integration, I estimate 5-10 days to fix) that I would like to tackle in January next year:

| Test case name | Analysis |
| ------------- |------------|
| feature_signet.py                                  |  ** Bitgesell signet blocks needed ** |
| p2p_dos_header_tree.py                      | ** Forked Bitgesell testnet headers needed ** |
| rpc_psbt.py --descriptors                      | ** Lots of integration and changes in Bitcoin core ** |
| mempool_package_limits.py                | ** Should be synced with Bitcoin core, and after initial investigation package limits are not failing in all cases, needs more analysis ** |
| feature_nulldummy.py --descriptors                 | ** Fails with unexpected witness data when simulating Segwit fork ** |

After those are fixed in the new batch of pull requests we should have all functional tests passing and could integrate all new tests from Bitcoin core if functionality is already available in Bitgesell and you would be interested to integrate them.

### PR reward address
0x7e92476D69Ff1377a8b45176b1829C4A5566653a (ETH mainnet or Polygon)
