### PR TITLE
qt: update BGL makefile comment

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -315,7 +315,7 @@ QT_FORMS_H=$(join $(dir $(QT_FORMS_UI)),$(addprefix ui_, $(notdir $(QT_FORMS_UI:
 $(QT_MOC): $(QT_FORMS_H)
 $(qt_libBGLqt_a_OBJECTS) $(qt_BGL_qt_OBJECTS) $(BGL_gui_OBJECTS) : | $(QT_MOC)
 
-# bitcoin-qt and bitcoin-gui binaries #
+# BGL-qt and BGL-gui binaries #
 BGL_qt_cppflags = $(AM_CPPFLAGS) $(BGL_INCLUDES) $(BGL_QT_INCLUDES) \
   $(QT_INCLUDES) $(QR_CFLAGS)
 BGL_qt_cxxflags = $(AM_CXXFLAGS) $(QT_PIE_FLAGS)


### PR DESCRIPTION
## Summary
- update the Qt makefile comment to refer to BGL-qt and BGL-gui
- align the section label with the actual Bitgesell build targets

## Bounty
- Related to #32
- Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina

## Verification
- `git diff --check -- src/Makefile.qt.include`
- `rg -n "bitcoin-qt|bitcoin-gui|BGL-qt|BGL-gui" src/Makefile.qt.include`