### PR TITLE
docs: update JSON-RPC BGL-cli examples

### DIFF
--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -24,7 +24,7 @@ This endpoint is only activated when the wallet component has been compiled in.
 It can service both wallet and non-wallet requests.
 It MUST be used for wallet requests when two or more wallets are loaded.
 
-This is the endpoint used by bitcoin-cli when a `-rpcwallet=` parameter is passed in.
+This is the endpoint used by BGL-cli when a `-rpcwallet=` parameter is passed in.
 
 Best practice would dictate using the `/wallet/<walletname>/` endpoint for ALL
 requests when multiple wallets are in use.
@@ -53,13 +53,13 @@ Examples:
 
 ```sh
 # "params": ["mywallet", false, false, "", false, false, true]
-bitcoin-cli createwallet mywallet false false "" false false true
+BGL-cli createwallet mywallet false false "" false false true
 
 # "params": {"wallet_name": "mywallet", "load_on_startup": true}
-bitcoin-cli -named createwallet wallet_name=mywallet load_on_startup=true
+BGL-cli -named createwallet wallet_name=mywallet load_on_startup=true
 
 # "params": {"args": ["mywallet"], "load_on_startup": true}
-bitcoin-cli -named createwallet mywallet load_on_startup=true
+BGL-cli -named createwallet mywallet load_on_startup=true
 ```
 
 ## Versioning


### PR DESCRIPTION
Updates the JSON-RPC interface guide so wallet endpoint and named-parameter examples use Bitgesell's `BGL-cli` binary instead of inherited `bitcoin-cli` examples.

## Summary
- update the `/wallet/<walletname>/` endpoint note from `bitcoin-cli` to `BGL-cli`
- update the parameter-passing examples to use `BGL-cli`

## Verification
- `git diff --check`
- `rg -n "bitcoin-cli" doc/JSON-RPC-interface.md` returns no matches

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina