### PR TITLE
qt: fix GUI help binary name

### DIFF
--- a/src/qt/BGL.cpp
+++ b/src/qt/BGL.cpp
@@ -572,10 +572,10 @@ int GuiMain(int argc, char* argv[])
             return EXIT_FAILURE;
         }
         if (invalid_token) {
-            InitError(Untranslated(strprintf("Command line contains unexpected token '%s', see bitcoin-qt -h for a list of options.", argv[i])));
+            InitError(Untranslated(strprintf("Command line contains unexpected token '%s', see BGL-qt -h for a list of options.", argv[i])));
             QMessageBox::critical(nullptr, PACKAGE_NAME,
                                   // message cannot be translated because translations have not been initialized
-                                  QString::fromStdString("Command line contains unexpected token '%1', see bitcoin-qt -h for a list of options.").arg(QString::fromStdString(argv[i])));
+                                  QString::fromStdString("Command line contains unexpected token '%1', see BGL-qt -h for a list of options.").arg(QString::fromStdString(argv[i])));
             return EXIT_FAILURE;
         }
     }


### PR DESCRIPTION
## Problem
The Qt startup argument validation error still tells users to run `bitcoin-qt -h`. The Bitgesell GUI executable is `BGL-qt`, so the help hint is incorrect.

## Changes
- Update both the core init error and the early Qt message box text to reference `BGL-qt -h`.

## Validation
- `git diff --check`
- Confirmed the GUI binary target is `BGL-qt` in `configure.ac` and `src/Makefile.qt.include`.

I did not run a full Qt build in this environment.

## Bounty
Related to Bitgesell bounty issue #32.

Payment: PayPal https://paypal.me/Jeremytsangchina, or USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y` if preferred.