### PR TITLE
docs: update Guix README BGL references

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -57,7 +57,7 @@ and examples](#common-guix-build-invocation-patterns-and-examples) section below
 before starting a build. For a full list of customization options, see the
 [recognized environment variables][env-vars-list] section.*
 
-To build Bitcoin Core reproducibly with all default options, invoke the
+To build BGL Core reproducibly with all default options, invoke the
 following from the top of a clean repository:
 
 ```sh
@@ -80,7 +80,7 @@ crucial differences:
     * _**DETACHED_SIGS_REPO**_
 
       Set the directory where detached codesignatures can be found for the current
-      Bitcoin Core version being built.
+      BGL Core version being built.
 
       _REQUIRED environment variable_
 


### PR DESCRIPTION
## Issue
Addresses part of #32 by aligning remaining project-name references in the Guix README.

## Summary
- Refer to reproducible builds as BGL Core builds.
- Refer to the current BGL Core version in the detached signatures description.

## Verification
- `git diff --check`
- `rg -n "Bitcoin Core" contrib/guix/README.md` (no matches)

## Bounty payout
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal: `https://paypal.me/Jeremytsangchina`