### PR TITLE
security: remove Bitcoin Core reporting contacts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,14 +7,10 @@ security updates: https://bitgesell.ca
 
 ## Reporting a Vulnerability
 
-To report security issues send an email to security@bitcoincore.org (not for support).
+Please do not report security vulnerabilities through public GitHub issues.
 
-The following keys may be used to communicate sensitive information to developers:
+Use GitHub's private vulnerability reporting for this repository when available:
+https://github.com/BitgesellOfficial/bitgesell/security/advisories/new
 
-| Name | Fingerprint |
-|------|-------------|
-| Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
-| Michael Ford | E777 299F C265 DD04 7930  70EB 944D 35F9 AC3D B76A |
-| Ava Chow | 1528 1230 0785 C964 44D3  334D 1756 5732 E08E 5E41 |
-
-You can import a key by running the following command with that individual’s fingerprint: `gpg --keyserver hkps://keys.openpgp.org --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.
+If private vulnerability reporting is not available, contact the project
+maintainers through the official Bitgesell website: https://bitgesell.ca


### PR DESCRIPTION
## Summary
- Removes the upstream Bitcoin Core security email and Bitcoin Core developer PGP keys from Bitgesell's security policy.
- Directs vulnerability reporters away from public issues and toward this repository's private vulnerability reporting flow when available.
- Keeps the existing official Bitgesell website as the fallback project contact path.

## Verification
- `git diff --check -- SECURITY.md`
- Searched `SECURITY.md` to confirm the old Bitcoin Core email/key references were removed.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina