### PR TITLE
Fix stale README developer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,15 @@ In "Developer Command Prompt for VS 2022":
     >cmake -G "Visual Studio 17 2022" -A x64 -S . -B build
     >cmake --build build --config RelWithDebInfo
 
-Usage examples
------------
-Usage examples can be found in the [examples](examples) directory. To compile them you need to configure with `--enable-examples`.
-  * [ECDSA example](examples/ecdsa.c)
-  * [Schnorr signatures example](examples/schnorr.c)
-  * [Deriving a shared secret (ECDH) example](examples/ecdh.c)
-
-To compile the Schnorr signature and ECDH examples, you also need to configure with `--enable-module-schnorrsig` and `--enable-module-ecdh`.
-
-Benchmark
+Developer documentation
 ------------
-If configured with `--enable-benchmark` (which is the default), binaries for benchmarking the libsecp256k1 functions will be present in the root directory after the build.
+Bitgesell Core developer and operator documentation is maintained under the
+[doc](doc) directory.
+
+Useful starting points:
+  * [Build instructions](doc/build-unix.md)
+  * [Functional tests](test/functional/README.md)
+  * [JSON-RPC interface](doc/JSON-RPC-interface.md)
 
 Facebook: [Bitgesell](https://www.facebook.com/Bitgesell)
 


### PR DESCRIPTION
## Problem
The README still contains a libsecp256k1-style examples/benchmark section. It links to `examples/ecdsa.c`, `examples/schnorr.c`, and `examples/ecdh.c`, but the repository does not contain an `examples` directory. The benchmark sentence also describes libsecp256k1 functions rather than Bitgesell Core.

## Summary
- Replace the stale examples/benchmark section with Bitgesell Core developer documentation links.
- Point readers to existing build, functional test, and JSON-RPC documentation.

## Verification
- `git diff --check`
- Confirmed `examples` is absent.
- Confirmed `doc/build-unix.md`, `test/functional/README.md`, and `doc/JSON-RPC-interface.md` exist.
- Confirmed the stale `examples/*` and libsecp256k1 benchmark references are removed from `README.md`.

Related bounty: #32 and #39

Payment if approved: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`.