### PR TITLE
init: update config comments for BGL

### DIFF
--- a/src/common/init.cpp
+++ b/src/common/init.cpp
@@ -30,7 +30,7 @@ std::optional<ConfigError> InitConfig(ArgsManager& args, SettingsAbortFn setting
         // possible for the config file to cause another configuration to be
         // used, though. Specifying a conf= option in the config file causes a
         // parse error, and specifying a datadir= location containing another
-        // bitcoin.conf file just ignores the other file.)
+        // BGL.conf file just ignores the other file.)
         const fs::path orig_datadir_path{args.GetDataDirBase()};
         const fs::path orig_config_path{AbsPathForConfigVal(args, args.GetPathArg("-conf", BGL_CONF_FILENAME), /*net_specific=*/false)};
 
@@ -62,7 +62,7 @@ std::optional<ConfigError> InitConfig(ArgsManager& args, SettingsAbortFn setting
             fs::create_directories(net_path / "wallets");
         }
 
-        // Show an error or warning if there is a bitcoin.conf file in the
+        // Show an error or warning if there is a BGL.conf file in the
         // datadir that is being ignored.
         const fs::path base_config_path = base_path / BGL_CONF_FILENAME;
         if (fs::exists(base_config_path) && !fs::equivalent(orig_config_path, base_config_path)) {


### PR DESCRIPTION
## Summary
- update `common::InitConfig` comments from `bitcoin.conf` to `BGL.conf`
- keep the comments aligned with the existing `BGL_CONF_FILENAME` logic

## Verification
- `git diff --check -- src/common/init.cpp`
- `rg -n "bitcoin\.conf|BGL\.conf|BGL_CONF_FILENAME" src/common/init.cpp src/common/args.h`

## Bounty
- Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina