### PR TITLE
docs: update external signer BGL commands

### DIFF
--- a/doc/external-signer.md
+++ b/doc/external-signer.md
@@ -1,17 +1,17 @@
-# Support for signing transactions outside of Bitcoin Core
+# Support for signing transactions outside of BGL Core
 
-Bitcoin Core can be launched with `-signer=<cmd>` where `<cmd>` is an external tool which can sign transactions and perform other functions. For example, it can be used to communicate with a hardware wallet.
+BGL Core can be launched with `-signer=<cmd>` where `<cmd>` is an external tool which can sign transactions and perform other functions. For example, it can be used to communicate with a hardware wallet.
 
 ## Example usage
 
-The following example is based on the [HWI](https://github.com/bitcoin-core/HWI) tool. Version 2.0 or newer is required. Although this tool is hosted under the Bitcoin Core GitHub organization and maintained by Bitcoin Core developers, it should be used with caution. It is considered experimental and has far less review than Bitcoin Core itself. Be particularly careful when running tools such as these on a computer with private keys on it.
+The following example is based on the [HWI](https://github.com/bitcoin-core/HWI) tool. Version 2.0 or newer is required. Although this tool is hosted under the Bitcoin Core GitHub organization and maintained by Bitcoin Core developers, it should be used with caution. It is considered experimental and has far less review than BGL Core itself. Be particularly careful when running tools such as these on a computer with private keys on it.
 
-When using a hardware wallet, consult the manufacturer website for (alternative) software they recommend. As long as their software conforms to the standard below, it should be able to work with Bitcoin Core.
+When using a hardware wallet, consult the manufacturer website for (alternative) software they recommend. As long as their software conforms to the standard below, it should be able to work with BGL Core.
 
-Start Bitcoin Core:
+Start BGL Core:
 
 ```sh
-$ bitcoind -signer=../HWI/hwi.py
+$ BGLd -signer=../HWI/hwi.py
 ```
 
 ### Device setup
@@ -23,7 +23,7 @@ Follow the hardware manufacturers instructions for the initial device setup, as 
 Get a list of signing devices / services:
 
 ```
-$ bitcoin-cli enumeratesigners
+$ BGL-cli enumeratesigners
 {
   "signers": [
     {
@@ -37,7 +37,7 @@ The master key fingerprint is used to identify a device.
 Create a wallet, this automatically imports the public keys:
 
 ```sh
-$ bitcoin-cli createwallet "hww" true true "" true true true
+$ BGL-cli createwallet "hww" true true "" true true true
 ```
 
 ### Verify an address
@@ -45,8 +45,8 @@ $ bitcoin-cli createwallet "hww" true true "" true true true
 Display an address on the device:
 
 ```sh
-$ bitcoin-cli -rpcwallet=<wallet> getnewaddress
-$ bitcoin-cli -rpcwallet=<wallet> walletdisplayaddress <address>
+$ BGL-cli -rpcwallet=<wallet> getnewaddress
+$ BGL-cli -rpcwallet=<wallet> walletdisplayaddress <address>
 ```
 
 Replace `<address>` with the result of `getnewaddress`.
@@ -56,7 +56,7 @@ Replace `<address>` with the result of `getnewaddress`.
 Under the hood this uses a [Partially Signed Bitcoin Transaction](psbt.md).
 
 ```sh
-$ bitcoin-cli -rpcwallet=<wallet> sendtoaddress <address> <amount>
+$ BGL-cli -rpcwallet=<wallet> sendtoaddress <address> <amount>
 ```
 
 This prompts your hardware wallet to sign, and fail if it's not connected. If successful
@@ -68,7 +68,7 @@ it automatically broadcasts the transaction.
 
 ## Signer API
 
-In order to be compatible with Bitcoin Core any signer command should conform to the specification below. This specification is subject to change. Ideally a BIP should propose a standard so that other wallets can also make use of it.
+In order to be compatible with BGL Core any signer command should conform to the specification below. This specification is subject to change. Ideally a BIP should propose a standard so that other wallets can also make use of it.
 
 Prerequisite knowledge:
 * [Output Descriptors](descriptors.md)
@@ -159,7 +159,7 @@ If <descriptor> contains an xpub, the command MUST fail if it does not match the
 
 The command MAY complain if `--testnet` is set, but the BIP32 coin type is not `1h` (and vice versa).
 
-## How Bitcoin Core uses the Signer API
+## How BGL Core uses the Signer API
 
 The `enumeratesigners` RPC simply calls `<cmd> enumerate`.
 


### PR DESCRIPTION
Updates the external signer guide so users can follow it with Bitgesell's current binary names instead of inherited Bitcoin Core commands.

## Summary
- change the guide title and BGL Core prose where this document describes the local project
- update command examples from `bitcoind` / `bitcoin-cli` to `BGLd` / `BGL-cli`
- update the signer API compatibility section heading for BGL Core
- keep the HWI upstream organization note intact because it describes the external HWI project, not Bitgesell commands

## Verification
- `git diff --check`
- `rg -n "bitcoind|bitcoin-cli" doc/external-signer.md` returns no matches

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina