### PR TITLE
github: update issue templates for BGL

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,10 +5,10 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## This issue tracker is only for technical issues related to Bitcoin Core.
+        ## This issue tracker is only for technical issues related to BGL Core.
 
-        * General bitcoin questions and/or support requests should use Bitcoin StackExchange at https://bitcoin.stackexchange.com.
-        * For reporting security issues, please read instructions at https://bitcoincore.org/en/contact/.
+        * General Bitgesell questions and support requests should use the project's community channels instead of this bug tracker.
+        * For reporting security issues, please read the project's security policy: https://github.com/BitgesellOfficial/bitgesell/blob/master/SECURITY.md.
         * If the node is "stuck" during sync or giving "block checksum mismatch" errors, please ensure your hardware is stable by running `memtest` and observe CPU temperature with a load-test tool such as `linpack` before creating an issue.
 
         ----
@@ -50,14 +50,14 @@ body:
       description: |
         Please copy and paste any relevant log output or attach a debug log file.
 
-        You can find the debug.log in your [data dir.](https://github.com/bitcoin/bitcoin/blob/master/doc/files.md#data-directory-location)
+        You can find the debug.log in your [BGL data directory.](https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/files.md#data-directory-location)
 
         Please be aware that the debug log might contain personally identifying information.
     validations:
       required: false
   - type: dropdown
     attributes:
-      label: How did you obtain Bitcoin Core
+      label: How did you obtain BGL Core?
       multiple: false
       options:
         - Compiled from source
@@ -69,8 +69,8 @@ body:
   - type: input
     id: core-version
     attributes:
-      label: What version of Bitcoin Core are you using?
-      description: Run `bitcoind --version` or in Bitcoin-QT use `Help > About Bitcoin Core`
+      label: What version of BGL Core are you using?
+      description: Run `BGLd --version` or in BGL-qt use `Help > About BGL Core`
       placeholder: e.g. v24.0.1 or master@e1bf547
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Bitcoin Core Security Policy
-    url: https://github.com/bitcoin/bitcoin/blob/master/SECURITY.md
-    about: View security policy
-  - name: Bitcoin Core Developers
-    url: https://bitcoincore.org
-    about: Bitcoin Core homepage
+  - name: BGL Core Security Policy
+    url: https://github.com/BitgesellOfficial/bitgesell/blob/master/SECURITY.md
+    about: View the project's security reporting policy
+  - name: Bitgesell Website
+    url: https://bitgesell.ca/
+    about: Bitgesell project homepage

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -28,9 +28,9 @@ body:
     id: useful-skills
     attributes:
       label: Useful Skills
-      description: For example, “`std::thread`”, “Qt5 GUI and async GUI design” or “basic understanding of Bitcoin mining and the Bitcoin Core RPC interface”.
+      description: For example, "`std::thread`", "Qt5 GUI and async GUI design", or "basic understanding of BGL mining and the BGL Core RPC interface".
       value: |
-        * Compiling Bitcoin Core from source
+        * Compiling BGL Core from source
         * Running the C++ unit tests and the Python functional tests
         * ...
   - type: textarea
@@ -40,5 +40,4 @@ body:
       value: |
         Want to work on this issue?
 
-        For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md) before opening your pull request.
-
+        For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/BitgesellOfficial/bitgesell/blob/master/CONTRIBUTING.md) before opening your pull request.

--- a/.github/ISSUE_TEMPLATE/gui_issue.yml
+++ b/.github/ISSUE_TEMPLATE/gui_issue.yml
@@ -5,10 +5,10 @@ body:
 - type: checkboxes
   id: acknowledgement
   attributes:
-    label: Issues, reports or feature requests related to the GUI should be opened directly on the GUI repo
-    description: https://github.com/bitcoin-core/gui/issues/
+    label: GUI reports are welcome here when they affect BGL-qt
+    description: Please include screenshots or logs if they help explain the GUI behavior.
     options:
-      - label: I still think this issue should be opened here
+      - label: This issue is related to the BGL-qt GUI
         required: true
 - type: textarea
   id: gui-request

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,14 +7,13 @@ security updates: https://bitgesell.ca
 
 ## Reporting a Vulnerability
 
-To report security issues send an email to security@bitcoincore.org (not for support).
+Please do not report suspected security vulnerabilities through public GitHub
+issues.
 
-The following keys may be used to communicate sensitive information to developers:
+Use GitHub's private vulnerability reporting flow if it is enabled for this
+repository, or contact the Bitgesell maintainers through the project website:
+https://bitgesell.ca.
 
-| Name | Fingerprint |
-|------|-------------|
-| Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
-| Michael Ford | E777 299F C265 DD04 7930  70EB 944D 35F9 AC3D B76A |
-| Ava Chow | 1528 1230 0785 C964 44D3  334D 1756 5732 E08E 5E41 |
-
-You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.
+Include enough detail for maintainers to reproduce and assess the issue, such
+as affected versions, configuration, logs, proof-of-concept steps, and the
+potential impact.


### PR DESCRIPTION
### Description
Updates the GitHub issue templates and security policy so new reporters are directed to Bitgesell/BGL resources instead of inherited Bitcoin Core resources.

### Notes
- Replaces Bitcoin Core security/support links in issue template config.
- Keeps GUI issues in this repo for BGL-qt instead of sending reporters to bitcoin-core/gui.
- Updates the security policy to avoid sending vulnerability reports to Bitcoin Core contacts while pointing reporters to private reporting/project channels.

### Issue / bounty links

- Addresses #43
- Related bounty: #32 / #39

### Validation
- `git diff --check`
- Parsed the touched issue template YAML files with PyYAML
- `python -m py_compile test\util\test_runner.py test\functional\combine_logs.py`

### Payout details

If approved for the bounty:

- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`