### PR TITLE
github: update issue templates for Bitgesell

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,10 +5,10 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## This issue tracker is only for technical issues related to Bitcoin Core.
+        ## This issue tracker is only for technical issues related to Bitgesell Core.
 
-        * General bitcoin questions and/or support requests should use Bitcoin StackExchange at https://bitcoin.stackexchange.com.
-        * For reporting security issues, please read instructions at https://bitcoincore.org/en/contact/.
+        * General Bitgesell questions and/or support requests should use the project homepage at https://bitgesell.ca.
+        * For reporting security issues, please read the repository security policy at https://github.com/BitgesellOfficial/bitgesell/blob/master/SECURITY.md.
         * If the node is "stuck" during sync or giving "block checksum mismatch" errors, please ensure your hardware is stable by running `memtest` and observe CPU temperature with a load-test tool such as `linpack` before creating an issue.
 
         ----
@@ -50,14 +50,14 @@ body:
       description: |
         Please copy and paste any relevant log output or attach a debug log file.
 
-        You can find the debug.log in your [data dir.](https://github.com/bitcoin/bitcoin/blob/master/doc/files.md#data-directory-location)
+        You can find the debug.log in your [data dir.](https://github.com/BitgesellOfficial/bitgesell/blob/master/doc/files.md#data-directory-location)
 
         Please be aware that the debug log might contain personally identifying information.
     validations:
       required: false
   - type: dropdown
     attributes:
-      label: How did you obtain Bitcoin Core
+      label: How did you obtain Bitgesell Core?
       multiple: false
       options:
         - Compiled from source
@@ -69,8 +69,8 @@ body:
   - type: input
     id: core-version
     attributes:
-      label: What version of Bitcoin Core are you using?
-      description: Run `bitcoind --version` or in Bitcoin-QT use `Help > About Bitcoin Core`
+      label: What version of Bitgesell Core are you using?
+      description: Run `BGLd --version` or in BGL-Qt use `Help > About Bitgesell Core`
       placeholder: e.g. v24.0.1 or master@e1bf547
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Bitcoin Core Security Policy
-    url: https://github.com/bitcoin/bitcoin/blob/master/SECURITY.md
+  - name: Bitgesell Security Policy
+    url: https://github.com/BitgesellOfficial/bitgesell/blob/master/SECURITY.md
     about: View security policy
-  - name: Bitcoin Core Developers
-    url: https://bitcoincore.org
-    about: Bitcoin Core homepage
+  - name: Bitgesell
+    url: https://bitgesell.ca
+    about: Bitgesell homepage

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -28,9 +28,9 @@ body:
     id: useful-skills
     attributes:
       label: Useful Skills
-      description: For example, “`std::thread`”, “Qt5 GUI and async GUI design” or “basic understanding of Bitcoin mining and the Bitcoin Core RPC interface”.
+      description: For example, `std::thread`, Qt5 GUI and async GUI design, or basic understanding of Bitgesell mining and the Bitgesell Core RPC interface.
       value: |
-        * Compiling Bitcoin Core from source
+        * Compiling Bitgesell Core from source
         * Running the C++ unit tests and the Python functional tests
         * ...
   - type: textarea
@@ -40,5 +40,4 @@ body:
       value: |
         Want to work on this issue?
 
-        For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md) before opening your pull request.
-
+        For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/BitgesellOfficial/bitgesell/blob/master/CONTRIBUTING.md) before opening your pull request.

--- a/.github/ISSUE_TEMPLATE/gui_issue.yml
+++ b/.github/ISSUE_TEMPLATE/gui_issue.yml
@@ -5,8 +5,8 @@ body:
 - type: checkboxes
   id: acknowledgement
   attributes:
-    label: Issues, reports or feature requests related to the GUI should be opened directly on the GUI repo
-    description: https://github.com/bitcoin-core/gui/issues/
+    label: I have checked existing Bitgesell GUI issues before opening this report.
+    description: Please include screenshots or screen recordings when they help explain the GUI issue.
     options:
       - label: I still think this issue should be opened here
         required: true


### PR DESCRIPTION
## Summary
- Updates GitHub issue template contact links from Bitcoin Core to Bitgesell.
- Updates bug report wording, security policy links, data-directory link, and version instructions to use Bitgesell/BGL names.
- Stops directing GUI reports to the Bitcoin Core GUI tracker and refreshes the good-first-issue guidance.

## Verification
- `git diff --check -- .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/bug.yml .github/ISSUE_TEMPLATE/good_first_issue.yml .github/ISSUE_TEMPLATE/gui_issue.yml`
- Parsed all `.github/ISSUE_TEMPLATE/*.yml` files with PyYAML.
- Searched the updated templates for leftover Bitcoin Core issue-routing links and command names.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina