### PR TITLE
contrib: filter Bitgesell seed user agents

### DIFF
--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -32,7 +32,7 @@ PATTERN_IPV6 = re.compile(r"^\[([0-9a-z:]+)\]:(\d+)$")
 PATTERN_ONION = re.compile(r"^([a-z2-7]{56}\.onion):(\d+)$")
 PATTERN_I2P = re.compile(r"^([a-z2-7]{52}\.b32.i2p):(\d+)$")
 PATTERN_AGENT = re.compile(
-    r"^/Satoshi:("
+    r"^/SatoshiBGL:("
     r"0.14.(0|1|2|3|99)|"
     r"0.15.(0|1|2|99)|"
     r"0.16.(0|1|2|3|99)|"


### PR DESCRIPTION
## Summary
- update `contrib/seeds/makeseeds.py` to accept Bitgesell node user agents
- align the seed filtering regex with `CLIENT_NAME("SatoshiBGL")` from `src/clientversion.cpp`

## Verification
- `git diff --check -- contrib/seeds/makeseeds.py`
- `python -m py_compile contrib/seeds/makeseeds.py`
- imported `PATTERN_AGENT` and checked that `/SatoshiBGL:26.0/` matches while `/Satoshi:26.0/` no longer matches

## Bounty
- Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina