### PR TITLE
qt: update help URI text for BGL

### DIFF
--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -57,7 +57,7 @@ HelpMessageDialog::HelpMessageDialog(QWidget *parent, bool about) :
     } else {
         setWindowTitle(tr("Command-line options"));
         QString header = "Usage: BGL-qt [command-line options] [URI]\n\n"
-                         "Optional URI is a Bitcoin address in BIP21 URI format.\n";
+                         "Optional URI is a BGL address in BIP21 URI format.\n";
         QTextCursor cursor(ui->helpMessage->document());
         cursor.insertText(version);
         cursor.insertBlock();


### PR DESCRIPTION
## Issue
Addresses part of #32 by correcting a user-facing Qt help string for BGL.

## Summary
- Change the optional URI help text from `Bitcoin address` to `BGL address` in the BGL-qt command-line options dialog.

## Verification
- `git diff --check`
- `rg -n "Bitcoin address" src/qt/utilitydialog.cpp` (no matches)

## Bounty payout
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal: `https://paypal.me/Jeremytsangchina`