### PR TITLE
external_signer: update BGL chain comment

### DIFF
--- a/src/external_signer.h
+++ b/src/external_signer.h
@@ -21,7 +21,7 @@ private:
     //! The command which handles interaction with the external signer.
     std::string m_command;
 
-    //! Bitcoin mainnet, testnet, etc
+    //! Bitgesell mainnet, testnet, etc
     std::string m_chain;
 
     std::string NetworkArg() const;


### PR DESCRIPTION
## Summary
- update the ExternalSigner chain member comment to use Bitgesell network wording
- keep the change scoped to the stale project name in the header comment

## Bounty
- Related to #32
- Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina

## Verification
- `git diff --check -- src/external_signer.h`
- `rg -n "Bitcoin mainnet|Bitgesell mainnet|mainnet, testnet" src/external_signer.h`