### PR TITLE
doc: add contributor quickstart

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,13 @@ what is the goal of the pull request
 Pull requests without a rationale and clear improvement may be closed
 immediately.
 
+Related issue or bounty:
+
 ### Notes
 implementation details, hints for reviewers
 
+Validation performed:
+
 ### BTC/BGL PR reward address
-if applicable, please type your reward wallet address here
+If applicable, type your reward wallet address here or say that you can provide
+it privately after maintainer approval.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,13 @@ Usage examples can be found in the [examples](examples) directory. To compile th
 
 To compile the Schnorr signature and ECDH examples, you also need to configure with `--enable-module-schnorrsig` and `--enable-module-ecdh`.
 
+## Contributing
+
+For a short fork-to-pull-request workflow, see
+[doc/contributor-quickstart.md](doc/contributor-quickstart.md). It covers
+focused branches, useful change scopes, local validation, and bounty submission
+notes.
+
 Benchmark
 ------------
 If configured with `--enable-benchmark` (which is the default), binaries for benchmarking the libsecp256k1 functions will be present in the root directory after the build.

--- a/doc/contributor-quickstart.md
+++ b/doc/contributor-quickstart.md
@@ -1,0 +1,78 @@
+# Bitgesell Contributor Quickstart
+
+This guide gives new contributors a short path from a fresh fork to a focused
+pull request. It is meant for small fixes, test updates, documentation changes,
+and bounty submissions.
+
+## 1. Prepare a Fork
+
+```bash
+git clone https://github.com/<your-name>/bitgesell.git
+cd bitgesell
+git remote add upstream https://github.com/BitgesellOfficial/bitgesell.git
+git fetch upstream
+git switch -c my-focused-change upstream/master
+```
+
+Keep each branch scoped to one topic. If you are working on a bounty, link the
+bounty issue in the pull request body.
+
+## 2. Choose the Smallest Useful Scope
+
+Good first pull requests usually fit one of these categories:
+
+- a failing or outdated test fixed in place
+- a small refactor with no behavior change
+- a stale command, link, or project-name reference corrected in documentation
+- a focused build, CI, or lint improvement
+- a narrowly described bug fix with a reproduction note
+
+Avoid mixing unrelated formatting, refactors, and feature changes in the same
+pull request. Review is easier when every diff hunk supports the same goal.
+
+## 3. Run the Relevant Check
+
+Pick the narrowest check that covers your change:
+
+```bash
+# Documentation-only changes
+git diff --check
+
+# Python functional-test framework changes
+python3 test/functional/test_runner.py --help
+
+# Autotools build, when dependencies are available
+./autogen.sh
+./configure
+make check
+```
+
+If you cannot run a broader check locally, say which command was skipped and why
+in the pull request notes.
+
+## 4. Write a Reviewable Pull Request
+
+Use the pull request body to answer these questions:
+
+- What changed?
+- Why is it useful for Bitgesell?
+- Which issue or bounty does it address?
+- Which checks did you run?
+- Is a BTC, BGL, or USDT reward address needed for a bounty payout?
+
+For bounty work, include the reward address only if you are comfortable sharing
+it in the public pull request. Otherwise, say that you can provide it privately
+after maintainer approval.
+
+## 5. Keep the Branch Current
+
+Before asking for a final review, rebase on the current upstream branch:
+
+```bash
+git fetch upstream
+git rebase upstream/master
+git push --force-with-lease
+```
+
+Use `--force-with-lease` instead of a plain force push so you do not overwrite
+remote work that you have not fetched.


### PR DESCRIPTION
### Description
Adds a focused contributor quickstart for Bitgesell pull requests and bounty submissions, then links it from the README and expands the PR template with issue/bounty, validation, and reward-address prompts.

This addresses the contributor onboarding part of #32 by making it clearer how to prepare a focused branch, choose a reviewable scope, run a relevant check, and document bounty payout details without exposing a public address before approval.

### Notes
- Adds `doc/contributor-quickstart.md` with fork, scope, validation, PR body, and rebase guidance.
- Links the guide from `README.md`.
- Updates `.github/PULL_REQUEST_TEMPLATE.md` so PR authors include the related issue/bounty and validation performed.

### Validation performed
- `git diff --check`

### BTC/BGL PR reward address
Can provide privately after maintainer approval.