### PR TITLE
guix: codesign BGL Qt app bundle

### DIFF
--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -83,7 +83,7 @@ mkdir -p "$DISTSRC"
             ;;
         *darwin*)
             # Apply detached codesignatures to dist/ (in-place)
-            signapple apply dist/Bitcoin-Qt.app codesignatures/osx/dist
+            signapple apply dist/BGL-Qt.app codesignatures/osx/dist
 
             # Make a .zip from dist/
             cd dist/


### PR DESCRIPTION
## Summary
- update the Darwin Guix codesigning step to apply detached signatures to `dist/BGL-Qt.app`
- align the codesign target with the current `OSX_APP=BGL-Qt.app` bundle name from `Makefile.am`

## Why
The Guix packaging flow now builds the Bitgesell Qt app bundle as `BGL-Qt.app`, but the codesign script still targeted the old upstream `Bitcoin-Qt.app` path. That would make the Darwin codesign step look for the wrong bundle.

## Verification
- `git diff --check`
- `Select-String -Path contrib\guix\libexec\codesign.sh -Pattern "signapple apply|Bitcoin-Qt.app|BGL-Qt.app"`
- normalized-line-ending syntax check: `Get-Content -Raw contrib\guix\libexec\codesign.sh | ... | bash -n -`

Refs #32

Payment preference if accepted:
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`