### PR TITLE
docs: update message capture Bitgesell paths

### DIFF
--- a/contrib/message-capture/message-capture-docs.md
+++ b/contrib/message-capture/message-capture-docs.md
@@ -6,17 +6,17 @@ This feature allows for message capture on a per-peer basis.  It answers the sim
 
 ## Usage and Functionality
 
-* Run `bitcoind` with the `-capturemessages` option.
+* Run `BGLd` with the `-capturemessages` option.
 * Look in the `message_capture` folder in your datadir.
-  * Typically this will be `~/.bitcoin/message_capture`.
-  * See that there are many folders inside, one for each peer names with its IP address and port.
+  * On Unix-like systems, the default Bitgesell datadir is typically `~/.BGL`, so captured messages are written under `~/.BGL/message_capture`.
+  * See that there are many folders inside, one for each peer named with its IP address and port.
   * Inside each peer's folder there are two `.dat` files: one is for received messages (`msgs_recv.dat`) and the other is for sent messages (`msgs_sent.dat`).
 * Run `contrib/message-capture/message-capture-parser.py` with the proper arguments.
   * See the `-h` option for help.
   * To see all messages, both sent and received, for all peers use:
     ```
     ./contrib/message-capture/message-capture-parser.py -o out.json \
-    ~/.bitcoin/message_capture/**/*.dat
+    ~/.BGL/message_capture/**/*.dat
     ```
   * Note:  The messages in the given `.dat` files will be interleaved in chronological order.  So, giving both received and sent `.dat` files (as above with `*.dat`) will result in all messages being interleaved in chronological order.
   * If an output file is not provided (i.e. the `-o` option is not used), then the output prints to `stdout`.


### PR DESCRIPTION
Fixes stale Bitcoin Core paths in the message-capture documentation for the Bitgesell binary/datadir names.

## Summary
- update the capture command from `bitcoind` to `BGLd`
- document the Unix-like default Bitgesell datadir as `~/.BGL/message_capture`
- update the parser example path from `~/.bitcoin` to `~/.BGL`
- fix a small grammar issue in the peer-folder description

## Verification
- `git diff --check`
- `rg -n "bitcoind|~/.bitcoin" contrib/message-capture/message-capture-docs.md` returns no matches
- confirmed the default Unix datadir in `src/common/args.cpp` is `~/.BGL`

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina