### PR TITLE
doc: use BGL-cli in JSON-RPC examples

### DIFF
--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -24,7 +24,7 @@ This endpoint is only activated when the wallet component has been compiled in.
 It can service both wallet and non-wallet requests.
 It MUST be used for wallet requests when two or more wallets are loaded.
 
-This is the endpoint used by bitcoin-cli when a `-rpcwallet=` parameter is passed in.
+This is the endpoint used by `BGL-cli` when a `-rpcwallet=` parameter is passed in.
 
 Best practice would dictate using the `/wallet/<walletname>/` endpoint for ALL
 requests when multiple wallets are in use.
@@ -53,13 +53,13 @@ Examples:
 
 ```sh
 # "params": ["mywallet", false, false, "", false, false, true]
-bitcoin-cli createwallet mywallet false false "" false false true
+BGL-cli createwallet mywallet false false "" false false true
 
 # "params": {"wallet_name": "mywallet", "load_on_startup": true}
-bitcoin-cli -named createwallet wallet_name=mywallet load_on_startup=true
+BGL-cli -named createwallet wallet_name=mywallet load_on_startup=true
 
 # "params": {"args": ["mywallet"], "load_on_startup": true}
-bitcoin-cli -named createwallet mywallet load_on_startup=true
+BGL-cli -named createwallet mywallet load_on_startup=true
 ```
 
 ## Versioning


### PR DESCRIPTION
### Description
Align the JSON-RPC wallet endpoint and createwallet examples with the Bitgesell CLI executable name.

This keeps the JSON-RPC interface guide consistent with the same document's `BGLd` and `BGL-qt` naming and avoids sending users to the upstream Bitcoin Core `bitcoin-cli` executable name.

Related to the PR bounty hunt: #39

### Notes
- Replaced the wallet endpoint sentence's `bitcoin-cli` reference with `BGL-cli`.
- Replaced the three parameter-passing examples with `BGL-cli`.
- Scope is intentionally docs-only.

### Validation
- `git diff --check`
- `rg -n "bitcoin-cli|BGL-cli|BGLd|BGL-qt" doc/JSON-RPC-interface.md`
- `python3 -m compileall -q test/functional/test_runner.py test/functional/test_framework`
