### PR TITLE
doc: fix stale project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
     <a href="https://bitgesell.ca/"><strong>Explore more about project »</strong></a>
     <br />
     <br />
-    <a href="#">English</a>
+    <a href="https://github.com/BitgesellOfficial/bitgesell/blob/master/README.md">English</a>
     ·
-    <a href="https://github.com/BitgesellOfficial/bitgesell/blob/master/README-zh.md">Chinese</a>
+    <a href="https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/README.md">Project documentation</a>
   </p>
 </p>
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -28,11 +28,9 @@ Drag BGL Core to your applications folder, and then run BGL Core.
 
 ### Need Help?
 
-* See the documentation at the [BGL Wiki](https://en.bitcoin.it/wiki/Main_Page)
-for help and more information.
-* Ask for help on [BGL StackExchange](https://bitcoin.stackexchange.com).
-* Ask for help on #BGL on Libera Chat. If you don't have an IRC client, you can use [web.libera.chat](https://web.libera.chat/#bitcoin).
-* Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
+* Visit the [Bitgesell website](https://bitgesell.ca/) for project information and downloads.
+* Open a [GitHub issue](https://github.com/BitgesellOfficial/bitgesell/issues) for BGL Core bugs or support questions.
+* Follow [Bitgesell on X](https://twitter.com/bitgesell) for project announcements.
 
 Building
 ---------------------
@@ -65,8 +63,8 @@ The BGL repo's [root README](/README.md) contains relevant information on the de
 - [Internal Design Docs](design/)
 
 ### Resources
-* Discuss on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Development & Technical Discussion board](https://bitcointalk.org/index.php?board=6.0).
-* Discuss project-specific development on #bitcoin-core-dev on Libera Chat. If you don't have an IRC client, you can use [web.libera.chat](https://web.libera.chat/#bitcoin-core-dev).
+* Discuss project-specific development in GitHub issues and pull requests.
+* Review release process notes in [release-process.md](release-process.md).
 
 ### Miscellaneous
 - [Assets Attribution](assets-attribution.md)

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -65,7 +65,7 @@ If you want to build the windows installer with `make deploy` you need [NSIS](ht
 
 Acquire the source in the usual way:
 
-    git clone https://github.com/Original-Tasty/bitgesell.git
+    git clone https://github.com/BitgesellOfficial/bitgesell.git
     cd bitgesell
 
 ## Building for 64-bit Windows


### PR DESCRIPTION
## Summary
- replace a stale Windows build clone URL that points to a removed fork
- replace the root README's missing Chinese README link with the existing project documentation link
- update documentation support links so they point to Bitgesell project resources instead of Bitcoin Core community channels

## Bounty / issue links

- Related bounty: #32 / #39

## Verification
- `git diff --check`
- `python -m py_compile test\util\test_runner.py test\functional\combine_logs.py`

## Payout details

If approved for the bounty:

- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`