### PR TITLE
contrib: update BGL cli fish comment

### DIFF
--- a/contrib/completions/fish/BGL-cli.fish
+++ b/contrib/completions/fish/BGL-cli.fish
@@ -91,7 +91,7 @@ complete \
     --arguments "(__fish_BGL_cli_get_options --nofiles)"
 
 # Add commands
-# Permit command completions after `bitcoin-cli help` but not after other commands
+# Permit command completions after `BGL-cli help` but not after other commands
 complete \
     --command BGL-cli \
     --no-files \


### PR DESCRIPTION
## Summary
- update the fish completion comment to say BGL-cli help
- align the comment with the actual Bitgesell completion command name

## Bounty
- Related to #32
- Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina

## Verification
- `git diff --check -- contrib/completions/fish/BGL-cli.fish`
- `rg -n "bitcoin-cli help|BGL-cli help|--command BGL-cli" contrib/completions/fish/BGL-cli.fish`