### PR TITLE
lint: update BGL locale comments

### DIFF
--- a/test/lint/lint-locale-dependence.py
+++ b/test/lint/lint-locale-dependence.py
@@ -3,25 +3,25 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
-# Be aware that bitcoind and bitcoin-qt differ in terms of localization: Qt
+# Be aware that BGLd and BGL-qt differ in terms of localization: Qt
 # opts in to POSIX localization by running setlocale(LC_ALL, "") on startup,
-# whereas no such call is made in bitcoind.
+# whereas no such call is made in BGLd.
 #
 # Qt runs setlocale(LC_ALL, "") on initialization. This installs the locale
 # specified by the user's LC_ALL (or LC_*) environment variable as the new
 # C locale.
 #
-# In contrast, bitcoind does not opt in to localization -- no call to
+# In contrast, BGLd does not opt in to localization -- no call to
 # setlocale(LC_ALL, "") is made and the environment variables LC_* are
 # thus ignored.
 #
-# This results in situations where bitcoind is guaranteed to be running
-# with the classic locale ("C") whereas the locale of bitcoin-qt will vary
+# This results in situations where BGLd is guaranteed to be running
+# with the classic locale ("C") whereas the locale of BGL-qt will vary
 # depending on the user's environment variables.
 #
 # An example: Assuming the environment variable LC_ALL=de_DE then the
-# call std::to_string(1.23) will return "1.230000" in bitcoind but
-# "1,230000" in bitcoin-qt.
+# call std::to_string(1.23) will return "1.230000" in BGLd but
+# "1,230000" in BGL-qt.
 #
 # From the Qt documentation:
 # "On Unix/Linux Qt is configured to use the system locale settings by default.


### PR DESCRIPTION
## Summary
- update lint-locale-dependence comments to refer to BGLd and BGL-qt
- keep the localization explanation aligned with Bitgesell binary names

## Bounty
- Related to #32
- Payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`
- PayPal fallback: https://paypal.me/Jeremytsangchina

## Verification
- `git diff --check -- test/lint/lint-locale-dependence.py`
- `rg -n "bitcoind|bitcoin-qt|BGLd|BGL-qt" test/lint/lint-locale-dependence.py`
- `python -m py_compile test/lint/lint-locale-dependence.py`