### PR TITLE
ipc: update BGL node comments

### DIFF
--- a/src/init/BGL-node.cpp
+++ b/src/init/BGL-node.cpp
@@ -47,7 +47,7 @@ namespace interfaces {
 std::unique_ptr<Init> MakeNodeInit(node::NodeContext& node, int argc, char* argv[], int& exit_status)
 {
     auto init = std::make_unique<init::BGLNodeInit>(node, argc > 0 ? argv[0] : "");
-    // Check if bitcoin-node is being invoked as an IPC server. If so, then
+    // Check if BGL-node is being invoked as an IPC server. If so, then
     // bypass normal execution and just respond to requests over the IPC
     // channel and return null.
     if (init->m_ipc->startSpawnedProcess(argc, argv, exit_status)) {

--- a/src/init/common.h
+++ b/src/init/common.h
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 //! @file
-//! @brief Common init functions shared by bitcoin-node, bitcoin-wallet, etc.
+//! @brief Common init functions shared by BGL-node, BGL-wallet, etc.
 
 #ifndef BGL_INIT_COMMON_H
 #define BGL_INIT_COMMON_H

--- a/src/rpc/node.cpp
+++ b/src/rpc/node.cpp
@@ -319,20 +319,20 @@ static RPCHelpMan echoipc()
             interfaces::Init& local_init = *EnsureAnyNodeContext(request.context).init;
             std::unique_ptr<interfaces::Echo> echo;
             if (interfaces::Ipc* ipc = local_init.ipc()) {
-                // Spawn a new bitcoin-node process and call makeEcho to get a
+                // Spawn a new BGL-node process and call makeEcho to get a
                 // client pointer to a interfaces::Echo instance running in
                 // that process. This is just for testing. A slightly more
                 // realistic test spawning a different executable instead of
-                // the same executable would add a new bitcoin-echo executable,
-                // and spawn bitcoin-echo below instead of bitcoin-node. But
-                // using bitcoin-node avoids the need to build and install a
+                // the same executable would add a new BGL-echo executable,
+                // and spawn BGL-echo below instead of BGL-node. But using
+                // BGL-node avoids the need to build and install a
                 // new executable just for this one test.
                 auto init = ipc->spawnProcess("BGL-node");
                 echo = init->makeEcho();
                 ipc->addCleanup(*echo, [init = init.release()] { delete init; });
             } else {
-                // IPC support is not available because this is a bitcoind
-                // process not a bitcoind-node process, so just create a local
+                // IPC support is not available because this is a BGLd
+                // process, not a BGL-node IPC process, so just create a local
                 // interfaces::Echo object and return it so the `echoipc` RPC
                 // method will work, and the python test calling `echoipc`
                 // can expect the same result.


### PR DESCRIPTION
## Summary
- update multiprocess/IPC comments from Bitcoin executable names to Bitgesell executable names
- keep the comments aligned with the existing `BGL-node` spawn path
- clarify the non-IPC fallback as a `BGLd` process rather than a `bitcoind` process

## Verification
- `git diff --check -- src/init/BGL-node.cpp src/init/common.h src/rpc/node.cpp`
- `rg -n "bitcoin-node|bitcoin-wallet|bitcoin-echo|bitcoind-node|bitcoind|BGL-node|BGL-wallet|BGL-echo|BGLd" src/init/BGL-node.cpp src/init/common.h src/rpc/node.cpp`

## Bounty
- Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina