### PR TITLE
test: remove obsolete gettime check

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -520,14 +520,6 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 #undef B
 #undef E
 
-/* Check for mingw/wine issue #3494
- * Remove this test before time.ctime(0xffffffff) == 'Sun Feb  7 07:28:15 2106'
- */
-BOOST_AUTO_TEST_CASE(gettime)
-{
-    BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
-}
-
 BOOST_AUTO_TEST_CASE(util_time_GetTime)
 {
     SetMockTime(111);


### PR DESCRIPTION
## Summary
Removes the obsolete `gettime` unit test that checks whether `GetTime()` fits in 32 bits.

## What changed
- Deleted the old MinGW/Wine `gettime` compatibility test from `src/test/util_tests.cpp`.
- Left the modern `util_time_GetTime` coverage in place for mock time and chrono precision handling.

## How tested
- `git diff --check`
- `rg -n "BOOST_AUTO_TEST_CASE\\(gettime\\)|mingw/wine issue #3494|0xffffffff" src/test/util_tests.cpp` (no matches)

Not run: `src/test/test_BGL --run_test=util_tests`, because this checkout does not have a configured build or test binary yet.

## Related issue/bounty
Fixes #143.
Also submitted under the public BGL PR bounty hunt (#32/#39) if maintainers consider this change eligible.

## Notes
This is intentionally a narrow cleanup PR matching the issue scope.
