### PR TITLE
docs: update ASMap BGL reference

### DIFF
--- a/contrib/asmap/README.md
+++ b/contrib/asmap/README.md
@@ -2,7 +2,7 @@
 
 Tool for performing various operations on textual and binary asmap files,
 particularly encoding/compressing the raw data to the binary format that can
-be used in Bitcoin Core with the `-asmap` option.
+be used in BGL Core with the `-asmap` option.
 
 Example usage:
 ```


### PR DESCRIPTION
## Issue
Addresses part of #32 by updating the ASMap helper documentation to use the Bitgesell project name.

## Summary
- Refer to the `-asmap` option as being used in `BGL Core` instead of `Bitcoin Core`.

## Verification
- `git diff --check`
- `rg -n "Bitcoin Core" contrib/asmap/README.md` (no matches)

## Bounty payout
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal: `https://paypal.me/Jeremytsangchina`