### PR TITLE
contrib: generate BGL key I/O vectors

### DIFF
--- a/contrib/testgen/gen_key_io_test_vectors.py
+++ b/contrib/testgen/gen_key_io_test_vectors.py
@@ -18,12 +18,12 @@ from test_framework.script import OP_0, OP_1, OP_2, OP_3, OP_16, OP_DUP, OP_EQUA
 from test_framework.segwit_addr import bech32_encode, decode_segwit_address, convertbits, CHARSET, Encoding  # noqa: E402
 
 # key types
-PUBKEY_ADDRESS = 0
-SCRIPT_ADDRESS = 5
-PUBKEY_ADDRESS_TEST = 111
-SCRIPT_ADDRESS_TEST = 196
-PUBKEY_ADDRESS_REGTEST = 111
-SCRIPT_ADDRESS_REGTEST = 196
+PUBKEY_ADDRESS = 10
+SCRIPT_ADDRESS = 25
+PUBKEY_ADDRESS_TEST = 34
+SCRIPT_ADDRESS_TEST = 50
+PUBKEY_ADDRESS_REGTEST = 34
+SCRIPT_ADDRESS_REGTEST = 50
 PRIVKEY = 128
 PRIVKEY_TEST = 239
 PRIVKEY_REGTEST = 239
