### PR TITLE
build: fix Windows tool resource names

### DIFF
--- a/src/BGL-cli-res.rc
+++ b/src/BGL-cli-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Bitgesell"
-            VALUE "FileDescription",    "BGL-util (CLI Bitgesell utility)"
+            VALUE "FileDescription",    "BGL-cli (JSON-RPC client for " PACKAGE_NAME ")"
             VALUE "FileVersion",        PACKAGE_VERSION
-            VALUE "InternalName",       "BGL-util"
+            VALUE "InternalName",       "BGL-cli"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "BGL-util.exe"
-            VALUE "ProductName",        "BGL-util"
+            VALUE "OriginalFilename",   "BGL-cli.exe"
+            VALUE "ProductName",        "BGL-cli"
             VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END

--- a/src/BGL-tx-res.rc
+++ b/src/BGL-tx-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Bitgesell"
-            VALUE "FileDescription",    "BGLd (Bitgesell node with a JSON-RPC server)"
+            VALUE "FileDescription",    "BGL-tx (CLI Bitgesell transaction editor utility)"
             VALUE "FileVersion",        PACKAGE_VERSION
-            VALUE "InternalName",       "BGLd"
+            VALUE "InternalName",       "BGL-tx"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "BGLd.exe"
-            VALUE "ProductName",        "BGLd"
+            VALUE "OriginalFilename",   "BGL-tx.exe"
+            VALUE "ProductName",        "BGL-tx"
             VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END

--- a/src/BGL-util-res.rc
+++ b/src/BGL-util-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Bitgesell"
-            VALUE "FileDescription",    "BGL-tx (CLI Bitgesell transaction editor utility)"
+            VALUE "FileDescription",    "BGL-util (CLI Bitgesell utility)"
             VALUE "FileVersion",        PACKAGE_VERSION
-            VALUE "InternalName",       "BGL-tx"
+            VALUE "InternalName",       "BGL-util"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "BGL-tx.exe"
-            VALUE "ProductName",        "BGL-tx"
+            VALUE "OriginalFilename",   "BGL-util.exe"
+            VALUE "ProductName",        "BGL-util"
             VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END

--- a/src/BGL-wallet-res.rc
+++ b/src/BGL-wallet-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Bitgesell"
-            VALUE "FileDescription",    "BGL-cli (JSON-RPC client for " PACKAGE_NAME ")"
+            VALUE "FileDescription",    "BGL-wallet (CLI Bitgesell wallet utility)"
             VALUE "FileVersion",        PACKAGE_VERSION
-            VALUE "InternalName",       "BGL-cli"
+            VALUE "InternalName",       "BGL-wallet"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "BGL-cli.exe"
-            VALUE "ProductName",        "BGL-cli"
+            VALUE "OriginalFilename",   "BGL-wallet.exe"
+            VALUE "ProductName",        "BGL-wallet"
             VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END


### PR DESCRIPTION
## Summary
- Fixes Windows VERSIONINFO metadata for `BGL-cli`, `BGL-tx`, `BGL-util`, and `BGL-wallet`.
- Aligns each resource file's `FileDescription`, `InternalName`, `OriginalFilename`, and `ProductName` with the executable that includes it.

## Verification
- `git diff --check -- src/BGL-cli-res.rc src/BGL-tx-res.rc src/BGL-util-res.rc src/BGL-wallet-res.rc`
- Inspected each updated resource file's `FileDescription`, `InternalName`, `OriginalFilename`, and `ProductName` fields.
- Cross-checked resource file usage in `src/Makefile.am`.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina