### PR TITLE
guix: codesign BGL Qt app bundle

### DIFF
--- a/contrib/guix/libexec/codesign.sh
+++ b/contrib/guix/libexec/codesign.sh
@@ -83,7 +83,7 @@ mkdir -p "$DISTSRC"
             ;;
         *darwin*)
             # Apply detached codesignatures to dist/ (in-place)
-            signapple apply dist/Bitcoin-Qt.app codesignatures/osx/dist
+            signapple apply dist/BGL-Qt.app codesignatures/osx/dist
 
             # Make a .zip from dist/
             cd dist/


### PR DESCRIPTION
## Summary
- Fixes the Guix macOS codesign path to apply detached signatures to `dist/BGL-Qt.app`.
- The repository's macOS app bundle is `BGL-Qt.app`, so the old `dist/Bitcoin-Qt.app` path would miss the generated bundle.

## Verification
- `git diff --cached --check -- contrib/guix/libexec/codesign.sh`
- `cmd /c "git show :contrib/guix/libexec/codesign.sh | bash -n"`
- Checked that `Bitcoin-Qt.app` is no longer present in the staged script.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal `https://paypal.me/Jeremytsangchina`.