### PR TITLE
test: fix rpcauth test failure when test/config.ini is missing

### DIFF
--- a/test/util/rpcauth-test.py
+++ b/test/util/rpcauth-test.py
@@ -15,12 +15,21 @@ import unittest
 class TestRPCAuth(unittest.TestCase):
     def setUp(self):
         config = configparser.ConfigParser()
-        config_path = os.path.abspath(
-            os.path.join(os.sep, os.path.abspath(os.path.dirname(__file__)),
-            "../config.ini"))
-        with open(config_path, encoding="utf8") as config_file:
-            config.read_file(config_file)
-        sys.path.insert(0, os.path.dirname(config['environment']['RPCAUTH']))
+        test_dir = os.path.abspath(os.path.dirname(__file__))
+        config_path = os.path.join(test_dir, "../config.ini")
+
+        if os.path.exists(config_path):
+            with open(config_path, encoding="utf8") as config_file:
+                config.read_file(config_file)
+            rpcauth_path = config['environment']['RPCAUTH']
+        else:
+            # Allow running this unit test directly from a source checkout
+            # where test/config.ini has not been generated yet.
+            rpcauth_path = os.path.abspath(os.path.join(test_dir, "../../share/rpcauth/rpcauth.py"))
+
+        rpcauth_dir = os.path.dirname(rpcauth_path)
+        if rpcauth_dir not in sys.path:
+            sys.path.insert(0, rpcauth_dir)
         self.rpcauth = importlib.import_module('rpcauth')
 
     def test_generate_salt(self):


### PR DESCRIPTION
## Summary
- make `test/util/rpcauth-test.py` runnable from a fresh source checkout where `test/config.ini` has not been generated yet
- keep current behavior when `test/config.ini` exists
- add fallback import path to `share/rpcauth/rpcauth.py` for local/direct unit test runs

## Why
The current test hard-fails with `FileNotFoundError` when run directly in a clean checkout:

```
python3 test/util/rpcauth-test.py
FileNotFoundError: .../test/config.ini
```

This change fixes that path so contributors can run the rpcauth unit test without doing a full config generation step first.

## Validation
- `python3 test/util/rpcauth-test.py` ✅ (3 tests passed)
- `python3 -m py_compile test/util/rpcauth-test.py` ✅

Fixes #32

@bountydotnew submit
