### PR TITLE
docs: fix local build guide paths

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -48,7 +48,7 @@ gmake -C depends NO_BOOST=1 NO_LIBEVENT=1 NO_QT=1 NO_SQLITE=1 NO_NATPMP=1 NO_UPN
 When the build is complete, the Berkeley DB installation location will be displayed:
 
 ```
-to: /path/to/bitcoin/depends/x86_64-unknown-freebsd[release-number]
+to: /path/to/bitgesell/depends/x86_64-unknown-freebsd[release-number]
 ```
 
 Finally, set `BDB_PREFIX` to this path according to your shell:

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -205,7 +205,7 @@ This example lists the steps necessary to setup and build a command line only di
 
     pacman --sync --needed autoconf automake boost gcc git libevent libtool make pkgconf python sqlite
     git clone https://github.com/BitgesellOfficial/bitgesell.git
-    cd /bitgesell
+    cd bitgesell
     ./autogen.sh
     ./configure
     make check

--- a/doc/multisig-tutorial.md
+++ b/doc/multisig-tutorial.md
@@ -2,7 +2,7 @@
 
 Currently, it is possible to create a multisig wallet using Bitcoin Core only.
 
-Although there is already a brief explanation about the multisig in the [Descriptors documentation](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md#multisig), this tutorial proposes to use the signet (instead of regtest), bringing the reader closer to a real environment and explaining some functions in more detail.
+Although there is already a brief explanation about the multisig in the [Descriptors documentation](descriptors.md#multisig), this tutorial proposes to use the signet (instead of regtest), bringing the reader closer to a real environment and explaining some functions in more detail.
 
 This tutorial uses [jq](https://github.com/stedolan/jq) JSON processor to process the results from RPC and stores the relevant values in bash variables. This makes the tutorial reproducible and easier to follow step by step.
 


### PR DESCRIPTION
## Summary
- Fixes a stale `/path/to/bitcoin` placeholder in the FreeBSD build guide.
- Fixes the Arch Linux build example to `cd bitgesell` after cloning instead of `cd /bitgesell`.
- Points the multisig tutorial's descriptor documentation link at the local repository doc.

## Validation
- Confirmed `doc/descriptors.md` exists.
- Confirmed the edited files no longer contain the stale path/link patterns.
- Ran `git diff --check`.

## Bounty
Submitted for #32 and #81.

Payout details if approved:
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`