### PR TITLE
docs: update small networking BGL references

### DIFF
--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -3,7 +3,7 @@ Reduce Traffic
 
 Some node operators need to deal with bandwidth caps imposed by their ISPs.
 
-By default, Bitcoin Core allows up to 125 connections to different peers, 11 of
+By default, BGL Core allows up to 125 connections to different peers, 11 of
 which are outbound. You can therefore, have at most 114 inbound connections.
 Of the 11 outbound peers, there can be 8 full-relay connections, 2
 block-relay-only ones and occasionally 1 short-lived feeler or an extra block-relay-only connection.

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -25,7 +25,7 @@ CLI `-addrinfo` returns the number of addresses known to your node per
 network. This can be useful to see how many onion peers your node knows,
 e.g. for `-onlynet=onion`.
 
-You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run `bitcoin-cli help getnodeaddresses` for details.
+You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run `BGL-cli help getnodeaddresses` for details.
 
 ## 1. Run BGL Core behind a Tor proxy
 

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -91,7 +91,7 @@ For instance:
 Each PUB notification has a topic and body, where the header
 corresponds to the notification type. For instance, for the
 notification `-zmqpubhashtx` the topic is `hashtx` (no null
-terminator). These options can also be provided in bitcoin.conf.
+terminator). These options can also be provided in BGL.conf.
 
 The topics are:
 


### PR DESCRIPTION
## Issue
Addresses part of #32 by updating remaining small networking documentation references from upstream Bitcoin names to Bitgesell names.

## Summary
- Use `BGL-cli` in the Tor document's `getnodeaddresses` example.
- Refer to `BGL Core` in the traffic reduction guide.
- Refer to `BGL.conf` in the ZMQ configuration note.

## Verification
- `git diff --check`
- `rg -n "bitcoin-cli|Bitcoin Core|bitcoin\.conf" doc/tor.md doc/reduce-traffic.md doc/zmq.md` (no matches)

## Bounty payout
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal: `https://paypal.me/Jeremytsangchina`