### PR TITLE
refactor: update user-facing binary names

### DIFF
--- a/src/BGLd.cpp
+++ b/src/BGLd.cpp
@@ -125,7 +125,7 @@ static bool ParseArgs(ArgsManager& args, int argc, char* argv[])
     // Error out when loose non-argument tokens are encountered on command line
     for (int i = 1; i < argc; i++) {
         if (!IsSwitchChar(argv[i][0])) {
-            return InitError(Untranslated(strprintf("Command line contains unexpected token '%s', see bitcoind -h for a list of options.", argv[i])));
+            return InitError(Untranslated(strprintf("Command line contains unexpected token '%s', see BGLd -h for a list of options.", argv[i])));
         }
     }
     return true;
@@ -168,7 +168,7 @@ static bool AppInit(NodeContext& node)
     std::any context{&node};
     try
     {
-        // -server defaults to true for bitcoind but not for the GUI so do this here
+        // -server defaults to true for BGLd but not for the GUI so do this here
         args.SoftSetBoolArg("-server", true);
         // Set this early so that parameter interactions go to console
         InitLogging(args);
@@ -261,7 +261,7 @@ MAIN_FUNCTION
 
     SetupEnvironment();
 
-    // Connect bitcoind signal handlers
+    // Connect BGLd signal handlers
     noui_connect();
 
     util::ThreadSetInternalName("init");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2361,7 +2361,7 @@ static RPCHelpMan scanblocks()
 {
     return RPCHelpMan{"scanblocks",
         "\nReturn relevant blockhashes for given descriptors (requires blockfilterindex).\n"
-        "This call may take several minutes. Make sure to use no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+        "This call may take several minutes. Make sure to use no RPC timeout (BGL-cli -rpcclienttimeout=0)",
         {
             scan_action_arg_desc,
             scan_objects_arg_desc,
@@ -2799,7 +2799,7 @@ static RPCHelpMan loadtxoutset()
         "Meanwhile, the original chainstate will complete the initial block download process in "
         "the background, eventually validating up to the block that the snapshot is based upon.\n\n"
 
-        "The result is a usable bitcoind instance that is current with the network tip in a "
+        "The result is a usable BGLd instance that is current with the network tip in a "
         "matter of minutes rather than hours. UTXO snapshot are typically obtained from "
         "third-party sources (HTTP, torrent, etc.) which is reasonable since their "
         "contents are always checked by hash.\n\n"

--- a/src/wallet/external_signer_scriptpubkeyman.cpp
+++ b/src/wallet/external_signer_scriptpubkeyman.cpp
@@ -47,7 +47,7 @@ bool ExternalSignerScriptPubKeyMan::SetupDescriptor(WalletBatch& batch, std::uni
 
 ExternalSigner ExternalSignerScriptPubKeyMan::GetExternalSigner() {
     const std::string command = gArgs.GetArg("-signer", "");
-    if (command == "") throw std::runtime_error(std::string(__func__) + ": restart bitcoind with -signer=<cmd>");
+    if (command == "") throw std::runtime_error(std::string(__func__) + ": restart BGLd with -signer=<cmd>");
     std::vector<ExternalSigner> signers;
     ExternalSigner::Enumerate(command, signers, Params().GetChainTypeString());
     if (signers.empty()) throw std::runtime_error(std::string(__func__) + ": No external signers found");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3241,7 +3241,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
             // Wallet is assumed to be from another chain, if genesis block in the active
             // chain differs from the genesis block known to the wallet.
             if (chain.getBlockHash(0) != locator.vHave.back()) {
-                error = Untranslated("Wallet files should not be reused across chains. Restart bitcoind with -walletcrosschain to override.");
+                error = Untranslated("Wallet files should not be reused across chains. Restart BGLd with -walletcrosschain to override.");
                 return false;
             }
         }


### PR DESCRIPTION
## Problem
A few user-facing runtime messages still reference Bitcoin Core binary names. In Bitgesell, those hints should point users to `BGLd` and `BGL-cli`.

Examples include the loose command-line argument error, RPC help text for `scanblocks` / `loadtxoutset`, and wallet restart guidance.

## Changes
- Update daemon help/error text from `bitcoind` to `BGLd`.
- Update RPC help text from `bitcoin-cli` to `BGL-cli`.
- Update wallet restart guidance to use `BGLd`.
- Update nearby daemon comments while touching the same code paths.

## Validation
- `git diff --check`
- Checked the touched files for remaining `bitcoind` / `bitcoin-cli` references in user-facing strings.

I did not run a full C++ build in this environment.

## Bounty
Related to Bitgesell bounty issue #32.

Payment: PayPal https://paypal.me/Jeremytsangchina, or USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y` if preferred.