### PR TITLE
increase rpc HTTP threads to 16, assignable on init

### DIFF
--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -14,8 +14,18 @@ namespace util {
 class SignalInterrupt;
 } // namespace util
 
-static const int DEFAULT_HTTP_THREADS=4;
-static const int DEFAULT_HTTP_WORKQUEUE=16;
+/**
+ * The default value for `-rpcthreads`. This number of threads will be created at startup.
+* More reference: https://github.com/bitcoin/bitcoin/pull/31215/commits/e56fc7ce6a92eae7e80657d9f57a148cc002358d
+ **/
+static const int DEFAULT_HTTP_THREADS=16
+
+/**
+ * The default value for `-rpcworkqueue`. This is the maximum depth of the work queue,
+ * we don't allocate this number of work queue items upfront.
+ */
+static const int DEFAULT_HTTP_WORKQUEUE=64;
+
 static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
 
 struct evhttp_request;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -667,7 +667,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::RPC);
     argsman.AddArg("-rpcwhitelist=<whitelist>", "Set a whitelist to filter incoming RPC calls for a specific user. The field <whitelist> comes in the format: <USERNAME>:<rpc 1>,<rpc 2>,...,<rpc n>. If multiple whitelists are set for a given user, they are set-intersected. See -rpcwhitelistdefault documentation for information on default whitelist behavior.", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     argsman.AddArg("-rpcwhitelistdefault", "Sets default behavior for rpc whitelisting. Unless rpcwhitelistdefault is set to 0, if any -rpcwhitelist is set, the rpc server acts as if all rpc users are subject to empty-unless-otherwise-specified whitelists. If rpcwhitelistdefault is set to 1 and no -rpcwhitelist is set, rpc server acts as if all rpc users are subject to empty whitelists.", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
-    argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
+    argsman.AddArg("-rpcworkqueue=<n>", strprintf("Set the maximum depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     argsman.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 
 #if HAVE_DECL_FORK


### PR DESCRIPTION
### Description

Hello @wu-emma @van-orton 

`rpcthreads` was introduced with a default of 4 in 2013 in https://github.com/bitcoin/bitcoin/commit/21eb5adadbe3110a8708f2570185566e1f137a49

rpcworkqueue was introduced with a default of 16 in 2015 in https://github.com/bitcoin/bitcoin/commit/40b556d3742a1f65d67e2d4c760d0b13fe8be5b7

### Notes
Increases `rpcthreads` to 16 to make BGLd performant.

Resolves #142 

### BTC/BGL PR reward address

if applicable, please type your reward wallet address here
