### PR TITLE
lint: use BGL names in lint container docs

### DIFF
--- a/ci/lint/container-entrypoint.sh
+++ b/ci/lint/container-entrypoint.sh
@@ -7,8 +7,8 @@
 export LC_ALL=C
 
 # Fixes permission issues when there is a container UID/GID mismatch with the owner
-# of the mounted bitcoin src dir.
-git config --global --add safe.directory /bitcoin
+# of the mounted BGL source directory.
+git config --global --add safe.directory /bgl
 
 export PATH="/python_build/bin:${PATH}"
 export LINT_RUNNER_PATH="/lint_test_runner"

--- a/ci/lint_imagefile
+++ b/ci/lint_imagefile
@@ -20,5 +20,5 @@ RUN /install.sh && \
   rm -rf /var/lib/apt/lists/*
 
 
-WORKDIR /bitcoin
+WORKDIR /bgl
 ENTRYPOINT ["/entrypoint.sh"]

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -7,9 +7,9 @@ To run linters locally with the same versions as the CI environment, use the inc
 Dockerfile:
 
 ```sh
-DOCKER_BUILDKIT=1 docker build -t bitcoin-linter --file "./ci/lint_imagefile" ./
+DOCKER_BUILDKIT=1 docker build -t bgl-linter --file "./ci/lint_imagefile" ./
 
-docker run --rm -v $(pwd):/bitcoin -it bitcoin-linter
+docker run --rm -v $(pwd):/bgl -it bgl-linter
 ```
 
 After building the container once, you can simply run the last command any time you


### PR DESCRIPTION
## Summary
- Renames the local lint container image example from `bitcoin-linter` to `bgl-linter`.
- Aligns the lint container workdir, README bind mount, and git safe-directory path on `/bgl`.

## Verification
- `git diff --check -- ci/lint/container-entrypoint.sh ci/lint_imagefile test/lint/README.md`
- `git show :ci/lint/container-entrypoint.sh | bash -n`
- Searched the lint container files and README to confirm the old `/bitcoin` and `bitcoin-linter` names were removed from the local lint container flow.

Related bounty: #32

Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`; PayPal fallback: https://paypal.me/Jeremytsangchina