### PR TITLE
util: update runtime diagnostics to BGL

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -100,7 +100,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, boo
         std::vector<uint256> old_heads = GetHeadBlocks();
         if (old_heads.size() == 2) {
             if (old_heads[0] != hashBlock) {
-                LogPrintLevel(BCLog::COINDB, BCLog::Level::Error, "The coins database detected an inconsistent state, likely due to a previous crash or shutdown. You will need to restart bitcoind with the -reindex-chainstate or -reindex configuration option.\n");
+                LogPrintLevel(BCLog::COINDB, BCLog::Level::Error, "The coins database detected an inconsistent state, likely due to a previous crash or shutdown. You will need to restart BGLd with the -reindex-chainstate or -reindex configuration option.\n");
             }
             assert(old_heads[0] == hashBlock);
             old_tip = old_heads[1];

--- a/src/util/exception.cpp
+++ b/src/util/exception.cpp
@@ -23,7 +23,7 @@ static std::string FormatException(const std::exception* pex, std::string_view t
     char pszModule[MAX_PATH] = "";
     GetModuleFileNameA(nullptr, pszModule, sizeof(pszModule));
 #else
-    const char* pszModule = "bitcoin";
+    const char* pszModule = "BGL";
 #endif
     if (pex)
         return strprintf(


### PR DESCRIPTION
## Summary
- Updates runtime diagnostic text to use Bitgesell naming.
- Changes the coins DB recovery log from `restart bitcoind` to `restart BGLd`.
- Changes the non-Windows fallback exception module name from `bitcoin` to `BGL`.

## Verification
- `git diff --check -- src/txdb.cpp src/util/exception.cpp`
- Checked target files for `restart bitcoind`, `pszModule = "bitcoin"`, `restart BGLd`, and `pszModule = "BGL"`.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal `https://paypal.me/Jeremytsangchina`.