### PR TITLE
Fix: Update error hints to point to BGL binaries instead of bitcoin binaries

### DIFF
--- a/src/BGLd.cpp
+++ b/src/BGLd.cpp
@@ -125,7 +125,7 @@ static bool ParseArgs(ArgsManager& args, int argc, char* argv[])
     // Error out when loose non-argument tokens are encountered on command line
     for (int i = 1; i < argc; i++) {
         if (!IsSwitchChar(argv[i][0])) {
-            return InitError(Untranslated(strprintf("Command line contains unexpected token '%s', see bitcoind -h for a list of options.", argv[i])));
+            return InitError(Untranslated(strprintf("Command line contains unexpected token '%s', see BGLd -h for a list of options.", argv[i])));
         }
     }
     return true;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2361,7 +2361,7 @@ static RPCHelpMan scanblocks()
 {
     return RPCHelpMan{"scanblocks",
         "\nReturn relevant blockhashes for given descriptors (requires blockfilterindex).\n"
-        "This call may take several minutes. Make sure to use no RPC timeout (bitcoin-cli -rpcclienttimeout=0)",
+        "This call may take several minutes. Make sure to use no RPC timeout (BGL-cli -rpcclienttimeout=0)",
         {
             scan_action_arg_desc,
             scan_objects_arg_desc,


### PR DESCRIPTION
Following the precedent set in PR #177, this PR fixes leftover references to Bitcoin binaries in error messages and hints to correctly point to their BGL counterparts.

Specifically:
- Updated the unexpected token error hint in `src/BGLd.cpp` to point users to `BGLd -h` instead of `bitcoind -h`.
- Updated the RPC timeout hint in `src/rpc/blockchain.cpp` to use `BGL-cli` instead of `bitcoin-cli`.

This should help reduce confusion for users running the Bitgesell binaries.