### PR TITLE
test: remove outdated `gettime` test #143

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -520,14 +520,6 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 #undef B
 #undef E
 
-/* Check for mingw/wine issue #3494
- * Remove this test before time.ctime(0xffffffff) == 'Sun Feb  7 07:28:15 2106'
- */
-BOOST_AUTO_TEST_CASE(gettime)
-{
-    BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
-}
-
 BOOST_AUTO_TEST_CASE(util_time_GetTime)
 {
     SetMockTime(111);


### PR DESCRIPTION
## Summary

Hi @wu-emma 

Resolves #143
 
- Removed the stale gettime test.
- The test was originally added to check for 32-bit vs 64-bit time mismatches in the mingw toolchain, but it became obsolete after switching to `std::chrono::system_clock` [6be319b](https://github.com/bitcoin/bitcoin/commit/0000a63689036dc4368d04c0648a55fdf507932f)

- Any future time-related errors should either trigger undefined behavior sanitizers (ubsan) or fail with existing assertions.
- If needed, the test can be reintroduced and extended to cover time handling comprehensively, in coordination with updates to block header timestamp handling (linked to the year 2106 boundary, covered by `_test_y2106)`.

## Motivation

- Switch to `std::chrono::system_clock` : [6be319b](https://github.com/bitcoin/bitcoin/commit/0000a63689036dc4368d04c0648a55fdf507932f)
- [#31846](https://github.com/bitcoin/bitcoin/pull/31846)