### PR TITLE
ci: guard Bitgesell default datadir

### DIFF
--- a/ci/test/03_test_script.sh
+++ b/ci/test/03_test_script.sh
@@ -82,9 +82,9 @@ fi
 
 # Make sure default datadir does not exist and is never read by creating a dummy file
 if [ "$CI_OS_NAME" == "macos" ]; then
-  echo > "${HOME}/Library/Application Support/Bitcoin"
+  echo > "${HOME}/Library/Application Support/BGL"
 else
-  echo > "${HOME}/.bitcoin"
+  echo > "${HOME}/.BGL"
 fi
 
 if [ -z "$NO_DEPENDS" ]; then

--- a/src/common/args.cpp
+++ b/src/common/args.cpp
@@ -697,10 +697,10 @@ bool HasTestOption(const ArgsManager& args, const std::string& test_option)
 fs::path GetDefaultDataDir()
 {
     // Windows:
-    //   old: C:\Users\Username\AppData\Roaming\Bitcoin
-    //   new: C:\Users\Username\AppData\Local\Bitcoin
-    // macOS: ~/Library/Application Support/Bitcoin
-    // Unix-like: ~/.bitcoin
+    //   old: C:\Users\Username\AppData\Roaming\BGL
+    //   new: C:\Users\Username\AppData\Local\BGL
+    // macOS: ~/Library/Application Support/BGL
+    // Unix-like: ~/.BGL
 #ifdef WIN32
     // Windows
     // Check for existence of datadir in old location and keep it there


### PR DESCRIPTION
## Summary
- Updates the CI default-datadir guard to create dummy Bitgesell datadir paths instead of Bitcoin paths.
- Updates the nearby `GetDefaultDataDir()` comments so the documented default paths match the BGL paths returned by the code.

## Verification
- `git diff --check -- ci/test/03_test_script.sh src/common/args.cpp`
- `git show :ci/test/03_test_script.sh | bash -n`
- Cross-checked the CI paths against `GetDefaultDataDir()` in `src/common/args.cpp`.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina