### PR TITLE
contrib: default signet miner to BGL-cli

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -469,9 +469,9 @@ def do_calibrate(args):
     print("nbits=%08x for %ds average mining time" % (target_to_nbits(want_targ), want_time))
     return 0
 
-def bitcoin_cli(basecmd, args, **kwargs):
+def bgl_cli(basecmd, args, **kwargs):
     cmd = basecmd + ["-signet"] + args
-    logging.debug("Calling bitcoin-cli: %r", cmd)
+    logging.debug("Calling BGL-cli: %r", cmd)
     out = subprocess.run(cmd, stdout=subprocess.PIPE, **kwargs, check=True).stdout
     if isinstance(out, bytes):
         out = out.decode('utf8')
@@ -479,7 +479,7 @@ def bitcoin_cli(basecmd, args, **kwargs):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cli", default="bitcoin-cli", type=str, help="bitcoin-cli command")
+    parser.add_argument("--cli", default="BGL-cli", type=str, help="BGL-cli command")
     parser.add_argument("--debug", action="store_true", help="Print debugging info")
     parser.add_argument("--quiet", action="store_true", help="Only print warnings/errors")
 
@@ -517,7 +517,7 @@ def main():
 
     args = parser.parse_args(sys.argv[1:])
 
-    args.bcli = lambda *a, input=b"", **kwargs: bitcoin_cli(args.cli.split(" "), list(a), input=input, **kwargs)
+    args.bcli = lambda *a, input=b"", **kwargs: bgl_cli(args.cli.split(" "), list(a), input=input, **kwargs)
 
     if hasattr(args, "address") and hasattr(args, "descriptor"):
         if args.address is None and args.descriptor is None:


### PR DESCRIPTION
## Problem
`contrib/signet/getcoins.py` already defaults to `BGL-cli`, but `contrib/signet/miner` still defaults to `bitcoin-cli`. This makes the signet miner helper fail unless users manually override `--cli` in a Bitgesell checkout.

## Changes
- Rename the helper wrapper from `bitcoin_cli` to `bgl_cli`.
- Change the default CLI command and help text to `BGL-cli`.
- Update debug logging to match the Bitgesell binary name.

## Validation
- `python -m py_compile contrib/signet/miner`
- `git diff --check`
- Compared with `contrib/signet/getcoins.py`, which already uses `BGL-cli`.

## Bounty
Related to Bitgesell bounty issue #32.

Payment: PayPal https://paypal.me/Jeremytsangchina, or USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y` if preferred.