### PR TITLE
kernel: update chainstate comments for BGL

### DIFF
--- a/src/BGL-chainstate.cpp
+++ b/src/BGL-chainstate.cpp
@@ -2,14 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-// The bitcoin-chainstate executable serves to surface the dependencies required
-// by a program wishing to use Bitcoin Core's consensus engine as it is right
+// The BGL-chainstate executable serves to surface the dependencies required
+// by a program wishing to use Bitgesell's consensus engine as it is right
 // now.
 //
 // DEVELOPER NOTE: Since this is a "demo-only", experimental, etc. executable,
 //                 it may diverge from Bitcoin Core's coding style.
 //
-// It is part of the libbitcoinkernel project.
+// It is part of the libBGLkernel project.
 
 #include <kernel/chainparams.h>
 #include <kernel/chainstatemanager_opts.h>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -899,7 +899,7 @@ BGL_util_LDADD = \
   $(LIBSECP256K1)
 #
 
-# bitcoin-chainstate binary #
+# BGL-chainstate binary #
 BGL_chainstate_SOURCES = BGL-chainstate.cpp
 BGL_chainstate_CPPFLAGS = $(AM_CPPFLAGS) $(BGL_INCLUDES) $(BOOST_CPPFLAGS)
 BGL_chainstate_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
@@ -908,7 +908,7 @@ BGL_chainstate_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(PTHREAD_FLAGS) $(LIBTOOL_A
 BGL_chainstate_LDADD = $(LIBBGLKERNEL)
 
 # libtool is unable to calculate this indirect dependency, presumably because it's a subproject.
-# libsecp256k1 only needs to be linked in when libbitcoinkernel is static.
+# libsecp256k1 only needs to be linked in when libBGLkernel is static.
 BGL_chainstate_LDADD += $(LIBSECP256K1)
 #
 
@@ -920,7 +920,7 @@ libBGLkernel_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS) $(PTHREAD_FLA
 libBGLkernel_la_LIBADD = $(LIBBGL_CRYPTO) $(LIBLEVELDB) $(LIBMEMENV) $(LIBSECP256K1)
 libBGLkernel_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS)
 
-# libbitcoinkernel requires default symbol visibility, explicitly specify that
+# libBGLkernel requires default symbol visibility, explicitly specify that
 # here so that things still work even when user configures with
 #   --enable-reduce-exports
 #
@@ -928,7 +928,7 @@ libBGLkernel_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k
 # to export from the library.
 libBGLkernel_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) -fvisibility=default
 
-# TODO: libbitcoinkernel is a work in progress consensus engine library, as more
+# TODO: libBGLkernel is a work in progress consensus engine library, as more
 #       and more modules are decoupled from the consensus engine, this list will
 #       shrink to only those which are absolutely necessary.
 libBGLkernel_la_SOURCES = \

--- a/src/kernel/BGLkernel.cpp
+++ b/src/kernel/BGLkernel.cpp
@@ -5,6 +5,6 @@
 #include <functional>
 #include <string>
 
-// Define G_TRANSLATION_FUN symbol in libbitcoinkernel library so users of the
+// Define G_TRANSLATION_FUN symbol in libBGLkernel library so users of the
 // library aren't required to export this symbol
 extern const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;


### PR DESCRIPTION
## Summary
- update `BGL-chainstate` source comments to refer to Bitgesell and `libBGLkernel`
- update the related Automake comments around the `BGL-chainstate` binary and `libBGLkernel` target
- keep comments aligned with the existing target and library names

## Verification
- `git diff --check -- src/BGL-chainstate.cpp src/kernel/BGLkernel.cpp src/Makefile.am`
- `rg -n "bitcoin-chainstate|libbitcoinkernel|BGL-chainstate|libBGLkernel" src/BGL-chainstate.cpp src/kernel/BGLkernel.cpp src/Makefile.am`

## Bounty
- Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina