### PR TITLE
contrib: verify commits for official repo

### DIFF
--- a/contrib/verify-commits/pre-push-hook.sh
+++ b/contrib/verify-commits/pre-push-hook.sh
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
-if ! [[ "$2" =~ ^(git@)?(www.)?github.com(:|/)BGL/BGL(.git)?$ ]]; then
+if ! [[ "$2" =~ ^(git@)?(www\.)?github\.com(:|/)BitgesellOfficial/bitgesell(\.git)?$ ]]; then
     exit 0
 fi
 


### PR DESCRIPTION
## Summary
- update `contrib/verify-commits/pre-push-hook.sh` to recognize the current official repository
- ensure the pre-push signature check runs for `BitgesellOfficial/bitgesell` instead of only the stale `BGL/BGL` remote
- escape regex dots while preserving SSH/HTTPS-style GitHub remote matching

## Verification
- `git diff --check -- contrib/verify-commits/pre-push-hook.sh`
- `git show :contrib/verify-commits/pre-push-hook.sh | bash -n`
- checked the regex matches `git@github.com:BitgesellOfficial/bitgesell.git` and `github.com/BitgesellOfficial/bitgesell`, and rejects `github.com:BGL/BGL.git`

## Bounty
- Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina