### PR TITLE
doc: update addrman format comment for BGL

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -140,12 +140,12 @@ void AddrManImpl::Serialize(Stream& s_) const
      * * format version byte (@see `Format`)
      * * lowest compatible format version byte. This is used to help old software decide
      *   whether to parse the file. For example:
-     *   * Bitcoin Core version N knows how to parse up to format=3. If a new format=4 is
+     *   * BGL Core version N knows how to parse up to format=3. If a new format=4 is
      *     introduced in version N+1 that is compatible with format=3 and it is known that
      *     version N will be able to parse it, then version N+1 will write
      *     (format=4, lowest_compatible=3) in the first two bytes of the file, and so
      *     version N will still try to parse it.
-     *   * Bitcoin Core version N+2 introduces a new incompatible format=5. It will write
+     *   * BGL Core version N+2 introduces a new incompatible format=5. It will write
      *     (format=5, lowest_compatible=5) and so any versions that do not know how to parse
      *     format=5 will not try to read the file.
      * * nKey


### PR DESCRIPTION
Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32

Summary:
- Updates the addrman serialized-format compatibility example to refer to BGL Core versions instead of Bitcoin Core versions.
- Keeps the compatibility semantics unchanged.

Verification:
- git diff --check -- src/addrman.cpp
- rg -n "Bitcoin Core version|BGL Core version" src/addrman.cpp

Payout:
- USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y
- PayPal fallback: https://paypal.me/Jeremytsangchina