### PR TITLE
contrib: limit QoS traffic on BGL port

### DIFF
--- a/contrib/qos/README.md
+++ b/contrib/qos/README.md
@@ -1,5 +1,5 @@
 ### QoS (Quality of service) ###
 
-This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the BGL network. It limits outbound TCP traffic with a source or destination port of 8333, but not if the destination IP is within a LAN.
+This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the BGL network. It limits outbound TCP traffic with a source or destination port of 8454, but not if the destination IP is within a LAN.
 
 This means one can have an always-on BGLd instance running, and another local BGLd/BGL-qt instance which connects to this node and receives blocks from it.

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -11,6 +11,8 @@ IF="eth0"
 LINKCEIL="1gbit"
 #limit outbound BGL protocol traffic to this rate
 LIMIT="160kbit"
+#BGL mainnet P2P port
+BGL_PORT="8454"
 #defines the IPv4 address space for which you wish to disable rate limiting
 LOCALNET_V4="192.168.0.0/16"
 #defines the IPv6 address space for which you wish to disable rate limiting
@@ -47,16 +49,16 @@ fi
 #	ret=$?
 #done
 
-#limit outgoing traffic to and from port 8333. but not when dealing with a host on the local network
+#limit outgoing traffic to and from the BGL P2P port. but not when dealing with a host on the local network
 #	(defined by $LOCALNET_V4 and $LOCALNET_V6)
 #	--set-mark marks packages matching these criteria with the number "2" (v4)
 #	--set-mark marks packages matching these criteria with the number "4" (v6)
 #	these packets are filtered by the tc filter with "handle 2"
 #	this filter sends the packages into the 1:11 class, and this class is limited to ${LIMIT}
-iptables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
-iptables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
+iptables -t mangle -A OUTPUT -p tcp -m tcp --dport ${BGL_PORT} ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
+iptables -t mangle -A OUTPUT -p tcp -m tcp --sport ${BGL_PORT} ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
 
 if [ -n "${LOCALNET_V6}" ] ; then
-	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
-	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
+	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --dport ${BGL_PORT} ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
+	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --sport ${BGL_PORT} ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
 fi


### PR DESCRIPTION
## Summary
- update the QoS traffic limiter from Bitcoin's mainnet port `8333` to Bitgesell's mainnet P2P port `8454`
- add a `BGL_PORT` variable so IPv4/IPv6 iptables rules stay aligned
- update the QoS README to document the correct BGL port

## Verification
- `git diff --check -- contrib/qos/tc.sh contrib/qos/README.md`
- `git show :contrib/qos/tc.sh | bash -n`
- `rg -n "8333|8454|BGL_PORT|nDefaultPort" contrib/qos src/kernel/chainparams.cpp`

## Bounty
- Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32
- USDT TRC20: `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina