### PR TITLE
docs: update offline signing BGL examples

### DIFF
--- a/doc/offline-signing-tutorial.md
+++ b/doc/offline-signing-tutorial.md
@@ -1,16 +1,16 @@
 # Offline Signing Tutorial
 
-This tutorial will describe how to use two instances of Bitcoin Core, one online and one offline, to greatly increase security by not having private keys reside on a networked device.
+This tutorial will describe how to use two instances of BGL Core, one online and one offline, to greatly increase security by not having private keys reside on a networked device.
 
 Maintaining an air-gap between private keys and any network connections drastically reduces the opportunity for those keys to be exfiltrated from the user.
 
-This workflow uses [Partially Signed Bitcoin Transactions](https://github.com/bitcoin/bitcoin/blob/master/doc/psbt.md) (PSBTs) to transfer the transaction to and from the offline wallet for signing using the private keys.
+This workflow uses [Partially Signed Bitcoin Transactions](psbt.md) (PSBTs) to transfer the transaction to and from the offline wallet for signing using the private keys.
 
 > [!NOTE]
 > While this tutorial demonstrates the process using `signet` network, you should omit the `-signet` flag in the provided commands when working with `mainnet`.
 
 ## Overview
-In this tutorial we have two hosts, both running Bitcoin v25.0
+In this tutorial we have two hosts, both running BGL Core v25.0
 
 * `offline` host which is disconnected from all networks (internet, Tor, wifi, bluetooth etc.) and does not have, or need, a copy of the blockchain.
 * `online` host which is a regular online node with a synced blockchain.
@@ -25,7 +25,7 @@ We are going to first create an `offline_wallet` on the offline host. We will th
 1. On the offline machine create a wallet named `offline_wallet` secured by a wallet `passphrase`. This wallet will contain private keys and must remain unconnected to any networks at all times.
 
 ```sh
-[offline]$ ./src/bitcoin-cli -signet -named createwallet \
+[offline]$ ./src/BGL-cli -signet -named createwallet \
                 wallet_name="offline_wallet" \
                 passphrase="** enter passphrase **"
 
@@ -35,12 +35,12 @@ We are going to first create an `offline_wallet` on the offline host. We will th
 ```
 
 > [!NOTE]
-> The use of a passphrase is crucial to encrypt the wallet.dat file. This encryption ensures that even if an unauthorized individual gains access to the offline host, they won't be able to access the wallet's contents. Further details about securing your wallet can be found in  [Managing the Wallet](https://github.com/bitcoin/bitcoin/blob/master/doc/managing-wallets.md#12-encrypting-the-wallet)
+> The use of a passphrase is crucial to encrypt the wallet.dat file. This encryption ensures that even if an unauthorized individual gains access to the offline host, they won't be able to access the wallet's contents. Further details about securing your wallet can be found in [Managing the Wallet](managing-wallets.md#12-encrypting-the-wallet)
 
 2. Export the public key-only descriptors from the offline host to a JSON file named `descriptors.json`. We use `jq` here to extract the `.descriptors` field from the full RPC response.
 
 ```sh
-[offline]$ ./src/bitcoin-cli -signet -rpcwallet="offline_wallet" listdescriptors \
+[offline]$ ./src/BGL-cli -signet -rpcwallet="offline_wallet" listdescriptors \
              | jq -r '.descriptors' \
              >> /path/to/descriptors.json
 ```
@@ -58,7 +58,7 @@ The `watch_only_wallet` wallet will be used to track and validate incoming trans
 > `disable_private_keys` indicates that the wallet should refuse to import private keys, i.e. will be a dedicated watch-only wallet.
 
 ```sh
-[online]$ ./src/bitcoin-cli -signet -named createwallet \
+[online]$ ./src/BGL-cli -signet -named createwallet \
               wallet_name="watch_only_wallet" \
               disable_private_keys=true
 
@@ -70,7 +70,7 @@ The `watch_only_wallet` wallet will be used to track and validate incoming trans
 2. Import the `offline_wallet`s public key descriptors to the online `watch_only_wallet` using the `descriptors.json` file created on the offline wallet.
 
 ```sh
-[online]$ ./src/bitcoin-cli -signet -rpcwallet="watch_only_wallet" importdescriptors "$(cat /path/to/descriptors.json)"
+[online]$ ./src/BGL-cli -signet -rpcwallet="watch_only_wallet" importdescriptors "$(cat /path/to/descriptors.json)"
 
 [
   {
@@ -109,9 +109,9 @@ At this point, it's important to understand that both the `offline_wallet` and o
 1. Generate an address to receive coins. You can use _either_ the `offline_wallet` or the online `watch_only_wallet` to generate this address, as they will produce the same addresses. For the sake of this guide, we'll use the online `watch_only_wallet` to generate the address.
 
 ```sh
-[online]$ ./src/bitcoin-cli -signet -rpcwallet="watch_only_wallet" getnewaddress
+[online]$ ./src/BGL-cli -signet -rpcwallet="watch_only_wallet" getnewaddress
 
-tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
+tbgl1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajk4z962
 ```
 
 2. Visit a faucet like https://signetfaucet.com and enter your address from the previous command to receive a small amount of signet coins to this address.
@@ -119,13 +119,13 @@ tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
 3. Confirm that coins were received using the online `watch_only_wallet`. Note that the transaction may take a few moments before being received on your local node, depending on its connectivity. Just re-run the command periodically until the transaction is received.
 
 ```sh
-[online]$ ./src/bitcoin-cli -signet -rpcwallet="watch_only_wallet" listunspent
+[online]$ ./src/BGL-cli -signet -rpcwallet="watch_only_wallet" listunspent
 
 [
   {
     "txid": "0f3953dfc3eb8e753cd1633151837c5b9953992914ff32b7de08c47f1f29c762",
     "vout": 1,
-    "address": "tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh",
+    "address": "tbgl1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajk4z962",
     "label": "",
     "scriptPubKey": "00145f2804634d6df60dd080932e83c408b2975cbbb2",
     "amount": 0.01000000,
@@ -143,13 +143,13 @@ tb1qtu5qgc6ddhmqm5yqjvhg83qgk2t4ewajg0h6yh
 
 ### Create and Export an Unsigned PSBT
 
-1. Get a destination address for the transaction. In this tutorial we'll be sending funds to the address `tb1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg3erez32`, but if you don't need the coins for further testing you could send the coins back to the faucet.
+1. Get a destination address for the transaction. In this tutorial we'll be sending funds to the address `tbgl1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg38eva0h`, but if you don't need the coins for further testing you could send the coins back to the faucet.
 
 2. Create a funded but unsigned PSBT to the destination address with the online `watch_only_wallet` by using `send [{"address":amount},...]` and export the unsigned PSBT to a file `funded_psbt.txt` for easy portability to the `offline_wallet` for signing:
 
 ```sh
-[online]$ ./src/bitcoin-cli -signet -rpcwallet="watch_only_wallet" send \
-              '{"tb1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg3erez32": 0.009}' \
+[online]$ ./src/BGL-cli -signet -rpcwallet="watch_only_wallet" send \
+              '{"tbgl1q9k5w0nhnhyeh78snpxh0t5t7c3lxdeg38eva0h": 0.009}' \
               | jq -r '.psbt' \
               >> /path/to/funded_psbt.txt
 
@@ -165,13 +165,13 @@ cHNidP8BAHECAAAAAWLHKR9/xAjetzL/FCmZU5lbfINRMWPRPHWO68PfUzkPAQAAAAD9////AoA4AQAA
 Decode and analyze the unsigned PSBT on the `offline_wallet` using the `funded_psbt.txt` file:
 
 ```sh
-[offline]$ ./src/bitcoin-cli -signet decodepsbt $(cat /path/to/funded_psbt.txt)
+[offline]$ ./src/BGL-cli -signet decodepsbt $(cat /path/to/funded_psbt.txt)
 
 {
     ...
 }
 
-[offline]$ ./src/bitcoin-cli -signet analyzepsbt $(cat /path/to/funded_psbt.txt)
+[offline]$ ./src/BGL-cli -signet analyzepsbt $(cat /path/to/funded_psbt.txt)
 
 {
   "inputs": [
@@ -202,13 +202,13 @@ Notice that the analysis of the PSBT shows that "signatures" are missing and sho
 Use the walletpassphrase command to unlock the `offline_wallet` with the passphrase. You should specify the passphrase and a timeout (in seconds) for how long you want the wallet to remain unlocked.
 
 ```sh
-[offline]$ ./src/bitcoin-cli -signet -rpcwallet="offline_wallet" walletpassphrase "** enter passphrase **" 60
+[offline]$ ./src/BGL-cli -signet -rpcwallet="offline_wallet" walletpassphrase "** enter passphrase **" 60
 ```
 
 2. Process, sign and finalize the PSBT on the `offline_wallet` using the `walletprocesspsbt` command, saving the output to a file `final_psbt.txt`.
 
  ```sh
-[offline]$ ./src/bitcoin-cli -signet -rpcwallet="offline_wallet" walletprocesspsbt \
+[offline]$ ./src/BGL-cli -signet -rpcwallet="offline_wallet" walletprocesspsbt \
                 $(cat /path/to/funded_psbt.txt) \
                 | jq -r .hex \
                 >> /path/to/final_psbt.txt
@@ -218,7 +218,7 @@ Use the walletpassphrase command to unlock the `offline_wallet` with the passphr
 Broadcast the funded, signed and finalized PSBT `final_psbt.txt` using `sendrawtransaction` with an online node:
 
 ```sh
-[online]$ ./src/bitcoin-cli -signet sendrawtransaction $(cat /path/to/final_psbt.txt)
+[online]$ ./src/BGL-cli -signet sendrawtransaction $(cat /path/to/final_psbt.txt)
 
 c2430a0e46df472b04b0ca887bbcd5c4abf7b2ce2eb71de981444a80e2b96d52
 ```
@@ -228,7 +228,7 @@ c2430a0e46df472b04b0ca887bbcd5c4abf7b2ce2eb71de981444a80e2b96d52
 Confirm the updated balance of the offline wallet using the `watch_only_wallet`.
 
 ```sh
-[online]$ ./src/bitcoin-cli -signet -rpcwallet="watch_only_wallet" getbalances
+[online]$ ./src/BGL-cli -signet -rpcwallet="watch_only_wallet" getbalances
 
 {
   "mine": {
@@ -247,7 +247,7 @@ Confirm the updated balance of the offline wallet using the `watch_only_wallet`.
 You can also show transactions related to the wallet using `listtransactions`
 
 ```sh
-[online]$ ./src/bitcoin-cli -signet -rpcwallet="watch_only_wallet" listtransactions
+[online]$ ./src/BGL-cli -signet -rpcwallet="watch_only_wallet" listtransactions
 
 {
     ...


### PR DESCRIPTION
Updates the offline signing tutorial so its examples use Bitgesell's command names, local documentation links, and valid BGL signet address prefixes.

## Summary
- update offline/online wallet commands from `bitcoin-cli` to `BGL-cli`
- switch internal documentation links to local BGL Core docs
- update project wording from Bitcoin Core to BGL Core where the tutorial describes this repo
- convert visible signet example addresses from Bitcoin `tb1...` to BGL `tbgl1...` using the same witness programs

## Verification
- `git diff --check`
- `rg -n "bitcoin-cli|bitcoind|bitcoin-qt|Bitcoin Core|Bitcoin v|https://github.com/bitcoin/bitcoin/blob/master/doc/(psbt|managing-wallets)|tb1q" doc/offline-signing-tutorial.md` returns no matches
- confirmed BGL signet Bech32 HRP `tbgl` in `src/kernel/chainparams.cpp`
- regenerated the visible `tbgl1...` examples with the repository's Bech32/SegWit address encoder

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina