### PR TITLE
test: remove outdated gettime check

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -520,14 +520,6 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 #undef B
 #undef E
 
-/* Check for mingw/wine issue #3494
- * Remove this test before time.ctime(0xffffffff) == 'Sun Feb  7 07:28:15 2106'
- */
-BOOST_AUTO_TEST_CASE(gettime)
-{
-    BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
-}
-
 BOOST_AUTO_TEST_CASE(util_time_GetTime)
 {
     SetMockTime(111);


### PR DESCRIPTION
## Summary
- Remove the obsolete `gettime` unit test called out in #143.
- Leave the existing `util_time_GetTime` mock-time coverage in place.

## Verification
- `git diff --check -- src/test/util_tests.cpp`
- `rg -n "BOOST_AUTO_TEST_CASE\(gettime\)|issue #3494|0xffffffff|time\.ctime" src/test/util_tests.cpp` (no matches)

Fixes #143.
Related to bounty #32.