### PR TITLE
Fix BGLd debug build

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -261,9 +261,7 @@ static bool LockHeld(void* mutex)
 template <typename MutexType>
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs)
 {
-    for (const LockStackItem& i : g_lockstack)
-        if (i.first == cs)
-            return;
+    if (LockHeld(cs)) return;
     tfm::format(std::cerr, "Assertion failed: lock %s not held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld());
     abort();
 }
@@ -273,12 +271,9 @@ template void AssertLockHeldInternal(const char*, const char*, int, RecursiveMut
 template <typename MutexType>
 void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, MutexType* cs)
 {
-    for (const LockStackItem& i : g_lockstack) {
-        if (i.first == cs) {
-            tfm::format(std::cerr, "Assertion failed: lock %s held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld());
-            abort();
-        }
-    }
+    if (!LockHeld(cs)) return;
+    tfm::format(std::cerr, "Assertion failed: lock %s held in %s:%i; locks held:\n%s", pszName, pszFile, nLine, LocksHeld());
+    abort();
 }
 template void AssertLockNotHeldInternal(const char*, const char*, int, Mutex*);
 template void AssertLockNotHeldInternal(const char*, const char*, int, RecursiveMutex*);


### PR DESCRIPTION
### Description
Goal of this pull request is to fix Bitgesell debug build.
Debug build can be enabled with `--enable-debug` flag passed to `./configure`

I have been working for a few days on fixing `feature_segwit.py` and `feature_nulldummy.py` functional test cases but got stuck in the transaction internals. Decided to use a debugger but currently the build is broken due to errors in `sync.cpp`. This pull request fixes the debug build.

### Notes
I checked if both debug and non-debug builds and there are no regressions in functional tests.
I also verified that a breakpoint can be set and that debugging works.

```
(gdb) b CreateTransactionInternal
Breakpoint 1 at 0x55ba19421c25: file wallet/spend.cpp, line 646.
(gdb) c
Continuing.
[Switching to Thread 0x7f72be7fc700 (LWP 252162)]

Thread 19 "b-httpworker.0" hit Breakpoint 1, CreateTransactionInternal (wallet=..., vecSend=std::vector of length 2919391646469, capacity 2919385181360 = {...}, 
    tx=<error reading variable: Cannot access memory at address 0xf845894800000030>, nFeeRet=<error reading variable>, nChangePosInOut=<error reading variable>, error=..., 
    coin_control=..., fee_calc_out=..., sign=false) at wallet/spend.cpp:646
646     {
(gdb) 
```