### PR TITLE
docs: update multiprocess design BGL names

### DIFF
--- a/doc/design/multiprocess.md
+++ b/doc/design/multiprocess.md
@@ -1,6 +1,6 @@
-# Multiprocess Bitcoin Design Document
+# Multiprocess BGL Design Document
 
-Guide to the design and architecture of the Bitcoin Core multiprocess feature
+Guide to the design and architecture of the BGL Core multiprocess feature
 
 _This document describes the design of the multiprocess feature. For usage information, see the top-level [multiprocess.md](../multiprocess.md) file._
 
@@ -27,31 +27,31 @@ _This document describes the design of the multiprocess feature. For usage infor
 
 ## Introduction
 
-The Bitcoin Core software has historically employed a monolithic architecture. The existing design has integrated functionality like P2P network operations, wallet management, and a GUI into a single executable. While effective, it has limitations in flexibility, security, and scalability. This project introduces changes that transition Bitcoin Core to a more modular architecture. It aims to enhance security, improve usability, and facilitate maintenance and development of the software in the long run.
+The BGL Core software has historically employed a monolithic architecture. The existing design has integrated functionality like P2P network operations, wallet management, and a GUI into a single executable. While effective, it has limitations in flexibility, security, and scalability. This project introduces changes that transition BGL Core to a more modular architecture. It aims to enhance security, improve usability, and facilitate maintenance and development of the software in the long run.
 
 ## Current Architecture
 
-The current system features two primary executables: `bitcoind` and `bitcoin-qt`. `bitcoind` combines a Bitcoin P2P node with an integrated JSON-RPC server, wallet, and indexes. `bitcoin-qt` extends this by incorporating a Qt-based GUI. This monolithic structure, although robust, presents challenges such as limited operational flexibility and increased security risks due to the tight integration of components.
+The current system features two primary executables: `BGLd` and `BGL-qt`. `BGLd` combines a BGL P2P node with an integrated JSON-RPC server, wallet, and indexes. `BGL-qt` extends this by incorporating a Qt-based GUI. This monolithic structure, although robust, presents challenges such as limited operational flexibility and increased security risks due to the tight integration of components.
 
 ## Proposed Architecture
 
 The new architecture divides the existing code into three specialized executables:
 
-- `bitcoin-node`: Manages the P2P node, indexes, and JSON-RPC server.
-- `bitcoin-wallet`: Handles all wallet functionality.
-- `bitcoin-gui`: Provides a standalone Qt-based GUI.
+- `BGL-node`: Manages the P2P node, indexes, and JSON-RPC server.
+- `BGL-wallet`: Handles all wallet functionality.
+- `BGL-gui`: Provides a standalone Qt-based GUI.
 
 This modular approach is designed to enhance security through component isolation and improve usability by allowing independent operation of each module. This allows for new use-cases, such as running the node on a dedicated machine and operating wallets and GUIs on separate machines with the flexibility to start and stop them as needed.
 
-This subdivision could be extended in the future. For example, indexes could be removed from the `bitcoin-node` executable and run in separate executables. And JSON-RPC servers could be added to wallet and index executables, so they can listen and respond to RPC requests on their own ports, without needing to forward RPC requests through `bitcoin-node`.
+This subdivision could be extended in the future. For example, indexes could be removed from the `BGL-node` executable and run in separate executables. And JSON-RPC servers could be added to wallet and index executables, so they can listen and respond to RPC requests on their own ports, without needing to forward RPC requests through `BGL-node`.
 
 <table><tr><td>
 
 ```mermaid
 flowchart LR
-    node[bitcoin-node] -- listens on --> socket["&lt;datadir&gt;/node.sock"]
-    wallet[bitcoin-wallet] -- connects to --> socket
-    gui[bitcoin-gui] -- connects to --> socket
+    node[BGL-node] -- listens on --> socket["&lt;datadir&gt;/node.sock"]
+    wallet[BGL-wallet] -- connects to --> socket
+    gui[BGL-gui] -- connects to --> socket
 ```
 
 </td></tr><tr><td>
