### PR TITLE
docs: update P2P bad ports BGL wording

### DIFF
--- a/doc/p2p-bad-ports.md
+++ b/doc/p2p-bad-ports.md
@@ -1,22 +1,22 @@
-When Bitcoin Core automatically opens outgoing P2P connections, it chooses
+When BGL Core automatically opens outgoing P2P connections, it chooses
 a peer (address and port) from its list of potential peers. This list is
 populated with unchecked data gossiped over the P2P network by other peers.
 
-A malicious actor may gossip an address:port where no Bitcoin node is listening,
-or one where a service is listening that is not related to the Bitcoin network.
-As a result, this service may occasionally get connection attempts from Bitcoin
+A malicious actor may gossip an address:port where no BGL node is listening,
+or one where a service is listening that is not related to the BGL network.
+As a result, this service may occasionally get connection attempts from BGL
 nodes.
 
 "Bad" ports are ones used by services which are usually not open to the public
-and usually require authentication. A connection attempt (by Bitcoin Core,
-trying to connect because it thinks there is a Bitcoin node on that
+and usually require authentication. A connection attempt (by BGL Core,
+trying to connect because it thinks there is a BGL node on that
 address:port) to such service may be considered a malicious action by an
 ultra-paranoid administrator. An example for such a port is 22 (ssh). On the
 other hand, connection attempts to public services that usually do not require
 authentication are unlikely to be considered a malicious action,
 e.g. port 80 (http).
 
-Below is a list of "bad" ports which Bitcoin Core avoids when choosing a peer to
+Below is a list of "bad" ports which BGL Core avoids when choosing a peer to
 connect to. If a node is listening on such a port, it will likely receive fewer
 incoming connections.
 


### PR DESCRIPTION
Updates the P2P bad ports note so the user-facing project and network wording refers to BGL Core and the BGL network instead of inherited Bitcoin Core text.

## Summary
- replace Bitcoin Core references with BGL Core where the document describes local P2P behavior
- replace Bitcoin node/network wording with BGL node/network wording
- keep upstream reference links in the further information section

## Verification
- `git diff --check`
- `rg -n "Bitcoin Core|Bitcoin node|Bitcoin network|Bitcoin nodes|Bitcoin " doc/p2p-bad-ports.md` returns no matches

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina