### PR TITLE
Fix BGL translation documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <br />
     <a href="#">English</a>
     ·
-    <a href="https://github.com/BitgesellOfficial/bitgesell/blob/master/README-zh.md">Chinese</a>
+    <a href="#translations">Translations</a>
   </p>
 </p>
 
@@ -196,7 +196,7 @@ Facebook: [Bitgesell](https://www.facebook.com/Bitgesell)
 ## Translations
 
 Changes to translations as well as new translations can be submitted to
-[BGL Core's Transifex page](https://www.transifex.com/bitcoin/bitcoin/).
+[BGL Core's Transifex page](https://www.transifex.com/BGL/BGL/).
 
 Translations are periodically pulled from Transifex and merged into the git repository. See the
 [translation process](doc/translation_process.md) for details on how this works.

--- a/doc/release-notes-empty-template.md
+++ b/doc/release-notes-empty-template.md
@@ -96,4 +96,4 @@ Thanks to everyone who directly contributed to this release:
 
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://www.transifex.com/BGL/BGL/).

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -57,12 +57,12 @@ Perform these checks when reviewing the release PR (see below):
   - Paste the output defining `HEADER_COMMITMENT_PERIOD` and `REDOWNLOAD_BUFFER_SIZE` into the top of [`src/headerssync.cpp`](/src/headerssync.cpp).
 - Clear the release notes and move them to the wiki (see "Write the release notes" below).
 - Translations on Transifex:
-    - Pull translations from Transifex into the master branch.
-    - Create [a new resource](https://www.transifex.com/bitcoin/bitcoin/content/) named after the major version with the slug `qt-translation-<RRR>x`, where `RRR` is the major branch number padded with zeros. Use `src/qt/locale/bitcoin_en.xlf` to create it.
+    - Pull translations from the [BGL Transifex project](https://www.transifex.com/BGL/BGL/) into the master branch.
+    - Create a new resource named after the major version with the slug `qt-translation-<RRR>x`, where `RRR` is the major branch number padded with zeros. Use `src/qt/locale/BGL_en.ts` to create it.
     - In the project workflow settings, ensure that [Translation Memory Fill-up](https://help.transifex.com/en/articles/6224817-setting-up-translation-memory-fill-up) is enabled and that [Translation Memory Context Matching](https://help.transifex.com/en/articles/6224753-translation-memory-with-context) is disabled.
     - Update the Transifex slug in [`.tx/config`](/.tx/config) to the slug of the resource created in the first step. This identifies which resource the translations will be synchronized from.
-    - Make an announcement that translators can start translating for the new version. You can use one of the [previous announcements](https://www.transifex.com/bitcoin/communication/) as a template.
-    - Change the auto-update URL for the resource to `master`, e.g. `https://raw.githubusercontent.com/bitcoin/bitcoin/master/src/qt/locale/bitcoin_en.xlf`. (Do this only after the previous steps, to prevent an auto-update from interfering.)
+    - Make an announcement that translators can start translating for the new version.
+    - Change the auto-update URL for the resource to `master`, e.g. `https://raw.githubusercontent.com/BitgesellOfficial/bitgesell/master/src/qt/locale/BGL_en.ts`. (Do this only after the previous steps, to prevent an auto-update from interfering.)
 
 #### After branch-off (on the major release branch)
 
@@ -71,7 +71,7 @@ Perform these checks when reviewing the release PR (see below):
 - Clear the release notes: `cp doc/release-notes-empty-template.md doc/release-notes.md`
 - Create a pinned meta-issue for testing the release candidate (see [this issue](https://github.com/bitcoin/bitcoin/issues/27621) for an example) and provide a link to it in the release announcements where useful.
 - Translations on Transifex
-    - Change the auto-update URL for the new major version's resource away from `master` and to the branch, e.g. `https://raw.githubusercontent.com/bitcoin/bitcoin/<branch>/src/qt/locale/bitcoin_en.xlf`. Do not forget this or it will keep tracking the translations on master instead, drifting away from the specific major release.
+    - Change the auto-update URL for the new major version's resource away from `master` and to the branch, e.g. `https://raw.githubusercontent.com/BitgesellOfficial/bitgesell/<branch>/src/qt/locale/BGL_en.ts`. Do not forget this or it will keep tracking the translations on master instead, drifting away from the specific major release.
 - Prune inputs from the qa-assets repo (See [pruning
   inputs](https://github.com/bitcoin-core/qa-assets#pruning-inputs)).
 


### PR DESCRIPTION
## Problem
The public README links to `README-zh.md`, but that file is not present in this repository. The README and release note template also still point translators at Bitcoin Core's Transifex project, while this repository's translation guide points to the BGL Transifex project.

## Summary
- Replace the missing README language link with the existing `#translations` section.
- Update the README and release notes template to use the BGL Transifex project.
- Update the release-process Transifex steps to reference the BGL translation source file and Bitgesell raw GitHub URLs.

## Verification
- `git diff --check`
- Confirmed `README-zh.md` is not present in the repository.
- Confirmed `src/qt/locale/BGL_en.ts` exists.
- Confirmed the new raw GitHub URL for `src/qt/locale/BGL_en.ts` returns HTTP 200.

Related bounty: #32

Payment if approved: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`.