### PR TITLE
build: fix Windows URI handler registration

### DIFF
--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -106,10 +106,10 @@ Section -post SEC0001
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
-    WriteRegStr HKCR "bitcoin" "URL Protocol" ""
-    WriteRegStr HKCR "bitcoin" "" "URL:BGL"
-    WriteRegStr HKCR "bitcoin\DefaultIcon" "" $INSTDIR\BGL-qt
-    WriteRegStr HKCR "bitcoin\shell\open\command" "" '"$INSTDIR\BGL-qt" "%1"'
+    WriteRegStr HKCR "BGL" "URL Protocol" ""
+    WriteRegStr HKCR "BGL" "" "URL:BGL"
+    WriteRegStr HKCR "BGL\DefaultIcon" "" $INSTDIR\BGL-qt.exe
+    WriteRegStr HKCR "BGL\shell\open\command" "" '"$INSTDIR\BGL-qt.exe" "%1"'
 SectionEnd
 
 # Macro for selecting uninstaller sections
@@ -149,7 +149,7 @@ Section -un.post UNSEC0001
     DeleteRegValue HKCU "${REGKEY}" Path
     DeleteRegKey /IfEmpty HKCU "${REGKEY}\Components"
     DeleteRegKey /IfEmpty HKCU "${REGKEY}"
-    DeleteRegKey HKCR "bitcoin"
+    DeleteRegKey HKCR "BGL"
     RmDir /REBOOTOK $SMPROGRAMS\$StartMenuGroup
     RmDir /REBOOTOK $INSTDIR
     Push $R0


### PR DESCRIPTION
## Summary
- Updates the Windows NSIS installer to register the BGL URI handler instead of the inherited `bitcoin` handler.
- Uses the executable name with `.exe` for the registered icon and open command.
- Updates uninstall cleanup to remove the `BGL` handler key.

## Validation
- Compared the handler block with `share/setup-BGL-win.nsi`, which already registers `BGL`.
- Ran `git diff --check`.

## Bounty
Submitted for #32 and #81.

Payout details if approved:
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`