### PR TITLE
clientversion: update BGL resource comment

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -19,7 +19,7 @@
 #define COPYRIGHT_STR "2009-" STRINGIZE(COPYRIGHT_YEAR) " " COPYRIGHT_HOLDERS_FINAL
 
 /**
- * bitcoind-res.rc includes this file, but it cannot cope with real c++ code.
+ * BGLd-res.rc includes this file, but it cannot cope with real c++ code.
  * WINDRES_PREPROC is defined to indicate that its pre-processor is running.
  * Anything other than a define should be guarded below.
  */


### PR DESCRIPTION
## Summary
- update clientversion.h to mention BGLd-res.rc instead of bitcoind-res.rc
- align the comment with the Bitgesell resource target used by the build

## Bounty
- Related to #32
- Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina

## Verification
- `git diff --check -- src/clientversion.h`
- `rg -n "bitcoind-res\.rc|BGLd-res\.rc" src/clientversion.h src/Makefile.am src/BGLd-res.rc`