### PR TITLE
build: fix make -j$(nproc) race for libsecp256k1 (closes #139)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -66,6 +66,12 @@ LIBBGL_CRYPTO += $(LIBBGL_CRYPTO_ARM_SHANI)
 endif
 noinst_LTLIBRARIES += $(LIBBGL_CRYPTO)
 
+# Ensure libsecp256k1 is fully built before any parallel link target picks it
+# up. Without this, `make -j$(nproc)` can race between multiple bin_PROGRAMS
+# targets all triggering `cd secp256k1 && $(MAKE)` concurrently, causing
+# intermittent error 1 exit codes on high-core-count CI runners. See #139.
+BUILT_SOURCES = $(LIBSECP256K1)
+
 $(LIBSECP256K1): $(wildcard secp256k1/src/*.h) $(wildcard secp256k1/src/*.c) $(wildcard secp256k1/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
 


### PR DESCRIPTION
## Root cause

`src/Makefile.am` declares `LIBSECP256K1` with a per-file wildcard
dependency at lines 69-70, but the `.la` target is never registered in
`EXTRA_LIBRARIES`, `BUILT_SOURCES`, or `noinst_LTLIBRARIES`.

Under serial `make` this is fine — automake auto-resolves the prereq
from `LDADD` references. Under `make -j$(nproc)` GNU make schedules
link-time targets (`BGLd`, `BGL-node`, `BGL-cli`) **before** the
`secp256k1` subprocess Makefile finishes, causing intermittent `error 1`
when multiple targets race to `cd secp256k1 && $(MAKE)`.

## Fix

Add `$(LIBSECP256K1)` to `BUILT_SOURCES` so it is materialized before
any object compilation step begins, regardless of `-j` level.

## Diff

Just 6 lines added to `src/Makefile.am` (one comment block + one
`BUILT_SOURCES` declaration). No behavior change for serial builds; eliminates the race for parallel builds.

## Testing

This is a build-system race condition fix — the change itself is a
well-known autotools idiom for handling sub-library dependencies in
parallel builds. The same pattern is used in Bitcoin Core's older
autotools-era `src/Makefile.am`.

I could not reproduce the original error on a clean Windows VM in the
time available (the bug surfaces non-deterministically on CI-class
machines with high core counts), but the fix is structurally sound and
strictly additive. Happy to coordinate further testing on Discord.

## Related

Closes #139.

Discord coordination welcome: `@madnadyka`, `@janus`, `@van-orton`.
Open to any test methodology you'd like before merge.