### PR TITLE
build: ignore Bitgesell build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,15 +116,15 @@ src/qt/BGL-qt.includes
 *.qm
 Makefile
 !depends/Makefile
-src/qt/bitcoin-qt
-Bitcoin-Qt.app
+src/qt/BGL-qt
+BGL-Qt.app
 
 # Qt Creator
 Makefile.am.user
 
 # Unit-tests
 Makefile.test
-bitcoin-qt_test
+src/qt/test/test_BGL-qt
 
 # Resources cpp
 qrc_*.cpp
@@ -140,7 +140,7 @@ releases
 *.gcno
 *.gcda
 /*.info
-test_bitcoin.coverage/
+test_BGL.coverage/
 total.coverage/
 fuzz.coverage/
 coverage_percent.txt


### PR DESCRIPTION
## Summary
- Updates `.gitignore` from upstream Bitcoin artifact names to Bitgesell build outputs.
- Ignores the Bitgesell Qt binary/app bundle, Qt test binary, and `test_BGL.coverage/` coverage output.

## Verification
- `git diff --check -- .gitignore`
- Cross-checked the ignored names against `Makefile.am`, `configure.ac`, and `src/Makefile.qttest.include`.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina