### PR TITLE
build: fix MSVC fuzz project references

### DIFF
--- a/build_msvc/fuzz/fuzz.vcxproj
+++ b/build_msvc/fuzz/fuzz.vcxproj
@@ -42,28 +42,28 @@
     <ProjectReference Include="..\libminisketch\libminisketch.vcxproj">
       <Project>{542007e3-be0d-4b0d-a6b0-aa8813e2558d}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\libbitcoin_consensus\libbitcoin_consensus.vcxproj">
+    <ProjectReference Include="..\libBGL_consensus\libBGL_consensus.vcxproj">
       <Project>{2b384fa8-9ee1-4544-93cb-0d733c25e8ce}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\libbitcoin_cli\libbitcoin_cli.vcxproj">
+    <ProjectReference Include="..\libBGL_cli\libBGL_cli.vcxproj">
       <Project>{0667528c-d734-4009-adf9-c0d6c4a5a5a6}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\libbitcoin_common\libbitcoin_common.vcxproj">
+    <ProjectReference Include="..\libBGL_common\libBGL_common.vcxproj">
       <Project>{7c87e378-df58-482e-aa2f-1bc129bc19ce}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\libbitcoin_crypto\libbitcoin_crypto.vcxproj">
+    <ProjectReference Include="..\libBGL_crypto\libBGL_crypto.vcxproj">
       <Project>{6190199c-6cf4-4dad-bfbd-93fa72a760c1}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\libbitcoin_node\libbitcoin_node.vcxproj">
+    <ProjectReference Include="..\libBGL_node\libBGL_node.vcxproj">
       <Project>{460fee33-1fe1-483f-b3bf-931ff8e969a5}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\libbitcoin_util\libbitcoin_util.vcxproj">
+    <ProjectReference Include="..\libBGL_util\libBGL_util.vcxproj">
       <Project>{b53a5535-ee9d-4c6f-9a26-f79ee3bc3754}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\libbitcoin_wallet\libbitcoin_wallet.vcxproj">
+    <ProjectReference Include="..\libBGL_wallet\libBGL_wallet.vcxproj">
       <Project>{93b86837-b543-48a5-a89b-7c87abb77df2}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\libbitcoin_zmq\libbitcoin_zmq.vcxproj">
+    <ProjectReference Include="..\libBGL_zmq\libBGL_zmq.vcxproj">
       <Project>{792d487f-f14c-49fc-a9de-3fc150f31c3f}</Project>
     </ProjectReference>
     <ProjectReference Include="..\libtest_util\libtest_util.vcxproj">


### PR DESCRIPTION
## Summary
- Updates the MSVC fuzz project references from non-existent `libbitcoin_*` projects to the Bitgesell `libBGL_*` projects.
- Keeps the existing project GUIDs unchanged because they already match the corresponding BGL project GUIDs.

## Verification
- `git diff --check -- build_msvc/fuzz/fuzz.vcxproj`
- Parsed `build_msvc/fuzz/fuzz.vcxproj` as XML with PowerShell.
- Confirmed the referenced `build_msvc/libBGL_*` directories exist and no `libbitcoin_*` references remain in the fuzz project.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina