### PR TITLE
rpc: increase default rpc threads

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -35,7 +35,7 @@ threads take up 8MiB for the thread stack on a 64-bit system, and 4MiB in a
 32-bit system.
 
 - `-par=<n>` - the number of script verification threads, defaults to the number of cores in the system minus one.
-- `-rpcthreads=<n>` - the number of threads used for processing RPC requests, defaults to `4`.
+- `-rpcthreads=<n>` - the number of threads used for processing RPC requests, defaults to `16`.
 
 ## Linux specific
 

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -14,7 +14,7 @@ namespace util {
 class SignalInterrupt;
 } // namespace util
 
-static const int DEFAULT_HTTP_THREADS=4;
+static const int DEFAULT_HTTP_THREADS=16;
 static const int DEFAULT_HTTP_WORKQUEUE=16;
 static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
 


### PR DESCRIPTION
## Summary

Increases the default RPC worker thread count from 4 to 16 and updates the memory reduction documentation to match.

This follows the change requested in #142 so the default RPC service capacity is less constrained on modern hosts, while still allowing operators to override it with `-rpcthreads=<n>`.

## Bounty / issue links

- Fixes #142
- Related bounty: #32 / #39

## Verification

- `git diff --check`
- Confirmed the default value is now `DEFAULT_HTTP_THREADS=16`
- Confirmed `doc/reduce-memory.md` documents the same default

I did not run the full C++ test suite locally because this workspace does not have a completed Bitgesell build tree.

## Payout details

If approved for the bounty:

- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`