@@ -62,42 +62,42 @@ templates = [
 # templates for valid bech32 sequences
 bech32_templates = [
   # hrp, version, witprog_size, metadata, encoding, output_prefix
-  ('bc',    0, 20, (False, 'main',    None, True), Encoding.BECH32,  p2wpkh_prefix),
-  ('bc',    0, 32, (False, 'main',    None, True), Encoding.BECH32,  p2wsh_prefix),
-  ('bc',    1, 32, (False, 'main',    None, True), Encoding.BECH32M, p2tr_prefix),
-  ('bc',    2,  2, (False, 'main',    None, True), Encoding.BECH32M, (OP_2, 2)),
-  ('tb',    0, 20, (False, 'test',    None, True), Encoding.BECH32,  p2wpkh_prefix),
-  ('tb',    0, 32, (False, 'test',    None, True), Encoding.BECH32,  p2wsh_prefix),
-  ('tb',    1, 32, (False, 'test',    None, True), Encoding.BECH32M, p2tr_prefix),
-  ('tb',    3, 16, (False, 'test',    None, True), Encoding.BECH32M, (OP_3, 16)),
-  ('tb',    0, 20, (False, 'signet',  None, True), Encoding.BECH32,  p2wpkh_prefix),
-  ('tb',    0, 32, (False, 'signet',  None, True), Encoding.BECH32,  p2wsh_prefix),
-  ('tb',    1, 32, (False, 'signet',  None, True), Encoding.BECH32M, p2tr_prefix),
-  ('tb',    3, 32, (False, 'signet',  None, True), Encoding.BECH32M, (OP_3, 32)),
-  ('bcrt',  0, 20, (False, 'regtest', None, True), Encoding.BECH32,  p2wpkh_prefix),
-  ('bcrt',  0, 32, (False, 'regtest', None, True), Encoding.BECH32,  p2wsh_prefix),
-  ('bcrt',  1, 32, (False, 'regtest', None, True), Encoding.BECH32M, p2tr_prefix),
-  ('bcrt', 16, 40, (False, 'regtest', None, True), Encoding.BECH32M, (OP_16, 40))
+  ('bgl',   0, 20, (False, 'main',    None, True), Encoding.BECH32,  p2wpkh_prefix),
+  ('bgl',   0, 32, (False, 'main',    None, True), Encoding.BECH32,  p2wsh_prefix),
+  ('bgl',   1, 32, (False, 'main',    None, True), Encoding.BECH32M, p2tr_prefix),
+  ('bgl',   2,  2, (False, 'main',    None, True), Encoding.BECH32M, (OP_2, 2)),
+  ('tbgl',  0, 20, (False, 'test',    None, True), Encoding.BECH32,  p2wpkh_prefix),
+  ('tbgl',  0, 32, (False, 'test',    None, True), Encoding.BECH32,  p2wsh_prefix),
+  ('tbgl',  1, 32, (False, 'test',    None, True), Encoding.BECH32M, p2tr_prefix),
+  ('tbgl',  3, 16, (False, 'test',    None, True), Encoding.BECH32M, (OP_3, 16)),
+  ('tbgl',  0, 20, (False, 'signet',  None, True), Encoding.BECH32,  p2wpkh_prefix),
+  ('tbgl',  0, 32, (False, 'signet',  None, True), Encoding.BECH32,  p2wsh_prefix),
+  ('tbgl',  1, 32, (False, 'signet',  None, True), Encoding.BECH32M, p2tr_prefix),
+  ('tbgl',  3, 32, (False, 'signet',  None, True), Encoding.BECH32M, (OP_3, 32)),
+  ('rbgl',  0, 20, (False, 'regtest', None, True), Encoding.BECH32,  p2wpkh_prefix),
+  ('rbgl',  0, 32, (False, 'regtest', None, True), Encoding.BECH32,  p2wsh_prefix),
+  ('rbgl',  1, 32, (False, 'regtest', None, True), Encoding.BECH32M, p2tr_prefix),
+  ('rbgl', 16, 40, (False, 'regtest', None, True), Encoding.BECH32M, (OP_16, 40))
 ]
 # templates for invalid bech32 sequences
 bech32_ng_templates = [
   # hrp, version, witprog_size, encoding, invalid_bech32, invalid_checksum, invalid_char
   ('tc',    0, 20, Encoding.BECH32,  False, False, False),
   ('bt',    1, 32, Encoding.BECH32M, False, False, False),
-  ('tb',   17, 32, Encoding.BECH32M, False, False, False),
-  ('bcrt',  3,  1, Encoding.BECH32M, False, False, False),
-  ('bc',   15, 41, Encoding.BECH32M, False, False, False),
-  ('tb',    0, 16, Encoding.BECH32,  False, False, False),
-  ('bcrt',  0, 32, Encoding.BECH32,  True,  False, False),
-  ('bc',    0, 16, Encoding.BECH32,  True,  False, False),
-  ('tb',    0, 32, Encoding.BECH32,  False, True,  False),
-  ('bcrt',  0, 20, Encoding.BECH32,  False, False, True),
-  ('bc',    0, 20, Encoding.BECH32M, False, False, False),
-  ('tb',    0, 32, Encoding.BECH32M, False, False, False),
-  ('bcrt',  0, 20, Encoding.BECH32M, False, False, False),
-  ('bc',    1, 32, Encoding.BECH32,  False, False, False),
-  ('tb',    2, 16, Encoding.BECH32,  False, False, False),
-  ('bcrt', 16, 20, Encoding.BECH32,  False, False, False),
+  ('tbgl', 17, 32, Encoding.BECH32M, False, False, False),
+  ('rbgl',  3,  1, Encoding.BECH32M, False, False, False),
+  ('bgl',  15, 41, Encoding.BECH32M, False, False, False),
+  ('tbgl',  0, 16, Encoding.BECH32,  False, False, False),
+  ('rbgl',  0, 32, Encoding.BECH32,  True,  False, False),
+  ('bgl',   0, 16, Encoding.BECH32,  True,  False, False),
+  ('tbgl',  0, 32, Encoding.BECH32,  False, True,  False),
+  ('rbgl',  0, 20, Encoding.BECH32,  False, False, True),
+  ('bgl',   0, 20, Encoding.BECH32M, False, False, False),
+  ('tbgl',  0, 32, Encoding.BECH32M, False, False, False),
+  ('rbgl',  0, 20, Encoding.BECH32M, False, False, False),
+  ('bgl',   1, 32, Encoding.BECH32,  False, False, False),
+  ('tbgl',  2, 16, Encoding.BECH32,  False, False, False),
+  ('rbgl', 16, 20, Encoding.BECH32,  False, False, False),
 ]
 
 def is_valid(v):
@@ -119,7 +119,7 @@ def is_valid(v):
 
 def is_valid_bech32(v):
     '''Check vector v for bech32 validity'''
-    for hrp in ['bc', 'tb', 'bcrt']:
+    for hrp in ['bgl', 'tbgl', 'rbgl']:
         if decode_segwit_address(hrp, v) != (None, None):
             return True
     return False


### PR DESCRIPTION
## Summary
- update `contrib/testgen/gen_key_io_test_vectors.py` to generate Bitgesell base58 prefixes
- update bech32/bech32m HRPs from Bitcoin values to `bgl`, `tbgl`, and `rbgl`
- keep generated valid/invalid vector checks aligned with `src/kernel/chainparams.cpp`

## Verification
- `git diff --check -- contrib/testgen/gen_key_io_test_vectors.py`
- `python -m py_compile contrib/testgen/gen_key_io_test_vectors.py`
- `python contrib/testgen/gen_key_io_test_vectors.py valid 32 | rg "bgl|tbgl|rbgl|bc1|tb1|bcrt"`
- used Python `json.loads` on `python contrib/testgen/gen_key_io_test_vectors.py invalid 32` output
- compared prefixes/HRPs with `src/kernel/chainparams.cpp`

## Bounty
- Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina