### PR TITLE
test: align lint paths with BGL names

### DIFF
--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -82,7 +82,7 @@ def main():
 
         matching_files_filtered = []
         for matching_file in matching_files:
-            if not re.search('^src/(leveldb|secp256k1|minisketch|tinyformat|test/fuzz/strprintf.cpp)|contrib/devtools/bitcoin-tidy/example_logprintf.cpp', matching_file):
+            if not re.search('^src/(leveldb|secp256k1|minisketch|tinyformat|test/fuzz/strprintf.cpp)|contrib/devtools/BGL-tidy/example_logprintf.cpp', matching_file):
                 matching_files_filtered.append(matching_file)
         matching_files_filtered.sort()
 

--- a/test/lint/lint-include-guards.py
+++ b/test/lint/lint-include-guards.py
@@ -18,7 +18,7 @@ from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
 HEADER_ID_PREFIX = 'BGL_'
 HEADER_ID_SUFFIX = '_H'
 
-EXCLUDE_FILES_WITH_PREFIX = ['contrib/devtools/bitcoin-tidy',
+EXCLUDE_FILES_WITH_PREFIX = ['contrib/devtools/BGL-tidy',
                              'src/crypto/ctaes',
                              'src/tinyformat.h',
                              'src/bench/nanobench.h',

--- a/test/lint/lint-includes.py
+++ b/test/lint/lint-includes.py
@@ -17,7 +17,7 @@ from subprocess import check_output, CalledProcessError
 from lint_ignore_dirs import SHARED_EXCLUDED_SUBTREES
 
 
-EXCLUDED_DIRS = ["contrib/devtools/bitcoin-tidy/",
+EXCLUDED_DIRS = ["contrib/devtools/BGL-tidy/",
                 ] + SHARED_EXCLUDED_SUBTREES
 
 EXPECTED_BOOST_INCLUDES = ["boost/date_time/posix_time/posix_time.hpp",

--- a/test/lint/test_runner/src/main.rs
+++ b/test/lint/test_runner/src/main.rs
@@ -26,7 +26,7 @@ fn get_linter_list() -> Vec<&'static Linter> {
             lint_fn: lint_doc
         },
         &Linter {
-            description: "Check that no symbol from bitcoin-config.h is used without the header being included",
+            description: "Check that no symbol from BGL-config.h is used without the header being included",
             name: "includes_build_config",
             lint_fn: lint_includes_build_config
         },
@@ -216,7 +216,7 @@ fn get_pathspecs_exclude_whitespace() -> Vec<String> {
             "doc/README_windows.txt",
             // Temporary excludes, or existing violations
             "doc/release-notes/release-notes-0.*",
-            "contrib/init/bitcoind.openrc",
+            "contrib/init/BGLd.openrc",
             "contrib/macdeploy/macdeployqtplus",
             "src/crypto/sha256_sse4.cpp",
             "src/qt/res/src/*.svg",
@@ -284,7 +284,7 @@ Please add any false positives, such as subtrees, or externally sourced files to
 }
 
 fn lint_includes_build_config() -> LintResult {
-    let config_path = "./src/config/bitcoin-config.h.in";
+    let config_path = "./src/config/BGL-config.h.in";
     if !Path::new(config_path).is_file() {
         assert!(Command::new("./autogen.sh")
             .status()
@@ -324,7 +324,7 @@ fn lint_includes_build_config() -> LintResult {
                 ])
                 .args(get_pathspecs_exclude_subtrees())
                 .args([
-                    // These are exceptions which don't use bitcoin-config.h, rather the Makefile.am adds
+                    // These are exceptions which don't use BGL-config.h, rather the Makefile.am adds
                     // these cppflags manually.
                     ":(exclude)src/crypto/sha256_arm_shani.cpp",
                     ":(exclude)src/crypto/sha256_avx2.cpp",
@@ -342,9 +342,9 @@ fn lint_includes_build_config() -> LintResult {
                     "--files-with-matches"
                 },
                 if mode {
-                    "^#include <config/bitcoin-config.h> // IWYU pragma: keep$"
+                    "^#include <config/BGL-config.h> // IWYU pragma: keep$"
                 } else {
-                    "#include <config/bitcoin-config.h>" // Catch redundant includes with and without the IWYU pragma
+                    "#include <config/BGL-config.h>" // Catch redundant includes with and without the IWYU pragma
                 },
                 "--",
             ])
@@ -358,11 +358,11 @@ fn lint_includes_build_config() -> LintResult {
         return Err(format!(
             r#"
 ^^^
-One or more files use a symbol declared in the bitcoin-config.h header. However, they are not
+One or more files use a symbol declared in the BGL-config.h header. However, they are not
 including the header. This is problematic, because the header may or may not be indirectly
 included. If the indirect include were to be intentionally or accidentally removed, the build could
 still succeed, but silently be buggy. For example, a slower fallback algorithm could be picked,
-even though bitcoin-config.h indicates that a faster feature is available and should be used.
+even though BGL-config.h indicates that a faster feature is available and should be used.
 
 If you are unsure which symbol is used, you can find it with this command:
 git grep --perl-regexp '{}' -- file_name
@@ -370,7 +370,7 @@ git grep --perl-regexp '{}' -- file_name
 Make sure to include it with the IWYU pragma. Otherwise, IWYU may falsely instruct to remove the
 include again.
 
-#include <config/bitcoin-config.h> // IWYU pragma: keep
+#include <config/BGL-config.h> // IWYU pragma: keep
             "#,
             defines_regex
         ));
@@ -379,7 +379,7 @@ include again.
     if redundant {
         return Err(r#"
 ^^^
-None of the files use a symbol declared in the bitcoin-config.h header. However, they are including
+None of the files use a symbol declared in the BGL-config.h header. However, they are including
 the header. Consider removing the unused include.
             "#
         .to_string());


### PR DESCRIPTION
Bounty submission for #32.

Summary:
- updates lint exclusions from the removed upstream `bitcoin-tidy` path to Bitgesell's `BGL-tidy` path
- updates the Rust lint runner to read `src/config/BGL-config.h.in` and match `#include <config/BGL-config.h>`
- updates the whitespace exclusion for the existing `contrib/init/BGLd.openrc` file

Verification:
- `git diff --check`
- `py -3 -m py_compile test/lint/lint-include-guards.py test/lint/lint-format-strings.py test/lint/lint-includes.py`
- confirmed referenced BGL paths exist
- confirmed target stale lint references (`bitcoin-config`, `bitcoin-tidy`, `bitcoind.openrc`) are removed from `test/lint`

Notes:
- Full Python lint scripts still fail on existing repository lint debt or Windows script execution behavior unrelated to this patch.
- Rust compilation was not run because `rustc` is not installed in this environment.

Payment details can be provided after approval.