### PR TITLE
build: replace BDB token in MSVC test config

### DIFF
--- a/build_msvc/BGLd/BGLd.vcxproj
+++ b/build_msvc/BGLd/BGLd.vcxproj
@@ -68,7 +68,7 @@
     <ReplaceInFile FilePath="$(ConfigIniOut)"
                   Replace="@ENABLE_WALLET_TRUE@" By=""></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"
-                  Replace="@BUILD_BGL_CLI_TRUE@" By=""></ReplaceInFile>
+                  Replace="@USE_BDB_TRUE@" By=""></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"
                   Replace="@USE_SQLITE_TRUE@" By=""></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"


### PR DESCRIPTION
## Summary
- Fixes the MSVC `test/config.ini` generation step to replace `@USE_BDB_TRUE@`.
- Removes the duplicate `@BUILD_BGL_CLI_TRUE@` replacement in `build_msvc/BGLd/BGLd.vcxproj`.

## Verification
- `git diff --check -- build_msvc/BGLd/BGLd.vcxproj`
- Parsed `build_msvc/BGLd/BGLd.vcxproj` as XML with PowerShell.
- Compared tokens in `test/config.ini.in` against the MSVC `ReplaceInFile` entries and confirmed none are missing.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina