### PR TITLE
docs: update descriptor wallet BGL wording

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -157,7 +157,7 @@ wallets and PSBTs, as well as a signing flow, see [this functional test](/test/f
 Disclaimers: It is important to note that this example serves as a quick-start and is kept basic for readability. A downside of the approach
 outlined here is that each participant must maintain (and backup) two separate wallets: a signer and the corresponding multisig.
 It should also be noted that privacy best-practices are not "by default" here - participants should take care to only use the signer to sign
-transactions related to the multisig. Lastly, it is not recommended to use anything other than a Bitcoin Core descriptor wallet to serve as your
+transactions related to the multisig. Lastly, it is not recommended to use anything other than a BGL Core descriptor wallet to serve as your
 signer(s). Other wallets, whether hardware or software, likely impose additional checks and safeguards to prevent users from signing transactions that
 could lead to loss of funds, or are deemed security hazards. Conforming to various 3rd-party checks and verifications is not in the scope of this example.
 


### PR DESCRIPTION
Updates the descriptors documentation so the multisig quick-start recommendation points readers to a BGL Core descriptor wallet instead of inherited Bitcoin Core wording.

## Summary
- update the multisig descriptor wallet recommendation from Bitcoin Core to BGL Core
- keep the surrounding descriptor and PSBT guidance unchanged

## Verification
- `git diff --check`
- `rg -n "Bitcoin Core descriptor wallet" doc/descriptors.md` returns no matches

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina