### PR TITLE
Update BGL config documentation references

### DIFF
--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -326,8 +326,8 @@ mkdir -p "$DISTSRC"
                 ;;
         esac
 
-        # copy over the example bitcoin.conf file. if contrib/devtools/gen-bitcoin-conf.sh
-        # has not been run before buildling, this file will be a stub
+        # copy over the example BGL.conf file. if contrib/devtools/gen-BGL-conf.sh
+        # has not been run before building, this file will be a stub
         cp "${DISTSRC}/share/examples/BGL.conf" "${DISTNAME}/"
 
         cp -r "${DISTSRC}/share/rpcauth" "${DISTNAME}/share/"

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -8,7 +8,7 @@ Maintenance releases, on the other hand, are required for patches of older relea
 
 * Update release candidate version in `configure.ac` (`CLIENT_VERSION_RC`).
 * Update manpages (after rebuilding the binaries), see [gen-manpages.py](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/README.md#gen-manpagespy).
-* Update bitcoin.conf and commit changes if they exist, see [gen-bitcoin-conf.sh](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/README.md#gen-bitcoin-confsh).
+* Update BGL.conf and commit changes if they exist, see [gen-BGL-conf.sh](../contrib/devtools/README.md#gen-bgl-confsh).
 
 This process also assumes that there will be no minor releases for old major releases.
 

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -91,7 +91,7 @@ For instance:
 Each PUB notification has a topic and body, where the header
 corresponds to the notification type. For instance, for the
 notification `-zmqpubhashtx` the topic is `hashtx` (no null
-terminator). These options can also be provided in bitcoin.conf.
+terminator). These options can also be provided in BGL.conf.
 
 The topics are:
 


### PR DESCRIPTION
Fixes part of #32.

Summary:
- Updates Guix release packaging comments to refer to `BGL.conf` and `gen-BGL-conf.sh`.
- Updates the release process checklist to tell maintainers to refresh `BGL.conf`.
- Updates the ZMQ guide to point users at `BGL.conf` for ZMQ options.

Validation:
- `git diff --check`
- `rg -n "bitcoin\.conf|gen-bitcoin-conf" contrib/guix/libexec/build.sh doc/release-process.md doc/zmq.md`

Bounty payout:
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y