### PR TITLE
contrib: use BGL-cli in signet miner

### DIFF
--- a/contrib/signet/miner
+++ b/contrib/signet/miner
@@ -471,7 +471,7 @@ def do_calibrate(args):
 
 def bitcoin_cli(basecmd, args, **kwargs):
     cmd = basecmd + ["-signet"] + args
-    logging.debug("Calling bitcoin-cli: %r", cmd)
+    logging.debug("Calling BGL-cli: %r", cmd)
     out = subprocess.run(cmd, stdout=subprocess.PIPE, **kwargs, check=True).stdout
     if isinstance(out, bytes):
         out = out.decode('utf8')
@@ -479,7 +479,7 @@ def bitcoin_cli(basecmd, args, **kwargs):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--cli", default="bitcoin-cli", type=str, help="bitcoin-cli command")
+    parser.add_argument("--cli", default="BGL-cli", type=str, help="BGL-cli command")
     parser.add_argument("--debug", action="store_true", help="Print debugging info")
     parser.add_argument("--quiet", action="store_true", help="Only print warnings/errors")
 


### PR DESCRIPTION
## Summary
- Changes the signet miner's default RPC CLI command from `bitcoin-cli` to `BGL-cli`.
- Updates the related debug/help text so the miner matches the Bitgesell executable naming already used by `getcoins.py`.

## Verification
- `git diff --check -- contrib/signet/miner`
- `rg -n -- "bitcoin-cli" contrib/signet/miner` returned no matches
- `python -m py_compile contrib/signet/miner`

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal `https://paypal.me/Jeremytsangchina`.