### PR TITLE
build: fix cuckoocache bool fuzz target compile

### DIFF
--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -435,7 +435,12 @@ public:
             * for the next iteration.
             */
             last_loc = locs[(1 + (std::find(locs.begin(), locs.end(), last_loc) - locs.begin())) & 7];
-            std::swap(table[last_loc], e);
+            // Avoid std::swap here: when Element is bool, table[last_loc]
+            // is a std::vector<bool>::reference proxy and cannot be swapped
+            // directly with the local bool on newer standard libraries.
+            Element evicted = std::move(table[last_loc]);
+            table[last_loc] = std::move(e);
+            e = std::move(evicted);
             // Can't std::swap a std::vector<bool>::reference and a bool&.
             bool epoch = last_epoch;
             last_epoch = epoch_flags[last_loc];


### PR DESCRIPTION
## Summary
- Fixes the `cuckoocache` fuzz target build when `Element` is `bool`.
- Avoids calling `std::swap(table[last_loc], e)` because `std::vector<bool>` returns a proxy reference that newer standard libraries do not swap directly with `bool&`.
- Preserves the existing eviction behavior by moving the evicted table value into `e` for the next insertion iteration.

Related: #39

## QA
- `./configure --without-gui --disable-wallet --disable-zmq --with-miniupnpc=no --with-natpmp=no --disable-bench`
- `make -j2`
- `./src/test/test_BGL --run_test=cuckoocache_tests --catch_system_errors=no`
- `FUZZ=cuckoocache ./src/test/fuzz/fuzz /tmp/bitgesell-cuckoo-empty-seed`
