### PR TITLE
contrib: update Debian upstream metadata

### DIFF
--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -1,7 +1,6 @@
 Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Bitcoin
-Upstream-Contact: Satoshi Nakamoto <satoshin@gmx.com>
- irc://#Bitcoin@freenode.net
+Upstream-Name: Bitgesell
+Upstream-Contact: Bitgesell Core Developers
 Source: https://github.com/BitgesellOfficial/bitgesell
 
 Files: *


### PR DESCRIPTION
## Summary
- update Debian copyright upstream metadata from the old Bitcoin project identity to Bitgesell
- remove stale Satoshi/Bitcoin IRC contact data while keeping the existing Bitgesell source URL

## Verification
- `git diff --check -- contrib/debian/copyright`
- `rg -n "Upstream-Name|Upstream-Contact|Source|#Bitcoin|Satoshi|Bitcoin$|Bitgesell" contrib/debian/copyright`

## Bounty
- Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina