### PR TITLE
test: update functional framework BGL comments

### DIFF
--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -244,7 +244,7 @@ def from_binary(cls, stream):
         assert len(stream.read()) == 0
     return obj
 
-# Objects that map to bitcoind objects, which can be serialized/deserialized
+# Objects that map to BGLd objects, which can be serialized/deserialized
 
 
 class CAddress:
@@ -421,7 +421,7 @@ class CBlockLocator:
 
     def serialize(self):
         r = b""
-        r += (0).to_bytes(4, "little", signed=True)  # Bitcoin Core ignores the version field. Set it to 0.
+        r += (0).to_bytes(4, "little", signed=True)  # BGL Core ignores the version field. Set it to 0.
         r += ser_uint256_vector(self.vHave)
         return r
 
@@ -1149,7 +1149,7 @@ class msg_version:
         self.nStartingHeight = int.from_bytes(f.read(4), "little", signed=True)
 
         # Relay field is optional for version 70001 onwards
-        # But, unconditionally check it to match behaviour in bitcoind
+        # But, unconditionally check it to match behaviour in BGLd
         self.relay = int.from_bytes(f.read(1), "little")  # f.read(1) may return an empty b''
 
     def serialize(self):

--- a/test/functional/test_framework/p2p.py
+++ b/test/functional/test_framework/p2p.py
@@ -4,9 +4,9 @@
 # Copyright (c) 2010-2022 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test objects for interacting with a bitcoind node over the p2p protocol.
+"""Test objects for interacting with a BGLd node over the p2p protocol.
 
-The P2PInterface objects interact with the bitcoind nodes under test using the
+The P2PInterface objects interact with the BGLd nodes under test using the
 node's p2p interface. They can be used to send messages to the node, and
 callbacks can be registered that execute when messages are received from the
 node. Messages are sent to/received from the node on an asyncio event loop.
@@ -431,7 +431,7 @@ class P2PConnection(asyncio.Protocol):
 
 
 class P2PInterface(P2PConnection):
-    """A high-level P2P interface class for communicating with a Bitcoin node.
+    """A high-level P2P interface class for communicating with a BGL node.
 
     This class provides high-level callbacks for processing P2P message
     payloads, as well as convenience methods for interacting with the

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -719,7 +719,7 @@ class BGLTestFramework(metaclass=BGLTestMetaClass):
         return blocks
 
     def create_outpoints(self, node, *, outputs):
-        """Send funds to a given list of `{address: amount}` targets using the bitcoind
+        """Send funds to a given list of `{address: amount}` targets using the BGLd
         wallet and return the corresponding outpoints as a list of dictionaries
         `[{"txid": txid, "vout": vout1}, {"txid": txid, "vout": vout2}, ...]`.
         The result can be used to specify inputs for RPCs like `createrawtransaction`,
@@ -920,7 +920,7 @@ class BGLTestFramework(metaclass=BGLTestMetaClass):
             raise SkipTest("bcc python module not available")
 
     def skip_if_no_BGLd_tracepoints(self):
-        """Skip the running test if bitcoind has not been compiled with USDT tracepoint support."""
+        """Skip the running test if BGLd has not been compiled with USDT tracepoint support."""
         if not self.is_usdt_compiled():
             raise SkipTest("BGLd has not been built with USDT tracepoints enabled.")
 
@@ -941,7 +941,7 @@ class BGLTestFramework(metaclass=BGLTestMetaClass):
             raise SkipTest("not on a POSIX system")
 
     def skip_if_no_BGLd_zmq(self):
-        """Skip the running test if bitcoind has not been compiled with zmq support."""
+        """Skip the running test if BGLd has not been compiled with zmq support."""
         if not self.is_zmq_compiled():
             raise SkipTest("BGLd has not been built with zmq enabled.")
 
@@ -971,7 +971,7 @@ class BGLTestFramework(metaclass=BGLTestMetaClass):
             raise SkipTest("BGL-wallet has not been compiled")
 
     def skip_if_no_BGL_util(self):
-        """Skip the running test if bitcoin-util has not been compiled."""
+        """Skip the running test if BGL-util has not been compiled."""
         if not self.is_BGL_util_compiled():
             raise SkipTest("BGL-util has not been compiled")
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -224,7 +224,7 @@ class TestNode():
 
         self.use_v2transport = "-v2transport=1" in extra_args or (self.default_to_v2 and "-v2transport=0" not in extra_args)
 
-        # Add a new stdout and stderr file each time bitcoind is started
+        # Add a new stdout and stderr file each time BGLd is started
         if stderr is None:
             stderr = tempfile.NamedTemporaryFile(dir=self.stderr_dir, delete=False)
         if stdout is None:


### PR DESCRIPTION
## Issue
Addresses part of #32 by updating functional test framework comments and docstrings to use BGL names.

## Summary
- Replace stale `bitcoind`/`Bitcoin node` wording with `BGLd`/`BGL node` in test framework docs.
- Update comments for serialized objects, version-field behavior, stdout/stderr handling, and utility availability.
- Comment/docstring-only change; no test behavior changed.

## Verification
- `git diff --check`
- `rg -n "bitcoind|Bitcoin node|Bitcoin Core ignores|bitcoin-util" test/functional/test_framework/p2p.py test/functional/test_framework/test_framework.py test/functional/test_framework/test_node.py test/functional/test_framework/messages.py` (no matches)

## Bounty payout
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal: `https://paypal.me/Jeremytsangchina`