@@ -90,7 +90,7 @@ This section describes the major components of the Inter-Process Communication (
 
 ### The `libmultiprocess` Runtime Library
 - **Core Functionality**: The `libmultiprocess` runtime library's primary function is to instantiate the generated client and server classes as needed.
-- **Bootstrapping IPC Connections**: It provides functions for starting new IPC connections, specifically binding generated client and server classes for an initial `interfaces::Init` interface (defined in [`src/interfaces/init.h`](../../src/interfaces/init.h)) to a UNIX socket. This initial interface has methods returning other interfaces that different Bitcoin Core modules use to communicate after the bootstrapping phase.
+- **Bootstrapping IPC Connections**: It provides functions for starting new IPC connections, specifically binding generated client and server classes for an initial `interfaces::Init` interface (defined in [`src/interfaces/init.h`](../../src/interfaces/init.h)) to a UNIX socket. This initial interface has methods returning other interfaces that different BGL Core modules use to communicate after the bootstrapping phase.
 - **Asynchronous I/O and Thread Management**: The library is also responsible for managing I/O and threading. Particularly, it ensures that IPC requests never block each other and that new threads on either side of a connection can always make client calls. It also manages worker threads on the server side of calls, ensuring that calls from the same client thread always execute on the same server thread (to avoid locking issues and support nested callbacks).
 
 ### Type Hooks in [`src/ipc/capnp/*-types.h`](../../src/ipc/capnp/)
@@ -124,13 +124,13 @@ Diagram showing generated source files and includes.
 ### Selection of Cap’n Proto
 The choice to use [Cap’n Proto](https://capnproto.org/) for IPC was primarily influenced by its support for passing object references and managing object lifetimes, which would have to be implemented manually with a framework that only supported plain requests and responses like [gRPC](https://grpc.io/). The support is especially helpful for passing callback objects like `std::function` and enabling bidirectional calls between processes.
 
-The choice to use an RPC framework at all instead of a custom protocol was necessitated by the size of Bitcoin Core internal interfaces which consist of around 150 methods that pass complex data structures and are called in complicated ways (in parallel, and from callbacks that can be nested and stored). Writing a custom protocol to wrap these complicated interfaces would be a lot more work, akin to writing a new RPC framework.
+The choice to use an RPC framework at all instead of a custom protocol was necessitated by the size of BGL Core internal interfaces which consist of around 150 methods that pass complex data structures and are called in complicated ways (in parallel, and from callbacks that can be nested and stored). Writing a custom protocol to wrap these complicated interfaces would be a lot more work, akin to writing a new RPC framework.
 
 ### Hiding IPC
 
 The IPC mechanism is deliberately isolated from the rest of the codebase so less code has to be concerned with IPC.
 
-Building Bitcoin Core with IPC support is optional, and node, wallet, and GUI code can be compiled to either run in the same process or separate processes. The build system also ensures Cap’n Proto library headers can only be used within the [`src/ipc/capnp/`](../../src/ipc/capnp/) directory, not in other parts of the codebase.
+Building BGL Core with IPC support is optional, and node, wallet, and GUI code can be compiled to either run in the same process or separate processes. The build system also ensures Cap’n Proto library headers can only be used within the [`src/ipc/capnp/`](../../src/ipc/capnp/) directory, not in other parts of the codebase.
 
 The libmultiprocess runtime is designed to place as few constraints as possible on IPC interfaces and to make IPC calls act like normal function calls. Method arguments, return values, and exceptions are automatically serialized and sent between processes. Object references and `std::function` arguments are tracked to allow invoked code to call back into invoking code at any time. And there is a 1:1 threading model where every client thread has a corresponding server thread responsible for executing incoming calls from that thread (there can be multiple calls from the same thread due to callbacks) without blocking, and holding the same thread-local variables and locks so behavior is the same whether IPC is used or not.
 
@@ -150,23 +150,23 @@ The currently defined IPC interfaces are unstable, and can change freely with no
 
 ## Security Considerations
 
-The integration of [Cap’n Proto](https://capnproto.org/) and [libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) into the Bitcoin Core architecture increases its potential attack surface. Cap’n Proto, being a complex and substantial new dependency, introduces potential sources of vulnerability, particularly through the creation of new UNIX sockets. The inclusion of libmultiprocess, while a smaller external dependency, also contributes to this risk. However, plans are underway to incorporate libmultiprocess as a git subtree, aligning it more closely with the project's well-reviewed internal libraries. While adopting these multiprocess features does introduce some risk, it's worth noting that they can be disabled, allowing builds without these new dependencies. This flexibility ensures that users can balance functionality with security considerations as needed.
+The integration of [Cap’n Proto](https://capnproto.org/) and [libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) into the BGL Core architecture increases its potential attack surface. Cap’n Proto, being a complex and substantial new dependency, introduces potential sources of vulnerability, particularly through the creation of new UNIX sockets. The inclusion of libmultiprocess, while a smaller external dependency, also contributes to this risk. However, plans are underway to incorporate libmultiprocess as a git subtree, aligning it more closely with the project's well-reviewed internal libraries. While adopting these multiprocess features does introduce some risk, it's worth noting that they can be disabled, allowing builds without these new dependencies. This flexibility ensures that users can balance functionality with security considerations as needed.
 
 ## Example Use Cases and Flows
 
 ### Retrieving a Block Hash
 
-Let’s walk through an example where the `bitcoin-wallet` process requests the hash of a block at a specific height from the `bitcoin-node` process. This example demonstrates the practical application of the IPC mechanism, specifically the interplay between C++ method calls and Cap’n Proto-generated RPC calls.
+Let’s walk through an example where the `BGL-wallet` process requests the hash of a block at a specific height from the `BGL-node` process. This example demonstrates the practical application of the IPC mechanism, specifically the interplay between C++ method calls and Cap’n Proto-generated RPC calls.
 
 <table><tr><td>
 
 ```mermaid
 sequenceDiagram
-    box "bitcoin-wallet process"
+    box "BGL-wallet process"
     participant WalletCode as Wallet code
     participant ChainClient as Generated Chain client class<br/>ProxyClient<messages::Chain>
     end
-    box "bitcoin-node process"
+    box "BGL-node process"
     participant ChainServer as Generated Chain server class<br/>ProxyServer<messages::Chain>
     participant LocalChain as Chain object<br/>node::ChainImpl
     end
@@ -183,7 +183,7 @@ sequenceDiagram
 <code>Chain::getBlockHash</code> call diagram
 </td></tr></table>
 
-1. **Initiation in bitcoin-wallet**
+1. **Initiation in BGL-wallet**
    - The wallet process calls the `getBlockHash` method on a `Chain` object. This method is defined as a virtual method in [`src/interfaces/chain.h`](../../src/interfaces/chain.h).
 
 2. **Translation to Cap’n Proto RPC**
@@ -191,38 +191,38 @@ sequenceDiagram
    - The client subclass is automatically generated by the `mpgen` tool from the [`chain.capnp`](https://github.com/ryanofsky/bitcoin/blob/pr/ipc/src/ipc/capnp/chain.capnp) file in [`src/ipc/capnp/`](../../src/ipc/capnp/).
 
 3. **Request Preparation and Dispatch**
-   - The `getBlockHash` method of the generated `Chain` client subclass in `bitcoin-wallet` populates a Cap’n Proto request with the `height` parameter, sends it to `bitcoin-node` process, and waits for a response.
+   - The `getBlockHash` method of the generated `Chain` client subclass in `BGL-wallet` populates a Cap’n Proto request with the `height` parameter, sends it to `BGL-node` process, and waits for a response.
 
-4. **Handling in bitcoin-node**
-   - Upon receiving the request, the Cap'n Proto dispatching code in the `bitcoin-node` process calls the `getBlockHash` method of the `Chain` [server class](#c-server-classes-in-generated-code).
+4. **Handling in BGL-node**
+   - Upon receiving the request, the Cap'n Proto dispatching code in the `BGL-node` process calls the `getBlockHash` method of the `Chain` [server class](#c-server-classes-in-generated-code).
    - The server class is automatically generated by the `mpgen` tool from the [`chain.capnp`](https://github.com/ryanofsky/bitcoin/blob/pr/ipc/src/ipc/capnp/chain.capnp) file in [`src/ipc/capnp/`](../../src/ipc/capnp/).
-   - The `getBlockHash` method of the generated `Chain` server subclass in `bitcoin-wallet` receives a Cap’n Proto request object with the `height` parameter, and calls the `getBlockHash` method on its local `Chain` object with the provided `height`.
-   - When the call returns, it encapsulates the return value in a Cap’n Proto response, which it sends back to the `bitcoin-wallet` process,
+   - The `getBlockHash` method of the generated `Chain` server subclass in `BGL-wallet` receives a Cap’n Proto request object with the `height` parameter, and calls the `getBlockHash` method on its local `Chain` object with the provided `height`.
+   - When the call returns, it encapsulates the return value in a Cap’n Proto response, which it sends back to the `BGL-wallet` process,
 
 5. **Response and Return**
-   - The `getBlockHash` method of the generated `Chain` client subclass in `bitcoin-wallet` which sent the request now receives the response.
+   - The `getBlockHash` method of the generated `Chain` client subclass in `BGL-wallet` which sent the request now receives the response.
    - It extracts the block hash value from the response, and returns it to the original caller.
 
 ## Future Enhancements
 
 Further improvements are possible such as:
 
-- Separating indexes from `bitcoin-node`, and running indexing code in separate processes (see [indexes: Stop using node internal types #24230](https://github.com/bitcoin/bitcoin/pull/24230)).
+- Separating indexes from `BGL-node`, and running indexing code in separate processes (see [indexes: Stop using node internal types #24230](https://github.com/bitcoin/bitcoin/pull/24230)).
 - Enabling wallet processes to listen for JSON-RPC requests on their own ports instead of needing the node process to listen and forward requests to them.
 - Automatically generating `.capnp` files from C++ interface definitions (see [Interface Definition Maintenance](#interface-definition-maintenance)).
 - Simplifying and stabilizing interfaces (see [Interface Stability](#interface-stability)).
 - Adding sandbox features, restricting subprocess access to resources and data (see [https://eklitzke.org/multiprocess-bitcoin](https://eklitzke.org/multiprocess-bitcoin)).
-- Using Cap'n Proto's support for [other languages](https://capnproto.org/otherlang.html), such as [Rust](https://github.com/capnproto/capnproto-rust), to allow code written in other languages to call Bitcoin Core C++ code, and vice versa (see [How to rustify libmultiprocess? #56](https://github.com/chaincodelabs/libmultiprocess/issues/56)).
+- Using Cap'n Proto's support for [other languages](https://capnproto.org/otherlang.html), such as [Rust](https://github.com/capnproto/capnproto-rust), to allow code written in other languages to call BGL Core C++ code, and vice versa (see [How to rustify libmultiprocess? #56](https://github.com/chaincodelabs/libmultiprocess/issues/56)).
 
 ## Conclusion
 
-This modularization represents an advancement in Bitcoin Core's architecture, offering enhanced security, flexibility, and maintainability. The project invites collaboration and feedback from the community.
+This modularization represents an advancement in BGL Core's architecture, offering enhanced security, flexibility, and maintainability. The project invites collaboration and feedback from the community.
 
 ## Appendices
 
 ### Glossary of Terms
 
-- **abstract class**: A class in C++ that consists of virtual functions. In the Bitcoin Core project, they define interfaces for inter-component communication.
+- **abstract class**: A class in C++ that consists of virtual functions. In the BGL Core project, they define interfaces for inter-component communication.
 
 - **asynchronous I/O**: A form of input/output processing that allows a program to continue other operations while a transmission is in progress.
 
@@ -232,11 +232,11 @@ This modularization represents an advancement in Bitcoin Core's architecture, of
 
 - **Cap’n Proto struct**: A structured data format used in Cap’n Proto, similar to structs in C++, for organizing and transporting data across different processes.
 
-- **client class (in generated code)**: A C++ class generated from a Cap’n Proto interface which inherits from a Bitcoin core abstract class, and implements each virtual method to send IPC requests to another process. (see also [components section](#c-client-subclasses-in-generated-code))
+- **client class (in generated code)**: A C++ class generated from a Cap’n Proto interface which inherits from a BGL Core abstract class, and implements each virtual method to send IPC requests to another process. (see also [components section](#c-client-subclasses-in-generated-code))
 
 - **IPC (inter-process communication)**: Mechanisms that enable processes to exchange requests and data.
 
-- **ipc::Exception class**: A class within Bitcoin Core's protocol-agnostic IPC code that is thrown by client class methods when there is an IPC error.
+- **ipc::Exception class**: A class within BGL Core's protocol-agnostic IPC code that is thrown by client class methods when there is an IPC error.
 
 - **libmultiprocess**: A custom library and code generation tool used for creating IPC interfaces and managing IPC connections.
 
@@ -246,9 +246,9 @@ This modularization represents an advancement in Bitcoin Core's architecture, of
 
 - **protocol-agnostic code**: Generic IPC code in [`src/ipc/`](../../src/ipc/) that does not rely on Cap’n Proto and could be used with other protocols. Distinct from code in [`src/ipc/capnp/`](../../src/ipc/capnp/) which relies on Cap’n Proto.
 
-- **RPC (remote procedure call)**: A protocol that enables a program to request a service from another program in a different address space or network. Bitcoin Core uses [JSON-RPC](https://en.wikipedia.org/wiki/JSON-RPC) for RPC.
+- **RPC (remote procedure call)**: A protocol that enables a program to request a service from another program in a different address space or network. BGL Core uses [JSON-RPC](https://en.wikipedia.org/wiki/JSON-RPC) for RPC.
 
-- **server class (in generated code)**: A C++ class generated from a Cap’n Proto interface which handles requests sent by a _client class_ in another process. The request handled by calling a local Bitcoin Core interface method, and the return values (if any) are sent back in a response. (see also: [components section](#c-server-classes-in-generated-code))
+- **server class (in generated code)**: A C++ class generated from a Cap’n Proto interface which handles requests sent by a _client class_ in another process. The request handled by calling a local BGL Core interface method, and the return values (if any) are sent back in a response. (see also: [components section](#c-server-classes-in-generated-code))
 
 - **unix socket**: Communication endpoint which is a filesystem path, used for exchanging data between processes running on the same host.
 


### PR DESCRIPTION
Updates the multiprocess design document so the architecture, executable names, and project wording match Bitgesell's current build names.

## Summary
- rename the design document from Multiprocess Bitcoin to Multiprocess BGL
- update `bitcoind` / `bitcoin-qt` / `bitcoin-node` / `bitcoin-wallet` / `bitcoin-gui` references to `BGLd` / `BGL-qt` / `BGL-node` / `BGL-wallet` / `BGL-gui`
- update BGL Core wording throughout the architecture, security, example flow, and glossary sections
- keep upstream Bitcoin Core and libmultiprocess links where they are historical or source references

## Verification
- `git diff --check`
- `rg -n "Multiprocess Bitcoin|Bitcoin Core|Bitcoin core|Bitcoin P2P|Bitcoin |bitcoin-node|bitcoin-wallet|bitcoin-gui|bitcoind|bitcoin-qt" doc/design/multiprocess.md` returns no matches
- confirmed BGL multiprocess executable names in `configure.ac`, `src/Makefile.am`, and `src/Makefile.qt.include`

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina