### PR TITLE
test: update Qt test BGL comments

### DIFF
--- a/src/qt/test/optiontests.cpp
+++ b/src/qt/test/optiontests.cpp
@@ -105,8 +105,8 @@ void OptionTests::parametersInteraction()
 {
     // Test that the bug https://github.com/bitcoin-core/gui/issues/567 does not resurface.
     // It was fixed via https://github.com/bitcoin-core/gui/pull/568.
-    // With fListen=false in ~/.config/Bitcoin/Bitcoin-Qt.conf and all else left as default,
-    // bitcoin-qt should set both -listen and -listenonion to false and start successfully.
+    // With fListen=false in ~/.config/BGL/BGL-Qt.conf and all else left as default,
+    // BGL-qt should set both -listen and -listenonion to false and start successfully.
     gArgs.LockSettings([&](common::Settings& s) {
         s.forced_settings.erase("listen");
         s.forced_settings.erase("listenonion");

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -266,9 +266,9 @@ public:
 //
 // This also requires overriding the default minimal Qt platform:
 //
-//     QT_QPA_PLATFORM=xcb     src/qt/test/test_bitcoin-qt  # Linux
-//     QT_QPA_PLATFORM=windows src/qt/test/test_bitcoin-qt  # Windows
-//     QT_QPA_PLATFORM=cocoa   src/qt/test/test_bitcoin-qt  # macOS
+//     QT_QPA_PLATFORM=xcb     src/qt/test/test_BGL-qt  # Linux
+//     QT_QPA_PLATFORM=windows src/qt/test/test_BGL-qt  # Windows
+//     QT_QPA_PLATFORM=cocoa   src/qt/test/test_BGL-qt  # macOS
 void TestGUI(interfaces::Node& node, const std::shared_ptr<CWallet>& wallet)
 {
     // Create widgets for sending coins and listing transactions.


### PR DESCRIPTION
## Issue
Addresses part of #32 by aligning Qt test comments with the BGL application names.

## Summary
- Update the QSettings comment path from the old Bitcoin Qt path to `~/.config/BGL/BGL-Qt.conf`.
- Update manual Qt wallet test examples to invoke `test_BGL-qt`.
- Leave upstream regression links and copyright headers unchanged.

## Verification
- `git diff --check`
- `rg -n "~/.config/Bitcoin|Bitcoin-Qt|bitcoin-qt|test_bitcoin-qt" src/qt/test/optiontests.cpp src/qt/test/wallettests.cpp` (no matches)

## Bounty payout
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal: `https://paypal.me/Jeremytsangchina`