### PR TITLE
doc: update unit test README for BGL

### DIFF
--- a/src/test/README.md
+++ b/src/test/README.md
@@ -58,7 +58,7 @@ standard terminal output.
 ... or to run just the doubledash test:
 
 ```bash
-test_ --run_test=getarg_tests/doubledash
+test_BGL --run_test=getarg_tests/doubledash
 ```
 
 `test_BGL` creates a temporary working (data) directory with a randomly
@@ -72,7 +72,7 @@ have a `debug.log` file, for example.
 The location of the temporary data directory can be specified with the
 `-testdatadir` option. This can make debugging easier. The directory
 path used is the argument path appended with
-`/test_common_Bitcoin Core/<test-name>/datadir`.
+`/test_common_BGL Core/<test-name>/datadir`.
 The directory path is created if necessary.
 Specifying this argument also causes the data directory
 not to be removed after the last test. This is useful for looking at
@@ -81,12 +81,12 @@ what the test wrote to `debug.log` after it completes, for example.
 so no leftover state is used.)
 
 ```bash
-$ test_bitcoin --run_test=getarg_tests/doubledash -- -testdatadir=/somewhere/mydatadir
+$ test_BGL --run_test=getarg_tests/doubledash -- -testdatadir=/somewhere/mydatadir
 Test directory (will not be deleted): "/somewhere/mydatadir/test_common_BGL Core/getarg_tests/doubledash/datadir
 Running 1 test case...
 
 *** No errors detected
-$ ls -l '/somewhere/mydatadir/test_common_Bitcoin Core/getarg_tests/doubledash/datadir'
+$ ls -l '/somewhere/mydatadir/test_common_BGL Core/getarg_tests/doubledash/datadir'
 total 8
 drwxrwxr-x 2 admin admin 4096 Nov 27 22:45 blocks
 -rw-rw-r-- 1 admin admin 1003 Nov 27 22:45 debug.log
@@ -96,7 +96,7 @@ If you run an entire test suite, such as `--run_test=getarg_tests`, or all the t
 (by not specifying `--run_test`), a separate directory
 will be created for each individual test.
 
-Run `test_bitcoin --help` for the full list of tests.
+Run `test_BGL --help` for the full list of tests.
 
 ### Adding test cases
 


### PR DESCRIPTION
## Summary
- Updates the unit-test README examples to use the Bitgesell `test_BGL` binary.
- Fixes the documented `-testdatadir` path from `test_common_Bitcoin Core` to `test_common_BGL Core`.
- Fixes the doubledash example command typo.

## Verification
- `git diff --check -- src/test/README.md`
- Searched `src/test/README.md` for leftover `test_bitcoin` and `test_common_Bitcoin Core` references.
- Cross-checked the temporary directory naming against `src/test/util/setup_common.cpp`.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina