### PR TITLE
docs: update multiprocess BGL executable names

### DIFF
--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -1,10 +1,10 @@
-# Multiprocess Bitcoin
+# Multiprocess BGL
 
 _This document describes usage of the multiprocess feature. For design information, see the [design/multiprocess.md](design/multiprocess.md) file._
 
 ## Build Option
 
-On unix systems, the `--enable-multiprocess` build option can be passed to `./configure` to build new `bitcoin-node`, `bitcoin-wallet`, and `bitcoin-gui` executables alongside existing `bitcoind` and `bitcoin-qt` executables.
+On unix systems, the `--enable-multiprocess` build option can be passed to `./configure` to build new `BGL-node`, `BGL-wallet`, and `BGL-gui` executables alongside existing `BGLd` and `BGL-qt` executables.
 
 ## Debugging
 
@@ -15,12 +15,12 @@ The `-debug=ipc` command line option can be used to see requests and responses b
 The multiprocess feature requires [Cap'n Proto](https://capnproto.org/) and [libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) as dependencies. A simple way to get started using it without installing these dependencies manually is to use the [depends system](../depends) with the `MULTIPROCESS=1` [dependency option](../depends#dependency-options) passed to make:
 
 ```
-cd <BITCOIN_SOURCE_DIRECTORY>
+cd <BGL_SOURCE_DIRECTORY>
 make -C depends NO_QT=1 MULTIPROCESS=1
 CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure
 make
-src/bitcoin-node -regtest -printtoconsole -debug=ipc
-BITCOIND=bitcoin-node test/functional/test_runner.py
+src/BGL-node -regtest -printtoconsole -debug=ipc
+BGLD=BGL-node test/functional/test_runner.py
 ```
 
 The configure script will pick up settings and library locations from the depends directory, so there is no need to pass `--enable-multiprocess` as a separate flag when using the depends system (it's controlled by the `MULTIPROCESS=1` option).
@@ -29,6 +29,6 @@ Alternately, you can install [Cap'n Proto](https://capnproto.org/) and [libmulti
 
 ## Usage
 
-`bitcoin-node` is a drop-in replacement for `bitcoind`, and `bitcoin-gui` is a drop-in replacement for `bitcoin-qt`, and there are no differences in use or external behavior between the new and old executables. But internally after [#10102](https://github.com/bitcoin/bitcoin/pull/10102), `bitcoin-gui` will spawn a `bitcoin-node` process to run P2P and RPC code, communicating with it across a socket pair, and `bitcoin-node` will spawn `bitcoin-wallet` to run wallet code, also communicating over a socket pair. This will let node, wallet, and GUI code run in separate address spaces for better isolation, and allow future improvements like being able to start and stop components independently on different machines and environments.
-[#19460](https://github.com/bitcoin/bitcoin/pull/19460) also adds a new `bitcoin-node` `-ipcbind` option and an `bitcoind-wallet` `-ipcconnect` option to allow new wallet processes to connect to an existing node process.
-And [#19461](https://github.com/bitcoin/bitcoin/pull/19461) adds a new `bitcoin-gui` `-ipcconnect` option to allow new GUI processes to connect to an existing node process.
+`BGL-node` is a drop-in replacement for `BGLd`, and `BGL-gui` is a drop-in replacement for `BGL-qt`, and there are no differences in use or external behavior between the new and old executables. But internally after [#10102](https://github.com/bitcoin/bitcoin/pull/10102), `BGL-gui` will spawn a `BGL-node` process to run P2P and RPC code, communicating with it across a socket pair, and `BGL-node` will spawn `BGL-wallet` to run wallet code, also communicating over a socket pair. This will let node, wallet, and GUI code run in separate address spaces for better isolation, and allow future improvements like being able to start and stop components independently on different machines and environments.
+[#19460](https://github.com/bitcoin/bitcoin/pull/19460) also adds a new `BGL-node` `-ipcbind` option and a `BGL-wallet` `-ipcconnect` option to allow new wallet processes to connect to an existing node process.
+And [#19461](https://github.com/bitcoin/bitcoin/pull/19461) adds a new `BGL-gui` `-ipcconnect` option to allow new GUI processes to connect to an existing node process.


### PR DESCRIPTION
Updates the multiprocess usage document so its executable names and test-runner example match Bitgesell's current build and test framework names.

## Summary
- rename multiprocess usage examples from `bitcoin-*` / `bitcoind` to `BGL-*` / `BGLd`
- update the source directory placeholder to `BGL_SOURCE_DIRECTORY`
- update the functional test runner example to use the `BGLD` environment variable
- keep upstream Bitcoin Core PR links where they are historical source references

## Verification
- `git diff --check`
- `rg -n "Multiprocess Bitcoin|bitcoin-node|bitcoin-wallet|bitcoin-gui|bitcoind|bitcoin-qt|BITCOIN_SOURCE_DIRECTORY|BITCOIND=" doc/multiprocess.md` returns no matches
- confirmed `BGL-node`, `BGL-wallet`, and `BGL-gui` names in `src/Makefile.am` / `configure.ac`
- confirmed the test framework reads the `BGLD` environment variable in `test/functional/test_framework/test_framework.py`

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina