### PR TITLE
test: cover versionbits deployment info names

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -92,6 +92,7 @@ BGL_TESTS =\
   test/cuckoocache_tests.cpp \
   test/dbwrapper_tests.cpp \
   test/denialofservice_tests.cpp \
+  test/deploymentinfo_tests.cpp \
   test/descriptor_tests.cpp \
   test/disconnected_transactions.cpp \
   test/flatfile_tests.cpp \

--- a/src/test/deploymentinfo_tests.cpp
+++ b/src/test/deploymentinfo_tests.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 The Bitgesell developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <deploymentinfo.h>
+
+#include <consensus/params.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <string>
+
+BOOST_AUTO_TEST_SUITE(deploymentinfo_tests)
+
+BOOST_AUTO_TEST_CASE(versionbits_deployment_names_are_complete)
+{
+    for (int i = 0; i < static_cast<int>(Consensus::MAX_VERSION_BITS_DEPLOYMENTS); ++i) {
+        const auto deployment = static_cast<Consensus::DeploymentPos>(i);
+        BOOST_REQUIRE(Consensus::ValidDeployment(deployment));
+
+        const char* const name = VersionBitsDeploymentInfo[deployment].name;
+        BOOST_REQUIRE_MESSAGE(name != nullptr, "missing deployment name at index " << i);
+        BOOST_CHECK_MESSAGE(!std::string{name}.empty(), "empty deployment name at index " << i);
+        BOOST_CHECK_EQUAL(DeploymentName(deployment), std::string{name});
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- add a focused `deploymentinfo_tests` unit-test suite
- assert every `VersionBitsDeploymentInfo` entry has a non-null, non-empty name
- compare `DeploymentName()` against the metadata table so missing versionbits entries are caught before RPC code can construct invalid strings

## Context

This adds regression coverage for the class of issue discussed in #123, where a missing versionbits deployment name could make `getblocktemplate` fail with `basic_string::_M_construct null not valid`.

## Verification

- RED check: temporarily set `taproot_discarded`'s deployment name to `nullptr`; `LD_LIBRARY_PATH=/home/thuan/miniconda3/envs/py311/lib src/test/test_BGL --run_test=deploymentinfo_tests` failed with `missing deployment name at index 1`
- `make -j2 -C src test/test_BGL`
- `LD_LIBRARY_PATH=/home/thuan/miniconda3/envs/py311/lib src/test/test_BGL --run_test=deploymentinfo_tests` -> `No errors detected`
- `git diff --cached --check`

## Bounty / payout

Submitting for the open Bitgesell PR bounty program (#32, #39, #81) if maintainers consider this eligible.

Payout if approved: USDT or USDC SPL on Solana: `6mL4QQwcwLmb9UX1PjHtRSQ8J3HazCeVSDdZdDVQGXJj`.
