### PR TITLE
build: include Windows resources in MSVC tools

### DIFF
--- a/build_msvc/BGL-cli/BGL-cli.vcxproj
+++ b/build_msvc/BGL-cli/BGL-cli.vcxproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\BGL-cli.cpp" />
+    <ResourceCompile Include="..\..\src\BGL-cli-res.rc" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libBGL_cli\libBGL_cli.vcxproj">

--- a/build_msvc/BGL-tx/BGL-tx.vcxproj
+++ b/build_msvc/BGL-tx/BGL-tx.vcxproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\BGL-tx.cpp" />
+    <ResourceCompile Include="..\..\src\BGL-tx-res.rc" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libBGL_common\libBGL_common.vcxproj">

--- a/build_msvc/BGL-util/BGL-util.vcxproj
+++ b/build_msvc/BGL-util/BGL-util.vcxproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\BGL-util.cpp" />
+    <ResourceCompile Include="..\..\src\BGL-util-res.rc" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libBGL_common\libBGL_common.vcxproj">

--- a/build_msvc/BGL-wallet/BGL-wallet.vcxproj
+++ b/build_msvc/BGL-wallet/BGL-wallet.vcxproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\BGL-wallet.cpp" />
+    <ResourceCompile Include="..\..\src\BGL-wallet-res.rc" />
     <ClCompile Include="..\..\src\init\BGL-wallet.cpp">
       <ObjectFileName>$(IntDir)init_BGL-wallet.obj</ObjectFileName>
     </ClCompile>

--- a/build_msvc/BGLd/BGLd.vcxproj
+++ b/build_msvc/BGLd/BGLd.vcxproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\BGLd.cpp" />
+    <ResourceCompile Include="..\..\src\BGLd-res.rc" />
     <ClCompile Include="..\..\src\init\BGLd.cpp">
       <ObjectFileName>$(IntDir)init_BGLd.obj</ObjectFileName>
     </ClCompile>


### PR DESCRIPTION
## Summary
- Adds the existing Windows resource files to the MSVC projects for `BGLd`, `BGL-cli`, `BGL-tx`, `BGL-util`, and `BGL-wallet`.
- This lets Visual Studio builds embed the same VERSIONINFO resources already wired into the Autotools build.

## Verification
- `git diff --check -- build_msvc/BGL-cli/BGL-cli.vcxproj build_msvc/BGL-tx/BGL-tx.vcxproj build_msvc/BGL-util/BGL-util.vcxproj build_msvc/BGL-wallet/BGL-wallet.vcxproj build_msvc/BGLd/BGLd.vcxproj`
- Parsed each updated `.vcxproj` as XML with PowerShell.
- Inspected each project for its matching `ResourceCompile` entry.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina