### PR TITLE
interfaces: update node comments for BGL

### DIFF
--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -65,7 +65,7 @@ public:
     virtual std::string getName() = 0;
 };
 
-//! Top-level interface for a bitcoin node (bitcoind process).
+//! Top-level interface for a Bitgesell node (BGLd process).
 class Node
 {
 public:
@@ -105,7 +105,7 @@ public:
     //! would be ignored because it is also specified in the command line.
     virtual bool isSettingIgnored(const std::string& name) = 0;
 
-    //! Return setting value from <datadir>/settings.json or bitcoin.conf.
+    //! Return setting value from <datadir>/settings.json or BGL.conf.
     virtual common::SettingsValue getPersistentSetting(const std::string& name) = 0;
 
     //! Update a setting in <datadir>/settings.json.


### PR DESCRIPTION
## Summary
- update Node interface comments to refer to the Bitgesell/BGLd process
- update the persistent setting comment to mention BGL.conf instead of bitcoin.conf

## Bounty
- Related to #32
- Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina

## Verification
- `git diff --check -- src/interfaces/node.h`
- `rg -n "bitcoin node|bitcoind process|bitcoin\.conf|Bitgesell node|BGLd process|BGL\.conf" src/interfaces/node.h`