### PR TITLE
build: ignore BGL build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,15 +116,15 @@ src/qt/BGL-qt.includes
 *.qm
 Makefile
 !depends/Makefile
-src/qt/bitcoin-qt
-Bitcoin-Qt.app
+src/qt/BGL-qt
+BGL-Qt.app
 
 # Qt Creator
 Makefile.am.user
 
 # Unit-tests
 Makefile.test
-bitcoin-qt_test
+src/qt/test/test_BGL-qt
 
 # Resources cpp
 qrc_*.cpp
@@ -140,7 +140,7 @@ releases
 *.gcno
 *.gcda
 /*.info
-test_bitcoin.coverage/
+test_BGL.coverage/
 total.coverage/
 fuzz.coverage/
 coverage_percent.txt


### PR DESCRIPTION
## Summary
- replace stale Bitcoin Qt build-artifact ignore entries with the current Bitgesell Qt executable/app names
- ignore the current Qt test binary path generated by the build
- update the lcov coverage ignore entry from `test_bitcoin.coverage/` to `test_BGL.coverage/`, matching the current coverage target in `Makefile.am`

## Verification
- `git diff --check`
- `git check-ignore -v src/qt/BGL-qt BGL-Qt.app src/qt/test/test_BGL-qt test_BGL.coverage/`

Refs #32

Payment preference if accepted:
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`