### PR TITLE
devtools: update symbol check BGL comments

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -41,7 +41,7 @@ MAX_VERSIONS = {
     lief.ELF.ARCH.RISCV:  (2,31),
 },
 'LIBATOMIC': (1,0),
-'V':         (0,5,0),  # xkb (bitcoin-qt only)
+'V':         (0,5,0),  # xkb (BGL-qt only)
 }
 
 # Ignore symbols that are exported as part of every executable
@@ -125,10 +125,10 @@ ELF_ALLOWED_LIBRARIES = {
 }
 
 MACHO_ALLOWED_LIBRARIES = {
-# bitcoind and bitcoin-qt
+# BGLd and BGL-qt
 'libc++.1.dylib', # C++ Standard Library
 'libSystem.B.dylib', # libc, libm, libpthread, libinfo
-# bitcoin-qt only
+# BGL-qt only
 'AppKit', # user interface
 'ApplicationServices', # common application tasks.
 'Carbon', # deprecated c back-compat API
@@ -155,7 +155,7 @@ PE_ALLOWED_LIBRARIES = {
 'msvcrt.dll', # C standard library for MSVC
 'SHELL32.dll', # shell API
 'WS2_32.dll', # sockets
-# bitcoin-qt only
+# BGL-qt only
 'dwmapi.dll', # desktop window manager
 'GDI32.dll', # graphics device interface
 'IMM32.dll', # input method editor


### PR DESCRIPTION
Bounty issue: https://github.com/BitgesellOfficial/bitgesell/issues/32

Summary:
- Updates stale binary-name comments in `contrib/devtools/symbol-check.py` from Bitcoin executable names to BGL executable names.
- Aligns the Mach-O, PE, and xkb library notes with the existing BGLd/BGL-qt naming used elsewhere in the file.

Verification:
- git diff --check -- contrib/devtools/symbol-check.py
- rg -n "bitcoin-qt|bitcoind|BGLd|BGL-qt" contrib/devtools/symbol-check.py
- python -m py_compile contrib/devtools/symbol-check.py

Payout:
- USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y
- PayPal fallback: https://paypal.me/Jeremytsangchina