### PR TITLE
docs: update release notes template for BGL

### DIFF
--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -5,40 +5,40 @@ for the process.*
 *version* Release Notes Draft
 ===============================
 
-Bitcoin Core version *version* is now available from:
+BGL Core version *version* is now available from:
 
-  <https://bitcoincore.org/bin/bitcoin-core-*version*/>
+  <https://bitgesell.ca/en/download/>
 
 This release includes new features, various bug fixes and performance
 improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
-  <https://github.com/bitcoin/bitcoin/issues>
+  <https://github.com/BitgesellOfficial/bitgesell/issues>
 
-To receive security and update notifications, please subscribe to:
+To receive security and update notifications, please follow the official project site:
 
-  <https://bitcoincore.org/en/list/announcements/join/>
+  <https://bitgesell.ca/>
 
 How to Upgrade
 ==============
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes in some cases), then run the
-installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
-or `bitcoind`/`bitcoin-qt` (on Linux).
+installer (on Windows) or just copy over `/Applications/BGL-Qt` (on macOS)
+or `BGLd`/`BGL-qt` (on Linux).
 
-Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+Upgrading directly from a version of BGL Core that has reached its EOL is
 possible, but it might take some time if the data directory needs to be migrated. Old
-wallet versions of Bitcoin Core are generally supported.
+wallet versions of BGL Core are generally supported.
 
 Compatibility
 ==============
 
-Bitcoin Core is supported and extensively tested on operating systems
-using the Linux Kernel 3.17+, macOS 11.0+, and Windows 7 and newer. Bitcoin
-Core should also work on most other Unix-like systems but is not as
-frequently tested on them. It is not recommended to use Bitcoin Core on
+BGL Core is supported and extensively tested on operating systems
+using the Linux Kernel 3.17+, macOS 11.0+, and Windows 7 and newer. BGL Core
+should also work on most other Unix-like systems but is not as
+frequently tested on them. It is not recommended to use BGL Core on
 unsupported systems.
 
 Notable changes


### PR DESCRIPTION
## Issue
Addresses part of #32 by updating the empty release notes template for Bitgesell/BGL releases.

## Summary
- Replace upstream Bitcoin Core release boilerplate with BGL Core wording.
- Point the template to Bitgesell download, project site, and GitHub issue tracker links.
- Update macOS/Linux application and binary names to `BGL-Qt`, `BGLd`, and `BGL-qt`.

## Verification
- `git diff --check`
- `rg -n "Bitcoin Core|Bitcoin-Qt|Bitcoin Qt|bitcoind|bitcoin-qt|bitcoincore\.org|github.com/bitcoin/bitcoin/issues" doc/release-notes-empty-template.md` (no matches)

## Bounty payout
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal: `https://paypal.me/Jeremytsangchina`