### PR TITLE
docs: align library design names with BGL build

### DIFF
--- a/doc/design/libraries.md
+++ b/doc/design/libraries.md
@@ -2,30 +2,30 @@
 
 | Name                     | Description |
 |--------------------------|-------------|
-| *libbitcoin_cli*         | RPC client functionality used by *bitcoin-cli* executable |
-| *libbitcoin_common*      | Home for common functionality shared by different executables and libraries. Similar to *libbitcoin_util*, but higher-level (see [Dependencies](#dependencies)). |
-| *libbitcoin_consensus*   | Stable, backwards-compatible consensus functionality used by *libbitcoin_node* and *libbitcoin_wallet* and also exposed as a [shared library](../shared-libraries.md). |
-| *libbitcoinconsensus*    | Shared library build of static *libbitcoin_consensus* library |
-| *libbitcoin_kernel*      | Consensus engine and support library used for validation by *libbitcoin_node* and also exposed as a [shared library](../shared-libraries.md). |
-| *libbitcoinqt*           | GUI functionality used by *bitcoin-qt* and *bitcoin-gui* executables |
-| *libbitcoin_ipc*         | IPC functionality used by *bitcoin-node*, *bitcoin-wallet*, *bitcoin-gui* executables to communicate when [`--enable-multiprocess`](multiprocess.md) is used. |
-| *libbitcoin_node*        | P2P and RPC server functionality used by *bitcoind* and *bitcoin-qt* executables. |
-| *libbitcoin_util*        | Home for common functionality shared by different executables and libraries. Similar to *libbitcoin_common*, but lower-level (see [Dependencies](#dependencies)). |
-| *libbitcoin_wallet*      | Wallet functionality used by *bitcoind* and *bitcoin-wallet* executables. |
-| *libbitcoin_wallet_tool* | Lower-level wallet functionality used by *bitcoin-wallet* executable. |
-| *libbitcoin_zmq*         | [ZeroMQ](../zmq.md) functionality used by *bitcoind* and *bitcoin-qt* executables. |
+| *libBGL_cli*         | RPC client functionality used by *BGL-cli* executable |
+| *libBGL_common*      | Home for common functionality shared by different executables and libraries. Similar to *libBGL_util*, but higher-level (see [Dependencies](#dependencies)). |
+| *libBGL_consensus*   | Stable, backwards-compatible consensus functionality used by *libBGL_node* and *libBGL_wallet* and also exposed as a [shared library](../shared-libraries.md). |
+| *BGLconsensus*       | Shared library build of static *libBGL_consensus* library |
+| *libBGLkernel*       | Consensus engine and support library used for validation by *libBGL_node* and also exposed as a [shared library](../shared-libraries.md). |
+| *libBGLqt*           | GUI functionality used by *BGL-qt* and *BGL-gui* executables |
+| *libBGL_ipc*         | IPC functionality used by *BGL-node*, *BGL-wallet*, *BGL-gui* executables to communicate when [`--enable-multiprocess`](multiprocess.md) is used. |
+| *libBGL_node*        | P2P and RPC server functionality used by *BGLd* and *BGL-qt* executables. |
+| *libBGL_util*        | Home for common functionality shared by different executables and libraries. Similar to *libBGL_common*, but lower-level (see [Dependencies](#dependencies)). |
+| *libBGL_wallet*      | Wallet functionality used by *BGLd* and *BGL-wallet* executables. |
+| *libBGL_wallet_tool* | Lower-level wallet functionality used by *BGL-wallet* executable. |
+| *libBGL_zmq*         | [ZeroMQ](../zmq.md) functionality used by *BGLd* and *BGL-qt* executables. |
 
 ## Conventions
 
-- Most libraries are internal libraries and have APIs which are completely unstable! There are few or no restrictions on backwards compatibility or rules about external dependencies. Exceptions are *libbitcoin_consensus* and *libbitcoin_kernel* which have external interfaces documented at [../shared-libraries.md](../shared-libraries.md).
+- Most libraries are internal libraries and have APIs which are completely unstable! There are few or no restrictions on backwards compatibility or rules about external dependencies. Exceptions are *libBGL_consensus* and *libBGLkernel* which have external interfaces documented at [../shared-libraries.md](../shared-libraries.md).
 
-- Generally each library should have a corresponding source directory and namespace. Source code organization is a work in progress, so it is true that some namespaces are applied inconsistently, and if you look at [`libbitcoin_*_SOURCES`](../../src/Makefile.am) lists you can see that many libraries pull in files from outside their source directory. But when working with libraries, it is good to follow a consistent pattern like:
+- Generally each library should have a corresponding source directory and namespace. Source code organization is a work in progress, so it is true that some namespaces are applied inconsistently, and if you look at [`libBGL_*_SOURCES`](../../src/Makefile.am) lists you can see that many libraries pull in files from outside their source directory. But when working with libraries, it is good to follow a consistent pattern like:
 
-  - *libbitcoin_node* code lives in `src/node/` in the `node::` namespace
-  - *libbitcoin_wallet* code lives in `src/wallet/` in the `wallet::` namespace
-  - *libbitcoin_ipc* code lives in `src/ipc/` in the `ipc::` namespace
-  - *libbitcoin_util* code lives in `src/util/` in the `util::` namespace
-  - *libbitcoin_consensus* code lives in `src/consensus/` in the `Consensus::` namespace
+  - *libBGL_node* code lives in `src/node/` in the `node::` namespace
+  - *libBGL_wallet* code lives in `src/wallet/` in the `wallet::` namespace
+  - *libBGL_ipc* code lives in `src/ipc/` in the `ipc::` namespace
+  - *libBGL_util* code lives in `src/util/` in the `util::` namespace
+  - *libBGL_consensus* code lives in `src/consensus/` in the `Consensus::` namespace
 
 ## Dependencies
 
@@ -39,43 +39,43 @@
 
 graph TD;
 
-bitcoin-cli[bitcoin-cli]-->libbitcoin_cli;
+BGL-cli[BGL-cli]-->libBGL_cli;
 
-bitcoind[bitcoind]-->libbitcoin_node;
-bitcoind[bitcoind]-->libbitcoin_wallet;
+BGLd[BGLd]-->libBGL_node;
+BGLd[BGLd]-->libBGL_wallet;
 
-bitcoin-qt[bitcoin-qt]-->libbitcoin_node;
-bitcoin-qt[bitcoin-qt]-->libbitcoinqt;
-bitcoin-qt[bitcoin-qt]-->libbitcoin_wallet;
+BGL-qt[BGL-qt]-->libBGL_node;
+BGL-qt[BGL-qt]-->libBGLqt;
+BGL-qt[BGL-qt]-->libBGL_wallet;
 
-bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet;
-bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet_tool;
+BGL-wallet[BGL-wallet]-->libBGL_wallet;
+BGL-wallet[BGL-wallet]-->libBGL_wallet_tool;
 
-libbitcoin_cli-->libbitcoin_util;
-libbitcoin_cli-->libbitcoin_common;
+libBGL_cli-->libBGL_util;
+libBGL_cli-->libBGL_common;
 
-libbitcoin_common-->libbitcoin_consensus;
-libbitcoin_common-->libbitcoin_util;
+libBGL_common-->libBGL_consensus;
+libBGL_common-->libBGL_util;
 
-libbitcoin_kernel-->libbitcoin_consensus;
-libbitcoin_kernel-->libbitcoin_util;
+libBGLkernel-->libBGL_consensus;
+libBGLkernel-->libBGL_util;
 
-libbitcoin_node-->libbitcoin_consensus;
-libbitcoin_node-->libbitcoin_kernel;
-libbitcoin_node-->libbitcoin_common;
-libbitcoin_node-->libbitcoin_util;
+libBGL_node-->libBGL_consensus;
+libBGL_node-->libBGLkernel;
+libBGL_node-->libBGL_common;
+libBGL_node-->libBGL_util;
 
-libbitcoinqt-->libbitcoin_common;
-libbitcoinqt-->libbitcoin_util;
+libBGLqt-->libBGL_common;
+libBGLqt-->libBGL_util;
 
-libbitcoin_wallet-->libbitcoin_common;
-libbitcoin_wallet-->libbitcoin_util;
+libBGL_wallet-->libBGL_common;
+libBGL_wallet-->libBGL_util;
 
-libbitcoin_wallet_tool-->libbitcoin_wallet;
-libbitcoin_wallet_tool-->libbitcoin_util;
+libBGL_wallet_tool-->libBGL_wallet;
+libBGL_wallet_tool-->libBGL_util;
 
 classDef bold stroke-width:2px, font-weight:bold, font-size: smaller;
-class bitcoin-qt,bitcoind,bitcoin-cli,bitcoin-wallet bold
+class BGL-qt,BGLd,BGL-cli,BGL-wallet bold
 ```
 </td></tr><tr><td>
 
@@ -83,22 +83,22 @@ class bitcoin-qt,bitcoind,bitcoin-cli,bitcoin-wallet bold
 
 </td></tr></table>
 
-- The graph shows what _linker symbols_ (functions and variables) from each library other libraries can call and reference directly, but it is not a call graph. For example, there is no arrow connecting *libbitcoin_wallet* and *libbitcoin_node* libraries, because these libraries are intended to be modular and not depend on each other's internal implementation details. But wallet code is still able to call node code indirectly through the `interfaces::Chain` abstract class in [`interfaces/chain.h`](../../src/interfaces/chain.h) and node code calls wallet code through the `interfaces::ChainClient` and `interfaces::Chain::Notifications` abstract classes in the same file. In general, defining abstract classes in [`src/interfaces/`](../../src/interfaces/) can be a convenient way of avoiding unwanted direct dependencies or circular dependencies between libraries.
+- The graph shows what _linker symbols_ (functions and variables) from each library other libraries can call and reference directly, but it is not a call graph. For example, there is no arrow connecting *libBGL_wallet* and *libBGL_node* libraries, because these libraries are intended to be modular and not depend on each other's internal implementation details. But wallet code is still able to call node code indirectly through the `interfaces::Chain` abstract class in [`interfaces/chain.h`](../../src/interfaces/chain.h) and node code calls wallet code through the `interfaces::ChainClient` and `interfaces::Chain::Notifications` abstract classes in the same file. In general, defining abstract classes in [`src/interfaces/`](../../src/interfaces/) can be a convenient way of avoiding unwanted direct dependencies or circular dependencies between libraries.
 
-- *libbitcoin_consensus* should be a standalone dependency that any library can depend on, and it should not depend on any other libraries itself.
+- *libBGL_consensus* should be a standalone dependency that any library can depend on, and it should not depend on any other libraries itself.
 
-- *libbitcoin_util* should also be a standalone dependency that any library can depend on, and it should not depend on other internal libraries.
+- *libBGL_util* should also be a standalone dependency that any library can depend on, and it should not depend on other internal libraries.
 
-- *libbitcoin_common* should serve a similar function as *libbitcoin_util* and be a place for miscellaneous code used by various daemon, GUI, and CLI applications and libraries to live. It should not depend on anything other than *libbitcoin_util* and *libbitcoin_consensus*. The boundary between _util_ and _common_ is a little fuzzy but historically _util_ has been used for more generic, lower-level things like parsing hex, and _common_ has been used for bitcoin-specific, higher-level things like parsing base58. The difference between util and common is mostly important because *libbitcoin_kernel* is not supposed to depend on *libbitcoin_common*, only *libbitcoin_util*. In general, if it is ever unclear whether it is better to add code to *util* or *common*, it is probably better to add it to *common* unless it is very generically useful or useful particularly to include in the kernel.
+- *libBGL_common* should serve a similar function as *libBGL_util* and be a place for miscellaneous code used by various daemon, GUI, and CLI applications and libraries to live. It should not depend on anything other than *libBGL_util* and *libBGL_consensus*. The boundary between _util_ and _common_ is a little fuzzy but historically _util_ has been used for more generic, lower-level things like parsing hex, and _common_ has been used for BGL-specific, higher-level things like parsing base58. The difference between util and common is mostly important because *libBGLkernel* is not supposed to depend on *libBGL_common*, only *libBGL_util*. In general, if it is ever unclear whether it is better to add code to *util* or *common*, it is probably better to add it to *common* unless it is very generically useful or useful particularly to include in the kernel.
 
 
-- *libbitcoin_kernel* should only depend on *libbitcoin_util* and *libbitcoin_consensus*.
+- *libBGLkernel* should only depend on *libBGL_util* and *libBGL_consensus*.
 
-- The only thing that should depend on *libbitcoin_kernel* internally should be *libbitcoin_node*. GUI and wallet libraries *libbitcoinqt* and *libbitcoin_wallet* in particular should not depend on *libbitcoin_kernel* and the unneeded functionality it would pull in, like block validation. To the extent that GUI and wallet code need scripting and signing functionality, they should be get able it from *libbitcoin_consensus*, *libbitcoin_common*, and *libbitcoin_util*, instead of *libbitcoin_kernel*.
+- The only thing that should depend on *libBGLkernel* internally should be *libBGL_node*. GUI and wallet libraries *libBGLqt* and *libBGL_wallet* in particular should not depend on *libBGLkernel* and the unneeded functionality it would pull in, like block validation. To the extent that GUI and wallet code need scripting and signing functionality, they should be able to get it from *libBGL_consensus*, *libBGL_common*, and *libBGL_util*, instead of *libBGLkernel*.
 
-- GUI, node, and wallet code internal implementations should all be independent of each other, and the *libbitcoinqt*, *libbitcoin_node*, *libbitcoin_wallet* libraries should never reference each other's symbols. They should only call each other through [`src/interfaces/`](../../src/interfaces/) abstract interfaces.
+- GUI, node, and wallet code internal implementations should all be independent of each other, and the *libBGLqt*, *libBGL_node*, *libBGL_wallet* libraries should never reference each other's symbols. They should only call each other through [`src/interfaces/`](../../src/interfaces/) abstract interfaces.
 
 ## Work in progress
 
-- Validation code is moving from *libbitcoin_node* to *libbitcoin_kernel* as part of [The libbitcoinkernel Project #24303](https://github.com/bitcoin/bitcoin/issues/24303)
+- Validation code is moving from *libBGL_node* to *libBGLkernel* as part of [The libbitcoinkernel Project #24303](https://github.com/bitcoin/bitcoin/issues/24303)
 - Source code organization is discussed in general in [Library source code organization #15732](https://github.com/bitcoin/bitcoin/issues/15732)


### PR DESCRIPTION
Aligns the library design documentation with the Bitgesell names used by the current build system.

## Summary
- update the library table from `libbitcoin_*` names to the actual `libBGL_*` / `libBGLkernel` / `BGLconsensus` names
- update executable references from `bitcoin-*` / `bitcoind` to `BGL-*` / `BGLd`
- update the Mermaid dependency graph to use the current BGL library and executable labels
- keep upstream Bitcoin Core issue links where they are source/history references

## Verification
- `git diff --check`
- `rg -n "libbitcoin|bitcoin-cli|bitcoind|bitcoin-qt|bitcoin-wallet|bitcoin-node|bitcoin-gui|bitcoin-specific" doc/design/libraries.md` only leaves the upstream issue title reference
- confirmed current library and executable names in `src/Makefile.am` and `configure.ac`

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina