### PR TITLE
test: use BGL utility binary names

### DIFF
--- a/test/util/data/BGL-util-test.json
+++ b/test/util/data/BGL-util-test.json
@@ -166,7 +166,7 @@
     "description": "Tests the check for an invalid string input index with replaceable"
   },
   {
-    "exec": "./bitcoin-tx",
+    "exec": "./BGL-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
@@ -176,7 +176,7 @@
     "description": "Tests the check for an invalid negative input index with replaceable"
   },
   {
-    "exec": "./bitcoin-tx",
+    "exec": "./BGL-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
@@ -186,7 +186,7 @@
     "description": "Tests the check for an invalid positive out-of-bounds input index with replaceable"
   },
   {
-    "exec": "./bitcoin-tx",
+    "exec": "./BGL-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
@@ -195,7 +195,7 @@
     "description": "Tests that the 'SEQUENCE' value for a single input is set to fdffffff for single input"
   },
   {
-    "exec": "./bitcoin-tx",
+    "exec": "./BGL-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
@@ -204,7 +204,7 @@
     "description": "Tests that the 'SEQUENCE' value for a single input is set to fdffffff when N omitted"
   },
   {
-    "exec": "./bitcoin-tx",
+    "exec": "./BGL-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
@@ -215,7 +215,7 @@
     "description": "Tests that only the 'SEQUENCE' value of input[1] is set to fdffffff"
   },
   {
-    "exec": "./bitcoin-tx",
+    "exec": "./BGL-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0",
@@ -226,7 +226,7 @@
     "description": "Tests that the 'SEQUENCE' value for each input is set to fdffffff when N omitted"
   },
   {
-    "exec": "./bitcoin-tx",
+    "exec": "./BGL-tx",
     "args":
     ["-create",
      "replaceable="],
@@ -234,7 +234,7 @@
     "description": "Tests behavior when no inputs are provided in the transaction"
   },
   {
-    "exec": "./bitcoin-tx",
+    "exec": "./BGL-tx",
     "args":
     ["-create",
      "in=5897de6bd6027a475eadd57019d4e6872c396d0716c4875a5f1a6fcfdf385c1f:0:abcdef00",

--- a/test/util/test_runner.py
+++ b/test/util/test_runner.py
@@ -74,10 +74,10 @@ def bctest(testDir, testObj, buildenv):
     """
     # Get the exec names and arguments
     execprog = os.path.join(buildenv["BUILDDIR"], "src", testObj["exec"] + buildenv["EXEEXT"])
-    if testObj["exec"] == "./bitcoin-util":
-        execprog = os.getenv("BITCOINUTIL", default=execprog)
-    elif testObj["exec"] == "./bitcoin-tx":
-        execprog = os.getenv("BITCOINTX", default=execprog)
+    if testObj["exec"] == "./BGL-util":
+        execprog = os.getenv("BGLUTIL", default=execprog)
+    elif testObj["exec"] == "./BGL-tx":
+        execprog = os.getenv("BGLTX", default=execprog)
 
     execargs = testObj['args']
     execrun = [execprog] + execargs


### PR DESCRIPTION
## Problem
The util test data has been renamed to Bitgesell binary names, but a few entries still invoke `./bitcoin-tx`. The util test runner also only honors the old `BITCOINUTIL` / `BITCOINTX` override names.

## Changes
- Switch the util test runner overrides to `BGLUTIL` and `BGLTX` for `./BGL-util` and `./BGL-tx`.
- Rename the remaining `./bitcoin-tx` test entries in `BGL-util-test.json` to `./BGL-tx`.

## Validation
- `python -m json.tool test/util/data/BGL-util-test.json`
- `python -m py_compile test/util/test_runner.py`
- `git diff --check`

## Bounty
Related to Bitgesell bounty issue #32.

Payment: PayPal https://paypal.me/Jeremytsangchina, or USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y` if preferred.