### PR TITLE
common: update signmessage address comment

### DIFF
--- a/src/common/signmessage.h
+++ b/src/common/signmessage.h
@@ -47,7 +47,7 @@ enum class SigningResult {
 };
 
 /** Verify a signed message.
- * @param[in] address Signer's bitcoin address, it must refer to a public key.
+ * @param[in] address Signer's Bitgesell address, it must refer to a public key.
  * @param[in] signature The signature in base64 format.
  * @param[in] message The message that was signed.
  * @return result code */


### PR DESCRIPTION
## Summary
- update the signed message verification address comment to say Bitgesell address
- add the missing trailing newline in the touched header

## Bounty
- Related to #32
- Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina

## Verification
- `git diff --check -- src/common/signmessage.h`
- `rg -n "bitcoin address|Bitgesell address|Signer's" src/common/signmessage.h`