### PR TITLE
coins: update BGL binary comment

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -368,7 +368,7 @@ const Coin& AccessByTxid(const CCoinsViewCache& cache, const Txid& txid);
 /**
  * This is a minimally invasive approach to shutdown on LevelDB read errors from the
  * chainstate, while keeping user interface out of the common library, which is shared
- * between bitcoind, and bitcoin-qt and non-server tools.
+ * between BGLd, BGL-qt, and non-server tools.
  *
  * Writes do not need similar protection, as failure to write is handled by the caller.
 */


### PR DESCRIPTION
## Summary
- update the coins view error catcher comment to use BGLd and BGL-qt names
- keep the comment aligned with Bitgesell binary naming

## Bounty
- Related to #32
- Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina

## Verification
- `git diff --check -- src/coins.h`
- `rg -n "bitcoind|bitcoin-qt|BGLd|BGL-qt|non-server tools" src/coins.h`