### PR TITLE
docs: update NetBSD build guide references

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -2,7 +2,7 @@
 
 **Updated for NetBSD [10.0](https://netbsd.org/releases/formal-10/NetBSD-10.0.html)**
 
-This guide describes how to build bitcoind, command-line utilities, and GUI on NetBSD.
+This guide describes how to build BGL Core, command-line utilities, and GUI on NetBSD.
 
 ## Preparation
 
@@ -36,7 +36,7 @@ See [dependencies.md](dependencies.md) for a complete overview.
 
 ### 2. Clone BGL Repo
 
-Clone the Bitcoin Core repository to a directory. All build scripts and commands will run from this directory.
+Clone the BGL Core repository to a directory. All build scripts and commands will run from this directory.
 
 ```bash
 git clone https://github.com/BitgesellOfficial/bitgesell.git
@@ -50,7 +50,7 @@ It is not necessary to build wallet functionality to run bitcoind or the GUI.
 
 ###### Descriptor Wallet Support
 
-`sqlite3` is required to enable support for [descriptor wallets](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).
+`sqlite3` is required to enable support for [descriptor wallets](descriptors.md).
 
 ```bash
 pkgin install sqlite3
@@ -66,7 +66,7 @@ pkgin install db4
 
 #### GUI Dependencies
 
-Bitcoin Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, Qt 5 is required.
+BGL Core includes a GUI built with the cross-platform Qt Framework. To compile the GUI, Qt 5 is required.
 
 ```bash
 pkgin install qt5-qtbase qt5-qttools
@@ -94,7 +94,7 @@ pkgin install python39
 
 ### 1. Configuration
 
-There are many ways to configure Bitcoin Core. Here is an example that
+There are many ways to configure BGL Core. Here is an example that
 explicitly disables the wallet and GUI:
 
 ```bash


### PR DESCRIPTION
## Summary
- Updates the NetBSD build guide to refer to BGL Core instead of Bitcoin Core in project-specific instructions.
- Changes the descriptor wallet documentation link to the local repository doc.

## Validation
- Confirmed `doc/descriptors.md` exists.
- Confirmed no `Bitcoin Core` or upstream `bitcoin/bitcoin` references remain in `doc/build-netbsd.md`.
- Ran `git diff --check`.

## Bounty
Submitted for #32 and #81.

Payout details if approved:
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`