### PR TITLE
qt: fix BGL autostart naming

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -138,7 +138,7 @@ void AddButtonShortcut(QAbstractButton* button, const QKeySequence& shortcut)
 
 bool parseBGLURI(const QUrl &uri, SendCoinsRecipient *out)
 {
-    // return if URI is not valid or is no bitcoin: URI
+    // return if URI is not valid or is no BGL: URI
     if(!uri.isValid() || uri.scheme() != QString("bgl"))
         return false;
 
@@ -437,7 +437,7 @@ bool openBGLConf()
 
     configFile.close();
 
-    /* Open bitcoin.conf with the associated application */
+    /* Open BGL.conf with the associated application */
     bool res = QDesktopServices::openUrl(QUrl::fromLocalFile(PathToQString(pathConfig)));
 #ifdef Q_OS_MACOS
     // Workaround for macOS-specific behavior; see #15409.
@@ -509,7 +509,7 @@ fs::path static StartupShortcutPath()
 
 bool GetStartOnSystemStartup()
 {
-    // check for Bitcoin*.lnk
+    // check for BGL*.lnk
     return fs::exists(StartupShortcutPath());
 }
 
@@ -584,7 +584,7 @@ fs::path static GetAutostartFilePath()
 {
     ChainType chain = gArgs.GetChainType();
     if (chain == ChainType::MAIN)
-        return GetAutostartDir() / "bitcoin.desktop";
+        return GetAutostartDir() / "BGL.desktop";
     return GetAutostartDir() / fs::u8path(strprintf("BGL-%s.desktop", ChainTypeToString(chain)));
 }
 
@@ -626,7 +626,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
         if (!optionFile.good())
             return false;
         ChainType chain = gArgs.GetChainType();
-        // Write a bitcoin.desktop file to the autostart directory:
+        // Write a BGL.desktop file to the autostart directory:
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
         if (chain == ChainType::MAIN)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -52,7 +52,7 @@ class QUrl;
 class QWidget;
 QT_END_NAMESPACE
 
-/** Utility functions used by the Bitcoin Qt UI.
+/** Utility functions used by the BGL Qt UI.
  */
 namespace GUIUtil
 {
@@ -77,7 +77,7 @@ namespace GUIUtil
      */
     void AddButtonShortcut(QAbstractButton* button, const QKeySequence& shortcut);
 
-    // Parse "bitcoin:" URI into recipient object, return true on successful parsing
+    // Parse "BGL:" URI into recipient object, return true on successful parsing
     bool parseBGLURI(const QUrl &uri, SendCoinsRecipient *out);
     bool parseBGLURI(QString uri, SendCoinsRecipient *out);
     QString formatBGLURI(const SendCoinsRecipient &info);

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -259,8 +259,8 @@ bool Intro::showIfNeeded(bool& did_show_intro, int64_t& prune_MiB)
         settings.setValue("fReset", false);
     }
     /* Only override -datadir if different from the default, to make it possible to
-     * override -datadir in the bitcoin.conf file in the default data directory
-     * (to be consistent with bitcoind behavior)
+     * override -datadir in the BGL.conf file in the default data directory
+     * (to be consistent with BGLd behavior)
      */
     if(dataDir != GUIUtil::getDefaultDataDirectory()) {
         gArgs.SoftSetArg("-datadir", fs::PathToString(GUIUtil::QStringToPath(dataDir))); // use OS locale for path setting


### PR DESCRIPTION
## Summary
- Fixes the Qt Linux autostart filename for mainnet from `bitcoin.desktop` to `BGL.desktop`.
- Updates nearby Qt comments and URI/config wording to use BGL naming consistently.

## Verification
- `git diff --check -- src/qt/guiutil.cpp src/qt/guiutil.h src/qt/intro.cpp`
- `rg -n -- "bitcoin.desktop" src/qt/guiutil.cpp src/qt/guiutil.h src/qt/intro.cpp`
- `rg -n -- "bitcoin.conf" src/qt/guiutil.cpp src/qt/guiutil.h src/qt/intro.cpp`
- `rg -n -- "bitcoind behavior" src/qt/guiutil.cpp src/qt/guiutil.h src/qt/intro.cpp`
- `rg -n -- "Bitcoin Qt UI" src/qt/guiutil.cpp src/qt/guiutil.h src/qt/intro.cpp`
- `rg -n -- "bitcoin: URI" src/qt/guiutil.cpp src/qt/guiutil.h src/qt/intro.cpp`

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal `https://paypal.me/Jeremytsangchina`.