### PR TITLE
Fix stale issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,10 +5,10 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## This issue tracker is only for technical issues related to Bitcoin Core.
+        ## This issue tracker is only for technical issues related to BGL Core.
 
-        * General bitcoin questions and/or support requests should use Bitcoin StackExchange at https://bitcoin.stackexchange.com.
-        * For reporting security issues, please read instructions at https://bitcoincore.org/en/contact/.
+        * General BGL questions and/or support requests should use the project community channels.
+        * For reporting security issues, please follow this repository's security policy.
         * If the node is "stuck" during sync or giving "block checksum mismatch" errors, please ensure your hardware is stable by running `memtest` and observe CPU temperature with a load-test tool such as `linpack` before creating an issue.
 
         ----
@@ -50,14 +50,14 @@ body:
       description: |
         Please copy and paste any relevant log output or attach a debug log file.
 
-        You can find the debug.log in your [data dir.](https://github.com/bitcoin/bitcoin/blob/master/doc/files.md#data-directory-location)
+        You can find the debug.log in your BGL Core data directory.
 
         Please be aware that the debug log might contain personally identifying information.
     validations:
       required: false
   - type: dropdown
     attributes:
-      label: How did you obtain Bitcoin Core
+      label: How did you obtain BGL Core
       multiple: false
       options:
         - Compiled from source
@@ -69,8 +69,8 @@ body:
   - type: input
     id: core-version
     attributes:
-      label: What version of Bitcoin Core are you using?
-      description: Run `bitcoind --version` or in Bitcoin-QT use `Help > About Bitcoin Core`
+      label: What version of BGL Core are you using?
+      description: Run `BGLd --version` or in BGL-Qt use `Help > About BGL Core`
       placeholder: e.g. v24.0.1 or master@e1bf547
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Bitcoin Core Security Policy
-    url: https://github.com/bitcoin/bitcoin/blob/master/SECURITY.md
-    about: View security policy
-  - name: Bitcoin Core Developers
-    url: https://bitcoincore.org
-    about: Bitcoin Core homepage
+  - name: Bitgesell Security Policy
+    url: https://github.com/BitgesellOfficial/bitgesell/security/policy
+    about: View security reporting guidance
+  - name: Bitgesell Project
+    url: https://github.com/BitgesellOfficial/bitgesell
+    about: Bitgesell Core repository

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -28,9 +28,9 @@ body:
     id: useful-skills
     attributes:
       label: Useful Skills
-      description: For example, “`std::thread`”, “Qt5 GUI and async GUI design” or “basic understanding of Bitcoin mining and the Bitcoin Core RPC interface”.
+      description: For example, “`std::thread`”, “Qt5 GUI and async GUI design” or “basic understanding of Bitgesell mining and the BGL Core RPC interface”.
       value: |
-        * Compiling Bitcoin Core from source
+        * Compiling BGL Core from source
         * Running the C++ unit tests and the Python functional tests
         * ...
   - type: textarea
@@ -40,5 +40,5 @@ body:
       value: |
         Want to work on this issue?
 
-        For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md) before opening your pull request.
+        For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/BitgesellOfficial/bitgesell/blob/master/CONTRIBUTING.md) before opening your pull request.
 

--- a/.github/ISSUE_TEMPLATE/gui_issue.yml
+++ b/.github/ISSUE_TEMPLATE/gui_issue.yml
@@ -5,8 +5,8 @@ body:
 - type: checkboxes
   id: acknowledgement
   attributes:
-    label: Issues, reports or feature requests related to the GUI should be opened directly on the GUI repo
-    description: https://github.com/bitcoin-core/gui/issues/
+    label: Issues, reports or feature requests related to the GUI should include enough detail for BGL Core maintainers to reproduce them
+    description: Include screenshots, logs, and platform details when applicable.
     options:
       - label: I still think this issue should be opened here
         required: true


### PR DESCRIPTION
### Description
Fix stale inherited Bitcoin Core references in the GitHub issue templates so new reports and contributor suggestions point to Bitgesell/BGL Core resources instead of upstream Bitcoin Core resources.

### Notes
- Updates the bug report template wording and version hint to BGL Core / BGLd / BGL-Qt.
- Updates contact links to this repository's security policy and project page.
- Updates the good-first-issue helper text and CONTRIBUTING.md link.
- Replaces the GUI template's upstream GUI-repo redirect with a BGL Core reproduction-detail request.

Verification:
- Parsed every `.github/ISSUE_TEMPLATE/*.yml` file with PyYAML.
- Checked the issue templates for leftover `Bitcoin`, `bitcoin`, `bitcoind`, `bitcoin-core`, and `bitcoincore` references.
- Ran `git diff --check`.

### BTC/BGL PR reward address
BGL/USDT payout can be coordinated after approval.

Refs #32
