### PR TITLE
doc: update MSVC hardening note for BGL

### DIFF
--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -71,7 +71,7 @@ Alternatively, open the `build_msvc/BGL.sln` file in Visual Studio.
 
 Security
 ---------------------
-[Base address randomization](https://learn.microsoft.com/en-us/cpp/build/reference/dynamicbase-use-address-space-layout-randomization) is used to make Bitcoin Core more secure. When building Bitcoin using the `build_msvc` process base address randomization can be disabled by editing `common.init.vcproj` to change `RandomizedBaseAddress` from `true` to `false` and then rebuilding the project.
+[Base address randomization](https://learn.microsoft.com/en-us/cpp/build/reference/dynamicbase-use-address-space-layout-randomization) is used to make BGL Core more secure. When building BGL using the `build_msvc` process base address randomization can be disabled by editing `common.init.vcxproj` to change `RandomizedBaseAddress` from `true` to `false` and then rebuilding the project.
 
 To check if `BGLd` has `RandomizedBaseAddress` enabled or disabled run
 


### PR DESCRIPTION
## Summary
- Updates the MSVC security/hardening note from Bitcoin naming to BGL naming.
- Corrects the project file extension from `common.init.vcproj` to the generated `common.init.vcxproj` name used by the rest of the MSVC README.

## Verification
- `git diff --check -- build_msvc/README.md`
- Searched `build_msvc/README.md` for the stale Bitcoin/Core wording and `common.init.vcproj` typo.
- Confirmed the source template is `build_msvc/common.init.vcxproj.in` and the README already refers to the generated `common.init.vcxproj` in the setup steps.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina