### PR TITLE
test: remove obsolete gettime check

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -520,14 +520,6 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 #undef B
 #undef E
 
-/* Check for mingw/wine issue #3494
- * Remove this test before time.ctime(0xffffffff) == 'Sun Feb  7 07:28:15 2106'
- */
-BOOST_AUTO_TEST_CASE(gettime)
-{
-    BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
-}
-
 BOOST_AUTO_TEST_CASE(util_time_GetTime)
 {
     SetMockTime(111);


### PR DESCRIPTION
## Summary

Removes the obsolete `gettime` unit test from `src/test/util_tests.cpp`.

The test was originally kept for an old MinGW/Wine time handling concern and now duplicates coverage handled by the chrono-based time tests immediately below it. This follows the cleanup requested in #143.

## Bounty / issue links

- Fixes #143
- Related bounty: #32 / #39

## Verification

- `git diff --check`
- Confirmed `BOOST_AUTO_TEST_CASE(gettime)` is no longer present in `src/test/util_tests.cpp`

I did not run the full C++ unit test binary locally because this workspace does not have a completed Bitgesell build tree.

## Payout details

If approved for the bounty:

- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`