### PR TITLE
docs: fix BGL-wallet manpage title

### DIFF
--- a/doc/man/BGL-wallet.1
+++ b/doc/man/BGL-wallet.1
@@ -1,5 +1,5 @@
 .TH BGL-WALLET "1"
 .SH NAME
-bitcoin-wallet \- manual page for bitcoin-wallet
+BGL-wallet \- manual page for BGL-wallet
 
 This is a placeholder file. Please follow the instructions in \fIcontrib/devtools/README.md\fR to generate the manual pages after a release.


### PR DESCRIPTION
Fixes the BGL wallet manpage placeholder so its NAME section matches the Bitgesell executable name.

## Summary
- replace inherited `bitcoin-wallet` text with `BGL-wallet` in `doc/man/BGL-wallet.1`

## Verification
- `git diff --check`
- `rg -n "bitcoin-wallet|bitcoin" doc/man/BGL-wallet.1` returns no matches

## Bounty
Related to #32.

Payout preference: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
PayPal fallback: https://paypal.me/Jeremytsangchina