### PR TITLE
build: register BGL URI in Windows installer

### DIFF
--- a/share/setup.nsi
+++ b/share/setup.nsi
@@ -106,10 +106,10 @@ Section -post SEC0001
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1
-    WriteRegStr HKCR "bitcoin" "URL Protocol" ""
-    WriteRegStr HKCR "bitcoin" "" "URL:BGL"
-    WriteRegStr HKCR "bitcoin\DefaultIcon" "" $INSTDIR\BGL-qt
-    WriteRegStr HKCR "bitcoin\shell\open\command" "" '"$INSTDIR\BGL-qt" "%1"'
+    WriteRegStr HKCR "BGL" "URL Protocol" ""
+    WriteRegStr HKCR "BGL" "" "URL:BGL"
+    WriteRegStr HKCR "BGL\DefaultIcon" "" $INSTDIR\BGL-qt
+    WriteRegStr HKCR "BGL\shell\open\command" "" '"$INSTDIR\BGL-qt" "%1"'
 SectionEnd
 
 # Macro for selecting uninstaller sections
@@ -149,7 +149,7 @@ Section -un.post UNSEC0001
     DeleteRegValue HKCU "${REGKEY}" Path
     DeleteRegKey /IfEmpty HKCU "${REGKEY}\Components"
     DeleteRegKey /IfEmpty HKCU "${REGKEY}"
-    DeleteRegKey HKCR "bitcoin"
+    DeleteRegKey HKCR "BGL"
     RmDir /REBOOTOK $SMPROGRAMS\$StartMenuGroup
     RmDir /REBOOTOK $INSTDIR
     Push $R0


### PR DESCRIPTION
## Summary
- Updates the checked-in Windows NSIS script to register the `BGL` URL protocol instead of the stale `bitcoin` protocol.
- Updates the matching uninstall registry cleanup entry.

## Verification
- `git diff --check -- share/setup.nsi`
- Checked `share/setup.nsi` has no remaining `HKCR "bitcoin"` registration entries.
- Checked `share/setup.nsi` contains the expected `HKCR "BGL"` registration and cleanup entries.
- `makensis` is not installed in this local environment, so I could not run a full installer build here.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal `https://paypal.me/Jeremytsangchina`.