### PR TITLE
docs: fix translation contribution link

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,10 @@ Facebook: [Bitgesell](https://www.facebook.com/Bitgesell)
 <!-- ACKNOWLEDGEMENTS -->
 ## Translations
 
-Changes to translations as well as new translations can be submitted to
-[BGL Core's Transifex page](https://www.transifex.com/bitcoin/bitcoin/).
+Changes to translations as well as new translations can be submitted by following the
+[translation process](doc/translation_process.md).
 
-Translations are periodically pulled from Transifex and merged into the git repository. See the
-[translation process](doc/translation_process.md) for details on how this works.
+Translations are periodically pulled from Transifex and merged into the git repository.
 
 See [SECURITY.md](SECURITY.md)
 


### PR DESCRIPTION
## Summary
- Replaces the stale external Transifex link in the README translations section.
- Points contributors to the in-repository translation process documentation instead.
- Avoids duplicating the same translation-process link in consecutive sentences.

## Validation
- Confirmed `doc/translation_process.md` exists.
- Ran `git diff --check`.

## Bounty
Submitted for #32 and #81.

Payout details if approved:
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`