### PR TITLE
test: functional: Fix mempool-* functional tests.

### DIFF
--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -7,7 +7,7 @@
 from copy import deepcopy
 from decimal import Decimal
 import math
-
+from test_framework.key import ECKey
 from test_framework.test_framework import BGLTestFramework
 from test_framework.messages import (
     MAX_BIP125_RBF_SEQUENCE,
@@ -49,7 +49,7 @@ class MempoolAcceptanceTest(BGLTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [[
-            '-txindex',
+            '-txindex', '-permitbaremultisig=0',
         ]] * self.num_nodes
         self.supports_cli = False
 
@@ -112,7 +112,7 @@ class MempoolAcceptanceTest(BGLTestFramework):
         tx.vout[0].nValue = int(output_amount * COIN)
         raw_tx_final = tx.serialize().hex()
         tx = tx_from_hex(raw_tx_final)
-        fee_expected = Decimal('50.0') - output_amount
+        fee_expected = Decimal('200.0') - output_amount
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': True, 'vsize': tx.get_vsize(), 'fees': {'base': fee_expected}}],
             rawtxs=[tx.serialize().hex()],

--- a/test/functional/mempool_datacarrier.py
+++ b/test/functional/mempool_datacarrier.py
@@ -11,7 +11,7 @@ from test_framework.script import (
     CScript,
     OP_RETURN,
 )
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import BGLTestFramework
 from test_framework.test_node import TestNode
 from test_framework.util import (
     assert_raises_rpc_error,
@@ -20,7 +20,7 @@ from test_framework.util import (
 from test_framework.wallet import MiniWallet
 
 
-class DataCarrierTest(BitcoinTestFramework):
+class DataCarrierTest(BGLTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
         self.extra_args = [

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -20,7 +20,6 @@ from test_framework.wallet import MiniWallet
 class MempoolSpendCoinbaseTest(BGLTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
 
     def run_test(self):
         wallet = MiniWallet(self.nodes[0])
@@ -38,23 +37,23 @@ class MempoolSpendCoinbaseTest(BGLTestFramework):
         utxo_mature = wallet.get_utxo(txid=coinbase_txid(chain_height - 100 + 1))
         utxo_immature = wallet.get_utxo(txid=coinbase_txid(chain_height - 100 + 2))
 
-        spend_101_id = wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_101)["txid"]
+        spend_mature_id = wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_mature)["txid"]
 
         # other coinbase should be too immature to spend
         immature_tx = wallet.create_self_transfer(utxo_to_spend=utxo_immature)
         assert_raises_rpc_error(-26,
                                 "bad-txns-premature-spend-of-coinbase",
-                                lambda: wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_102))
+                                lambda: wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_immature))
 
-        # mempool should have just spend_101:
-        assert_equal(self.nodes[0].getrawmempool(), [spend_101_id])
+        # mempool should have just the mature one:
+        assert_equal(self.nodes[0].getrawmempool(), [spend_mature_id])
 
         # mine a block, mature one should get confirmed
         self.generate(self.nodes[0], 1)
         assert_equal(set(self.nodes[0].getrawmempool()), set())
 
         # ... and now height 102 can be spent:
-        spend_102_id = wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_102)["txid"]
+        spend_102_id = wallet.send_self_transfer(from_node=self.nodes[0], utxo_to_spend=utxo_immature)["txid"]
         assert_equal(self.nodes[0].getrawmempool(), [spend_102_id])
 
 

--- a/test/functional/mempool_updatefromblock.py
+++ b/test/functional/mempool_updatefromblock.py
@@ -22,6 +22,9 @@ class MempoolUpdateFromBlockTest(BGLTestFramework):
         self.num_nodes = 1
         self.extra_args = [['-limitdescendantsize=1000', '-limitancestorsize=1000', '-limitancestorcount=100']]
 
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
     def get_new_address(self):
         key = ECKey()
         key.generate()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -69,6 +69,13 @@ FILTER_TYPE_BASIC = 0
 
 WITNESS_SCALE_FACTOR = 4
 
+DEFAULT_ANCESTOR_LIMIT = 25    # default max number of in-mempool ancestors
+DEFAULT_DESCENDANT_LIMIT = 25  # default max number of in-mempool descendants
+
+# Default setting for -datacarriersize. 80 bytes of data, +1 for OP_RETURN, +2 for the pushdata opcodes.
+MAX_OP_RETURN_RELAY = 83
+
+DEFAULT_MEMPOOL_EXPIRY_HOURS = 336  # hours
 # Serialization/deserialization tools
 def keccak256(s):
     h = sha3.keccak_256()


### PR DESCRIPTION
Goal of this pull request is to fix `mempool_*` functional tests in bitcoinsync2022 branch.

### Notes

```
bitgesell-2022$ test/functional/test_runner.py test/functional/mempool_*

...

TEST                             | STATUS    | DURATION

mempool_accept.py                | ✓ Passed  | 1 s
mempool_accept_wtxid.py          | ✓ Passed  | 12 s
mempool_datacarrier.py           | ✓ Passed  | 1 s
mempool_expiry.py                | ✓ Passed  | 1 s
mempool_limit.py                 | ✓ Passed  | 3 s
mempool_package_limits.py        | ✓ Passed  | 2 s
mempool_package_onemore.py       | ✓ Passed  | 1 s
mempool_packages.py              | ✓ Passed  | 6 s
mempool_persist.py --descriptors | ✓ Passed  | 14 s
mempool_reorg.py                 | ✓ Passed  | 2 s
mempool_resurrect.py             | ✓ Passed  | 1 s
mempool_spend_coinbase.py        | ✓ Passed  | 1 s
mempool_unbroadcast.py           | ✓ Passed  | 6 s
mempool_compatibility.py         | ○ Skipped | 0 s
mempool_updatefromblock.py       | ○ Skipped | 0 s

ALL                              | ✓ Passed  | 51 s (accumulated) 

```