### PR TITLE
docs: update core API comments for BGL

### DIFF
--- a/src/addresstype.h
+++ b/src/addresstype.h
@@ -126,7 +126,7 @@ public:
  *  * WitnessV0KeyHash: TxoutType::WITNESS_V0_KEYHASH destination (P2WPKH address)
  *  * WitnessV1Taproot: TxoutType::WITNESS_V1_TAPROOT destination (P2TR address)
  *  * WitnessUnknown: TxoutType::WITNESS_UNKNOWN destination (P2W??? address)
- *  A CTxDestination is the internal data type encoded in a bitcoin address
+ *  A CTxDestination is the internal data type encoded in a BGL address
  */
 using CTxDestination = std::variant<CNoDestination, PubKeyDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessV1Taproot, WitnessUnknown>;
 
@@ -146,7 +146,7 @@ bool IsValidDestination(const CTxDestination& dest);
 bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet);
 
 /**
- * Generate a Bitcoin scriptPubKey for the given CTxDestination. Returns a P2PKH
+ * Generate a BGL scriptPubKey for the given CTxDestination. Returns a P2PKH
  * script for a CKeyID destination, a P2SH script for a CScriptID, and an empty
  * script for CNoDestination.
  */

--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -21,7 +21,7 @@ private:
     //! The command which handles interaction with the external signer.
     std::string m_command;
 
-    //! Bitcoin mainnet, testnet, etc
+    //! BGL mainnet, testnet, etc
     std::string m_chain;
 
     std::string NetworkArg() const;

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -71,7 +71,7 @@ std::vector<CKeyID> GetAffectedKeys(const CScript& spk, const SigningProvider& p
  * are sets of keys that have not yet been used to provide addresses or receive
  * change.
  *
- * The Bitcoin Core wallet was originally a collection of unrelated private
+ * The BGL Core wallet was originally a collection of unrelated private
  * keys with their associated addresses. If a non-HD wallet generated a
  * key/address, gave that address out and then restored a backup from before
  * that key's generation, then any funds sent to that address would be


### PR DESCRIPTION
## Issue
Addresses part of #32 by updating stale core API comments to use BGL names.

## Summary
- Update address type comments from bitcoin/BTC wording to BGL wording.
- Update external signer chain comment to refer to BGL networks.
- Update wallet keypool history comment to refer to BGL Core.
- Comment-only change; no runtime behavior changed.

## Verification
- `git diff --check`
- `rg -n "Bitcoin mainnet|bitcoin address|Bitcoin scriptPubKey|Bitcoin Core wallet" src/external_signer.h src/addresstype.h src/wallet/scriptpubkeyman.h` (no matches)

## Bounty payout
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal: `https://paypal.me/Jeremytsangchina`