### PR TITLE
doc: update multiprocess docs for BGL names

### DIFF
--- a/doc/design/libraries.md
+++ b/doc/design/libraries.md
@@ -2,30 +2,30 @@
 
 | Name                     | Description |
 |--------------------------|-------------|
-| *libbitcoin_cli*         | RPC client functionality used by *bitcoin-cli* executable |
-| *libbitcoin_common*      | Home for common functionality shared by different executables and libraries. Similar to *libbitcoin_util*, but higher-level (see [Dependencies](#dependencies)). |
-| *libbitcoin_consensus*   | Stable, backwards-compatible consensus functionality used by *libbitcoin_node* and *libbitcoin_wallet* and also exposed as a [shared library](../shared-libraries.md). |
-| *libbitcoinconsensus*    | Shared library build of static *libbitcoin_consensus* library |
-| *libbitcoin_kernel*      | Consensus engine and support library used for validation by *libbitcoin_node* and also exposed as a [shared library](../shared-libraries.md). |
-| *libbitcoinqt*           | GUI functionality used by *bitcoin-qt* and *bitcoin-gui* executables |
-| *libbitcoin_ipc*         | IPC functionality used by *bitcoin-node*, *bitcoin-wallet*, *bitcoin-gui* executables to communicate when [`--enable-multiprocess`](multiprocess.md) is used. |
-| *libbitcoin_node*        | P2P and RPC server functionality used by *bitcoind* and *bitcoin-qt* executables. |
-| *libbitcoin_util*        | Home for common functionality shared by different executables and libraries. Similar to *libbitcoin_common*, but lower-level (see [Dependencies](#dependencies)). |
-| *libbitcoin_wallet*      | Wallet functionality used by *bitcoind* and *bitcoin-wallet* executables. |
-| *libbitcoin_wallet_tool* | Lower-level wallet functionality used by *bitcoin-wallet* executable. |
-| *libbitcoin_zmq*         | [ZeroMQ](../zmq.md) functionality used by *bitcoind* and *bitcoin-qt* executables. |
+| *libBGL_cli*         | RPC client functionality used by the *BGL-cli* executable |
+| *libBGL_common*      | Home for common functionality shared by different executables and libraries. Similar to *libBGL_util*, but higher-level (see [Dependencies](#dependencies)). |
+| *libBGL_consensus*   | Stable, backwards-compatible consensus functionality used by *libBGL_node* and *libBGL_wallet* and also exposed as a [shared library](../shared-libraries.md). |
+| *BGLconsensus*       | Shared library interface for script verification |
+| *libBGLkernel*       | Consensus engine and support library used for validation by *libBGL_node* and also exposed as a [shared library](../shared-libraries.md). |
+| *libBGLqt*           | GUI functionality used by *BGL-qt* and *BGL-gui* executables |
+| *libBGL_ipc*         | IPC functionality used by *BGL-node*, *BGL-wallet*, and *BGL-gui* executables to communicate when [`--enable-multiprocess`](multiprocess.md) is used. |
+| *libBGL_node*        | P2P and RPC server functionality used by *BGLd*, *BGL-node*, *BGL-qt*, and *BGL-gui* executables. |
+| *libBGL_util*        | Home for common functionality shared by different executables and libraries. Similar to *libBGL_common*, but lower-level (see [Dependencies](#dependencies)). |
+| *libBGL_wallet*      | Wallet functionality used by *BGLd*, *BGL-wallet*, *BGL-qt*, and *BGL-gui* executables. |
+| *libBGL_wallet_tool* | Lower-level wallet functionality used by the *BGL-wallet* executable. |
+| *libBGL_zmq*         | [ZeroMQ](../zmq.md) functionality used by *BGLd*, *BGL-qt*, and *BGL-gui* executables. |
 
 ## Conventions
 
-- Most libraries are internal libraries and have APIs which are completely unstable! There are few or no restrictions on backwards compatibility or rules about external dependencies. Exceptions are *libbitcoin_consensus* and *libbitcoin_kernel* which have external interfaces documented at [../shared-libraries.md](../shared-libraries.md).
+- Most libraries are internal libraries and have APIs which are completely unstable! There are few or no restrictions on backwards compatibility or rules about external dependencies. Exceptions are *libBGL_consensus* and *libBGLkernel* which have external interfaces documented at [../shared-libraries.md](../shared-libraries.md).
 
-- Generally each library should have a corresponding source directory and namespace. Source code organization is a work in progress, so it is true that some namespaces are applied inconsistently, and if you look at [`libbitcoin_*_SOURCES`](../../src/Makefile.am) lists you can see that many libraries pull in files from outside their source directory. But when working with libraries, it is good to follow a consistent pattern like:
+- Generally each library should have a corresponding source directory and namespace. Source code organization is a work in progress, so it is true that some namespaces are applied inconsistently, and if you look at [`libBGL_*_SOURCES`](../../src/Makefile.am) lists you can see that many libraries pull in files from outside their source directory. But when working with libraries, it is good to follow a consistent pattern like:
 
-  - *libbitcoin_node* code lives in `src/node/` in the `node::` namespace
-  - *libbitcoin_wallet* code lives in `src/wallet/` in the `wallet::` namespace
-  - *libbitcoin_ipc* code lives in `src/ipc/` in the `ipc::` namespace
-  - *libbitcoin_util* code lives in `src/util/` in the `util::` namespace
-  - *libbitcoin_consensus* code lives in `src/consensus/` in the `Consensus::` namespace
+  - *libBGL_node* code lives in `src/node/` in the `node::` namespace
+  - *libBGL_wallet* code lives in `src/wallet/` in the `wallet::` namespace
+  - *libBGL_ipc* code lives in `src/ipc/` in the `ipc::` namespace
+  - *libBGL_util* code lives in `src/util/` in the `util::` namespace
+  - *libBGL_consensus* code lives in `src/consensus/` in the `Consensus::` namespace
 
 ## Dependencies
 
@@ -39,43 +39,51 @@
 
 graph TD;
 
-bitcoin-cli[bitcoin-cli]-->libbitcoin_cli;
+bgl_cli[BGL-cli]-->libBGL_cli;
 
-bitcoind[bitcoind]-->libbitcoin_node;
-bitcoind[bitcoind]-->libbitcoin_wallet;
+bgld[BGLd]-->libBGL_node;
+bgld[BGLd]-->libBGL_wallet;
 
-bitcoin-qt[bitcoin-qt]-->libbitcoin_node;
-bitcoin-qt[bitcoin-qt]-->libbitcoinqt;
-bitcoin-qt[bitcoin-qt]-->libbitcoin_wallet;
+bgl_qt[BGL-qt]-->libBGL_node;
+bgl_qt[BGL-qt]-->libBGLqt;
+bgl_qt[BGL-qt]-->libBGL_wallet;
 
-bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet;
-bitcoin-wallet[bitcoin-wallet]-->libbitcoin_wallet_tool;
+bgl_node[BGL-node]-->libBGL_node;
+bgl_node[BGL-node]-->libBGL_ipc;
 
-libbitcoin_cli-->libbitcoin_util;
-libbitcoin_cli-->libbitcoin_common;
+bgl_gui[BGL-gui]-->libBGL_node;
+bgl_gui[BGL-gui]-->libBGLqt;
+bgl_gui[BGL-gui]-->libBGL_wallet;
+bgl_gui[BGL-gui]-->libBGL_ipc;
 
-libbitcoin_common-->libbitcoin_consensus;
-libbitcoin_common-->libbitcoin_util;
+bgl_wallet[BGL-wallet]-->libBGL_wallet;
+bgl_wallet[BGL-wallet]-->libBGL_wallet_tool;
 
-libbitcoin_kernel-->libbitcoin_consensus;
-libbitcoin_kernel-->libbitcoin_util;
+libBGL_cli-->libBGL_util;
+libBGL_cli-->libBGL_common;
 
-libbitcoin_node-->libbitcoin_consensus;
-libbitcoin_node-->libbitcoin_kernel;
-libbitcoin_node-->libbitcoin_common;
-libbitcoin_node-->libbitcoin_util;
+libBGL_common-->libBGL_consensus;
+libBGL_common-->libBGL_util;
 
-libbitcoinqt-->libbitcoin_common;
-libbitcoinqt-->libbitcoin_util;
+libBGLkernel-->libBGL_consensus;
+libBGLkernel-->libBGL_util;
 
-libbitcoin_wallet-->libbitcoin_common;
-libbitcoin_wallet-->libbitcoin_util;
+libBGL_node-->libBGL_consensus;
+libBGL_node-->libBGLkernel;
+libBGL_node-->libBGL_common;
+libBGL_node-->libBGL_util;
 
-libbitcoin_wallet_tool-->libbitcoin_wallet;
-libbitcoin_wallet_tool-->libbitcoin_util;
+libBGLqt-->libBGL_common;
+libBGLqt-->libBGL_util;
+
+libBGL_wallet-->libBGL_common;
+libBGL_wallet-->libBGL_util;
+
+libBGL_wallet_tool-->libBGL_wallet;
+libBGL_wallet_tool-->libBGL_util;
 
 classDef bold stroke-width:2px, font-weight:bold, font-size: smaller;
-class bitcoin-qt,bitcoind,bitcoin-cli,bitcoin-wallet bold
+class bgl_qt,bgld,bgl_cli,bgl_node,bgl_gui,bgl_wallet bold
 ```
 </td></tr><tr><td>
 
@@ -83,22 +91,22 @@ class bitcoin-qt,bitcoind,bitcoin-cli,bitcoin-wallet bold
 
 </td></tr></table>
 
-- The graph shows what _linker symbols_ (functions and variables) from each library other libraries can call and reference directly, but it is not a call graph. For example, there is no arrow connecting *libbitcoin_wallet* and *libbitcoin_node* libraries, because these libraries are intended to be modular and not depend on each other's internal implementation details. But wallet code is still able to call node code indirectly through the `interfaces::Chain` abstract class in [`interfaces/chain.h`](../../src/interfaces/chain.h) and node code calls wallet code through the `interfaces::ChainClient` and `interfaces::Chain::Notifications` abstract classes in the same file. In general, defining abstract classes in [`src/interfaces/`](../../src/interfaces/) can be a convenient way of avoiding unwanted direct dependencies or circular dependencies between libraries.
+- The graph shows what _linker symbols_ (functions and variables) from each library other libraries can call and reference directly, but it is not a call graph. For example, there is no arrow connecting *libBGL_wallet* and *libBGL_node* libraries, because these libraries are intended to be modular and not depend on each other's internal implementation details. But wallet code is still able to call node code indirectly through the `interfaces::Chain` abstract class in [`interfaces/chain.h`](../../src/interfaces/chain.h) and node code calls wallet code through the `interfaces::ChainClient` and `interfaces::Chain::Notifications` abstract classes in the same file. In general, defining abstract classes in [`src/interfaces/`](../../src/interfaces/) can be a convenient way of avoiding unwanted direct dependencies or circular dependencies between libraries.
 
-- *libbitcoin_consensus* should be a standalone dependency that any library can depend on, and it should not depend on any other libraries itself.
+- *libBGL_consensus* should be a standalone dependency that any library can depend on, and it should not depend on any other libraries itself.
 
-- *libbitcoin_util* should also be a standalone dependency that any library can depend on, and it should not depend on other internal libraries.
+- *libBGL_util* should also be a standalone dependency that any library can depend on, and it should not depend on other internal libraries.
 
-- *libbitcoin_common* should serve a similar function as *libbitcoin_util* and be a place for miscellaneous code used by various daemon, GUI, and CLI applications and libraries to live. It should not depend on anything other than *libbitcoin_util* and *libbitcoin_consensus*. The boundary between _util_ and _common_ is a little fuzzy but historically _util_ has been used for more generic, lower-level things like parsing hex, and _common_ has been used for bitcoin-specific, higher-level things like parsing base58. The difference between util and common is mostly important because *libbitcoin_kernel* is not supposed to depend on *libbitcoin_common*, only *libbitcoin_util*. In general, if it is ever unclear whether it is better to add code to *util* or *common*, it is probably better to add it to *common* unless it is very generically useful or useful particularly to include in the kernel.
+- *libBGL_common* should serve a similar function as *libBGL_util* and be a place for miscellaneous code used by various daemon, GUI, and CLI applications and libraries to live. It should not depend on anything other than *libBGL_util* and *libBGL_consensus*. The boundary between _util_ and _common_ is a little fuzzy but historically _util_ has been used for more generic, lower-level things like parsing hex, and _common_ has been used for BGL-specific, higher-level things like parsing base58. The difference between util and common is mostly important because *libBGLkernel* is not supposed to depend on *libBGL_common*, only *libBGL_util*. In general, if it is ever unclear whether it is better to add code to *util* or *common*, it is probably better to add it to *common* unless it is very generically useful or useful particularly to include in the kernel.
 
 
-- *libbitcoin_kernel* should only depend on *libbitcoin_util* and *libbitcoin_consensus*.
+- *libBGLkernel* should only depend on *libBGL_util* and *libBGL_consensus*.
 
-- The only thing that should depend on *libbitcoin_kernel* internally should be *libbitcoin_node*. GUI and wallet libraries *libbitcoinqt* and *libbitcoin_wallet* in particular should not depend on *libbitcoin_kernel* and the unneeded functionality it would pull in, like block validation. To the extent that GUI and wallet code need scripting and signing functionality, they should be get able it from *libbitcoin_consensus*, *libbitcoin_common*, and *libbitcoin_util*, instead of *libbitcoin_kernel*.
+- The only thing that should depend on *libBGLkernel* internally should be *libBGL_node*. GUI and wallet libraries *libBGLqt* and *libBGL_wallet* in particular should not depend on *libBGLkernel* and the unneeded functionality it would pull in, like block validation. To the extent that GUI and wallet code need scripting and signing functionality, they should be able to get it from *libBGL_consensus*, *libBGL_common*, and *libBGL_util*, instead of *libBGLkernel*.
 
-- GUI, node, and wallet code internal implementations should all be independent of each other, and the *libbitcoinqt*, *libbitcoin_node*, *libbitcoin_wallet* libraries should never reference each other's symbols. They should only call each other through [`src/interfaces/`](../../src/interfaces/) abstract interfaces.
+- GUI, node, and wallet code internal implementations should all be independent of each other, and the *libBGLqt*, *libBGL_node*, *libBGL_wallet* libraries should never reference each other's symbols. They should only call each other through [`src/interfaces/`](../../src/interfaces/) abstract interfaces.
 
 ## Work in progress
 
-- Validation code is moving from *libbitcoin_node* to *libbitcoin_kernel* as part of [The libbitcoinkernel Project #24303](https://github.com/bitcoin/bitcoin/issues/24303)
+- Validation code is moving from *libBGL_node* to *libBGLkernel* as part of the upstream [kernel library project #24303](https://github.com/bitcoin/bitcoin/issues/24303)
 - Source code organization is discussed in general in [Library source code organization #15732](https://github.com/bitcoin/bitcoin/issues/15732)

--- a/doc/design/multiprocess.md
+++ b/doc/design/multiprocess.md
@@ -1,6 +1,6 @@
-# Multiprocess Bitcoin Design Document
+# Multiprocess Bitgesell Design Document
 
-Guide to the design and architecture of the Bitcoin Core multiprocess feature
+Guide to the design and architecture of the Bitgesell Core multiprocess feature
 
 _This document describes the design of the multiprocess feature. For usage information, see the top-level [multiprocess.md](../multiprocess.md) file._
 
@@ -27,31 +27,31 @@ _This document describes the design of the multiprocess feature. For usage infor
 
 ## Introduction
 
-The Bitcoin Core software has historically employed a monolithic architecture. The existing design has integrated functionality like P2P network operations, wallet management, and a GUI into a single executable. While effective, it has limitations in flexibility, security, and scalability. This project introduces changes that transition Bitcoin Core to a more modular architecture. It aims to enhance security, improve usability, and facilitate maintenance and development of the software in the long run.
+Bitgesell Core has historically employed a monolithic architecture. The existing design has integrated functionality like P2P network operations, wallet management, and a GUI into a single executable. While effective, it has limitations in flexibility, security, and scalability. This project introduces changes that transition Bitgesell Core to a more modular architecture. It aims to enhance security, improve usability, and facilitate maintenance and development of the software in the long run.
 
 ## Current Architecture
 
-The current system features two primary executables: `bitcoind` and `bitcoin-qt`. `bitcoind` combines a Bitcoin P2P node with an integrated JSON-RPC server, wallet, and indexes. `bitcoin-qt` extends this by incorporating a Qt-based GUI. This monolithic structure, although robust, presents challenges such as limited operational flexibility and increased security risks due to the tight integration of components.
+The current system features two primary executables: `BGLd` and `BGL-qt`. `BGLd` combines a Bitgesell P2P node with an integrated JSON-RPC server, wallet, and indexes. `BGL-qt` extends this by incorporating a Qt-based GUI. This monolithic structure, although robust, presents challenges such as limited operational flexibility and increased security risks due to the tight integration of components.
 
 ## Proposed Architecture
 
 The new architecture divides the existing code into three specialized executables:
 
-- `bitcoin-node`: Manages the P2P node, indexes, and JSON-RPC server.
-- `bitcoin-wallet`: Handles all wallet functionality.
-- `bitcoin-gui`: Provides a standalone Qt-based GUI.
+- `BGL-node`: Manages the P2P node, indexes, and JSON-RPC server.
+- `BGL-wallet`: Handles all wallet functionality.
+- `BGL-gui`: Provides a standalone Qt-based GUI.
 
 This modular approach is designed to enhance security through component isolation and improve usability by allowing independent operation of each module. This allows for new use-cases, such as running the node on a dedicated machine and operating wallets and GUIs on separate machines with the flexibility to start and stop them as needed.
 
-This subdivision could be extended in the future. For example, indexes could be removed from the `bitcoin-node` executable and run in separate executables. And JSON-RPC servers could be added to wallet and index executables, so they can listen and respond to RPC requests on their own ports, without needing to forward RPC requests through `bitcoin-node`.
+This subdivision could be extended in the future. For example, indexes could be removed from the `BGL-node` executable and run in separate executables. And JSON-RPC servers could be added to wallet and index executables, so they can listen and respond to RPC requests on their own ports, without needing to forward RPC requests through `BGL-node`.
 
 <table><tr><td>
 
 ```mermaid
 flowchart LR
-    node[bitcoin-node] -- listens on --> socket["&lt;datadir&gt;/node.sock"]
-    wallet[bitcoin-wallet] -- connects to --> socket
-    gui[bitcoin-gui] -- connects to --> socket
+    node[BGL-node] -- listens on --> socket["&lt;datadir&gt;/node.sock"]
+    wallet[BGL-wallet] -- connects to --> socket
+    gui[BGL-gui] -- connects to --> socket
 ```
 
 </td></tr><tr><td>
@@ -90,7 +90,7 @@ This section describes the major components of the Inter-Process Communication (
 
 ### The `libmultiprocess` Runtime Library
 - **Core Functionality**: The `libmultiprocess` runtime library's primary function is to instantiate the generated client and server classes as needed.
-- **Bootstrapping IPC Connections**: It provides functions for starting new IPC connections, specifically binding generated client and server classes for an initial `interfaces::Init` interface (defined in [`src/interfaces/init.h`](../../src/interfaces/init.h)) to a UNIX socket. This initial interface has methods returning other interfaces that different Bitcoin Core modules use to communicate after the bootstrapping phase.
+- **Bootstrapping IPC Connections**: It provides functions for starting new IPC connections, specifically binding generated client and server classes for an initial `interfaces::Init` interface (defined in [`src/interfaces/init.h`](../../src/interfaces/init.h)) to a UNIX socket. This initial interface has methods returning other interfaces that different Bitgesell Core modules use to communicate after the bootstrapping phase.
 - **Asynchronous I/O and Thread Management**: The library is also responsible for managing I/O and threading. Particularly, it ensures that IPC requests never block each other and that new threads on either side of a connection can always make client calls. It also manages worker threads on the server side of calls, ensuring that calls from the same client thread always execute on the same server thread (to avoid locking issues and support nested callbacks).
 
 ### Type Hooks in [`src/ipc/capnp/*-types.h`](../../src/ipc/capnp/)
@@ -124,13 +124,13 @@ Diagram showing generated source files and includes.
 ### Selection of Cap’n Proto
 The choice to use [Cap’n Proto](https://capnproto.org/) for IPC was primarily influenced by its support for passing object references and managing object lifetimes, which would have to be implemented manually with a framework that only supported plain requests and responses like [gRPC](https://grpc.io/). The support is especially helpful for passing callback objects like `std::function` and enabling bidirectional calls between processes.
 
-The choice to use an RPC framework at all instead of a custom protocol was necessitated by the size of Bitcoin Core internal interfaces which consist of around 150 methods that pass complex data structures and are called in complicated ways (in parallel, and from callbacks that can be nested and stored). Writing a custom protocol to wrap these complicated interfaces would be a lot more work, akin to writing a new RPC framework.
+The choice to use an RPC framework at all instead of a custom protocol was necessitated by the size of Bitgesell Core internal interfaces which consist of around 150 methods that pass complex data structures and are called in complicated ways (in parallel, and from callbacks that can be nested and stored). Writing a custom protocol to wrap these complicated interfaces would be a lot more work, akin to writing a new RPC framework.
 
 ### Hiding IPC
 
 The IPC mechanism is deliberately isolated from the rest of the codebase so less code has to be concerned with IPC.
 
-Building Bitcoin Core with IPC support is optional, and node, wallet, and GUI code can be compiled to either run in the same process or separate processes. The build system also ensures Cap’n Proto library headers can only be used within the [`src/ipc/capnp/`](../../src/ipc/capnp/) directory, not in other parts of the codebase.
+Building Bitgesell Core with IPC support is optional, and node, wallet, and GUI code can be compiled to either run in the same process or separate processes. The build system also ensures Cap’n Proto library headers can only be used within the [`src/ipc/capnp/`](../../src/ipc/capnp/) directory, not in other parts of the codebase.
 
 The libmultiprocess runtime is designed to place as few constraints as possible on IPC interfaces and to make IPC calls act like normal function calls. Method arguments, return values, and exceptions are automatically serialized and sent between processes. Object references and `std::function` arguments are tracked to allow invoked code to call back into invoking code at any time. And there is a 1:1 threading model where every client thread has a corresponding server thread responsible for executing incoming calls from that thread (there can be multiple calls from the same thread due to callbacks) without blocking, and holding the same thread-local variables and locks so behavior is the same whether IPC is used or not.
 
@@ -150,23 +150,23 @@ The currently defined IPC interfaces are unstable, and can change freely with no
 
 ## Security Considerations
 
-The integration of [Cap’n Proto](https://capnproto.org/) and [libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) into the Bitcoin Core architecture increases its potential attack surface. Cap’n Proto, being a complex and substantial new dependency, introduces potential sources of vulnerability, particularly through the creation of new UNIX sockets. The inclusion of libmultiprocess, while a smaller external dependency, also contributes to this risk. However, plans are underway to incorporate libmultiprocess as a git subtree, aligning it more closely with the project's well-reviewed internal libraries. While adopting these multiprocess features does introduce some risk, it's worth noting that they can be disabled, allowing builds without these new dependencies. This flexibility ensures that users can balance functionality with security considerations as needed.
+The integration of [Cap’n Proto](https://capnproto.org/) and [libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) into the Bitgesell Core architecture increases its potential attack surface. Cap’n Proto, being a complex and substantial new dependency, introduces potential sources of vulnerability, particularly through the creation of new UNIX sockets. The inclusion of libmultiprocess, while a smaller external dependency, also contributes to this risk. However, plans are underway to incorporate libmultiprocess as a git subtree, aligning it more closely with the project's well-reviewed internal libraries. While adopting these multiprocess features does introduce some risk, it's worth noting that they can be disabled, allowing builds without these new dependencies. This flexibility ensures that users can balance functionality with security considerations as needed.
 
 ## Example Use Cases and Flows
 
 ### Retrieving a Block Hash
 
-Let’s walk through an example where the `bitcoin-wallet` process requests the hash of a block at a specific height from the `bitcoin-node` process. This example demonstrates the practical application of the IPC mechanism, specifically the interplay between C++ method calls and Cap’n Proto-generated RPC calls.
+Let’s walk through an example where the `BGL-wallet` process requests the hash of a block at a specific height from the `BGL-node` process. This example demonstrates the practical application of the IPC mechanism, specifically the interplay between C++ method calls and Cap’n Proto-generated RPC calls.
 
 <table><tr><td>
 
 ```mermaid
 sequenceDiagram
-    box "bitcoin-wallet process"
+    box "BGL-wallet process"
     participant WalletCode as Wallet code
     participant ChainClient as Generated Chain client class<br/>ProxyClient<messages::Chain>
     end
-    box "bitcoin-node process"
+    box "BGL-node process"
     participant ChainServer as Generated Chain server class<br/>ProxyServer<messages::Chain>
     participant LocalChain as Chain object<br/>node::ChainImpl
     end
@@ -183,7 +183,7 @@ sequenceDiagram
 <code>Chain::getBlockHash</code> call diagram
 </td></tr></table>
 
-1. **Initiation in bitcoin-wallet**
+1. **Initiation in BGL-wallet**
    - The wallet process calls the `getBlockHash` method on a `Chain` object. This method is defined as a virtual method in [`src/interfaces/chain.h`](../../src/interfaces/chain.h).
 
 2. **Translation to Cap’n Proto RPC**
@@ -191,38 +191,38 @@ sequenceDiagram
    - The client subclass is automatically generated by the `mpgen` tool from the [`chain.capnp`](https://github.com/ryanofsky/bitcoin/blob/pr/ipc/src/ipc/capnp/chain.capnp) file in [`src/ipc/capnp/`](../../src/ipc/capnp/).
 
 3. **Request Preparation and Dispatch**
-   - The `getBlockHash` method of the generated `Chain` client subclass in `bitcoin-wallet` populates a Cap’n Proto request with the `height` parameter, sends it to `bitcoin-node` process, and waits for a response.
+   - The `getBlockHash` method of the generated `Chain` client subclass in `BGL-wallet` populates a Cap’n Proto request with the `height` parameter, sends it to the `BGL-node` process, and waits for a response.
 
-4. **Handling in bitcoin-node**
-   - Upon receiving the request, the Cap'n Proto dispatching code in the `bitcoin-node` process calls the `getBlockHash` method of the `Chain` [server class](#c-server-classes-in-generated-code).
+4. **Handling in BGL-node**
+   - Upon receiving the request, the Cap'n Proto dispatching code in the `BGL-node` process calls the `getBlockHash` method of the `Chain` [server class](#c-server-classes-in-generated-code).
    - The server class is automatically generated by the `mpgen` tool from the [`chain.capnp`](https://github.com/ryanofsky/bitcoin/blob/pr/ipc/src/ipc/capnp/chain.capnp) file in [`src/ipc/capnp/`](../../src/ipc/capnp/).
-   - The `getBlockHash` method of the generated `Chain` server subclass in `bitcoin-wallet` receives a Cap’n Proto request object with the `height` parameter, and calls the `getBlockHash` method on its local `Chain` object with the provided `height`.
-   - When the call returns, it encapsulates the return value in a Cap’n Proto response, which it sends back to the `bitcoin-wallet` process,
+   - The `getBlockHash` method of the generated `Chain` server subclass in `BGL-node` receives a Cap’n Proto request object with the `height` parameter, and calls the `getBlockHash` method on its local `Chain` object with the provided `height`.
+   - When the call returns, it encapsulates the return value in a Cap’n Proto response, which it sends back to the `BGL-wallet` process,
 
 5. **Response and Return**
-   - The `getBlockHash` method of the generated `Chain` client subclass in `bitcoin-wallet` which sent the request now receives the response.
+   - The `getBlockHash` method of the generated `Chain` client subclass in `BGL-wallet` which sent the request now receives the response.
    - It extracts the block hash value from the response, and returns it to the original caller.
 
 ## Future Enhancements
 
 Further improvements are possible such as:
 
-- Separating indexes from `bitcoin-node`, and running indexing code in separate processes (see [indexes: Stop using node internal types #24230](https://github.com/bitcoin/bitcoin/pull/24230)).
+- Separating indexes from `BGL-node`, and running indexing code in separate processes (see [indexes: Stop using node internal types #24230](https://github.com/bitcoin/bitcoin/pull/24230)).
 - Enabling wallet processes to listen for JSON-RPC requests on their own ports instead of needing the node process to listen and forward requests to them.
 - Automatically generating `.capnp` files from C++ interface definitions (see [Interface Definition Maintenance](#interface-definition-maintenance)).
 - Simplifying and stabilizing interfaces (see [Interface Stability](#interface-stability)).
 - Adding sandbox features, restricting subprocess access to resources and data (see [https://eklitzke.org/multiprocess-bitcoin](https://eklitzke.org/multiprocess-bitcoin)).
-- Using Cap'n Proto's support for [other languages](https://capnproto.org/otherlang.html), such as [Rust](https://github.com/capnproto/capnproto-rust), to allow code written in other languages to call Bitcoin Core C++ code, and vice versa (see [How to rustify libmultiprocess? #56](https://github.com/chaincodelabs/libmultiprocess/issues/56)).
+- Using Cap'n Proto's support for [other languages](https://capnproto.org/otherlang.html), such as [Rust](https://github.com/capnproto/capnproto-rust), to allow code written in other languages to call Bitgesell Core C++ code, and vice versa (see [How to rustify libmultiprocess? #56](https://github.com/chaincodelabs/libmultiprocess/issues/56)).
 
 ## Conclusion
 
-This modularization represents an advancement in Bitcoin Core's architecture, offering enhanced security, flexibility, and maintainability. The project invites collaboration and feedback from the community.
+This modularization represents an advancement in Bitgesell Core's architecture, offering enhanced security, flexibility, and maintainability. The project invites collaboration and feedback from the community.
 
 ## Appendices
 
 ### Glossary of Terms
 
-- **abstract class**: A class in C++ that consists of virtual functions. In the Bitcoin Core project, they define interfaces for inter-component communication.
+- **abstract class**: A class in C++ that consists of virtual functions. In the Bitgesell Core project, they define interfaces for inter-component communication.
 
 - **asynchronous I/O**: A form of input/output processing that allows a program to continue other operations while a transmission is in progress.
 
@@ -232,11 +232,11 @@ This modularization represents an advancement in Bitcoin Core's architecture, of
 
 - **Cap’n Proto struct**: A structured data format used in Cap’n Proto, similar to structs in C++, for organizing and transporting data across different processes.
 
-- **client class (in generated code)**: A C++ class generated from a Cap’n Proto interface which inherits from a Bitcoin core abstract class, and implements each virtual method to send IPC requests to another process. (see also [components section](#c-client-subclasses-in-generated-code))
+- **client class (in generated code)**: A C++ class generated from a Cap’n Proto interface which inherits from a Bitgesell Core abstract class, and implements each virtual method to send IPC requests to another process. (see also [components section](#c-client-subclasses-in-generated-code))
 
 - **IPC (inter-process communication)**: Mechanisms that enable processes to exchange requests and data.
 
-- **ipc::Exception class**: A class within Bitcoin Core's protocol-agnostic IPC code that is thrown by client class methods when there is an IPC error.
+- **ipc::Exception class**: A class within Bitgesell Core's protocol-agnostic IPC code that is thrown by client class methods when there is an IPC error.
 
 - **libmultiprocess**: A custom library and code generation tool used for creating IPC interfaces and managing IPC connections.
 
@@ -246,9 +246,9 @@ This modularization represents an advancement in Bitcoin Core's architecture, of
 
 - **protocol-agnostic code**: Generic IPC code in [`src/ipc/`](../../src/ipc/) that does not rely on Cap’n Proto and could be used with other protocols. Distinct from code in [`src/ipc/capnp/`](../../src/ipc/capnp/) which relies on Cap’n Proto.
 
-- **RPC (remote procedure call)**: A protocol that enables a program to request a service from another program in a different address space or network. Bitcoin Core uses [JSON-RPC](https://en.wikipedia.org/wiki/JSON-RPC) for RPC.
+- **RPC (remote procedure call)**: A protocol that enables a program to request a service from another program in a different address space or network. Bitgesell Core uses [JSON-RPC](https://en.wikipedia.org/wiki/JSON-RPC) for RPC.
 
-- **server class (in generated code)**: A C++ class generated from a Cap’n Proto interface which handles requests sent by a _client class_ in another process. The request handled by calling a local Bitcoin Core interface method, and the return values (if any) are sent back in a response. (see also: [components section](#c-server-classes-in-generated-code))
+- **server class (in generated code)**: A C++ class generated from a Cap’n Proto interface which handles requests sent by a _client class_ in another process. The request is handled by calling a local Bitgesell Core interface method, and the return values (if any) are sent back in a response. (see also: [components section](#c-server-classes-in-generated-code))
 
 - **unix socket**: Communication endpoint which is a filesystem path, used for exchanging data between processes running on the same host.
 

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -1,10 +1,10 @@
-# Multiprocess Bitcoin
+# Multiprocess Bitgesell
 
 _This document describes usage of the multiprocess feature. For design information, see the [design/multiprocess.md](design/multiprocess.md) file._
 
 ## Build Option
 
-On unix systems, the `--enable-multiprocess` build option can be passed to `./configure` to build new `bitcoin-node`, `bitcoin-wallet`, and `bitcoin-gui` executables alongside existing `bitcoind` and `bitcoin-qt` executables.
+On unix systems, the `--enable-multiprocess` build option can be passed to `./configure` to build new `BGL-node`, `BGL-wallet`, and `BGL-gui` executables alongside existing `BGLd` and `BGL-qt` executables.
 
 ## Debugging
 
@@ -15,12 +15,12 @@ The `-debug=ipc` command line option can be used to see requests and responses b
 The multiprocess feature requires [Cap'n Proto](https://capnproto.org/) and [libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) as dependencies. A simple way to get started using it without installing these dependencies manually is to use the [depends system](../depends) with the `MULTIPROCESS=1` [dependency option](../depends#dependency-options) passed to make:
 
 ```
-cd <BITCOIN_SOURCE_DIRECTORY>
+cd <BITGESELL_SOURCE_DIRECTORY>
 make -C depends NO_QT=1 MULTIPROCESS=1
 CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure
 make
-src/bitcoin-node -regtest -printtoconsole -debug=ipc
-BITCOIND=bitcoin-node test/functional/test_runner.py
+src/BGL-node -regtest -printtoconsole -debug=ipc
+BITCOIND=BGL-node test/functional/test_runner.py
 ```
 
 The configure script will pick up settings and library locations from the depends directory, so there is no need to pass `--enable-multiprocess` as a separate flag when using the depends system (it's controlled by the `MULTIPROCESS=1` option).
@@ -29,6 +29,6 @@ Alternately, you can install [Cap'n Proto](https://capnproto.org/) and [libmulti
 
 ## Usage
 
-`bitcoin-node` is a drop-in replacement for `bitcoind`, and `bitcoin-gui` is a drop-in replacement for `bitcoin-qt`, and there are no differences in use or external behavior between the new and old executables. But internally after [#10102](https://github.com/bitcoin/bitcoin/pull/10102), `bitcoin-gui` will spawn a `bitcoin-node` process to run P2P and RPC code, communicating with it across a socket pair, and `bitcoin-node` will spawn `bitcoin-wallet` to run wallet code, also communicating over a socket pair. This will let node, wallet, and GUI code run in separate address spaces for better isolation, and allow future improvements like being able to start and stop components independently on different machines and environments.
-[#19460](https://github.com/bitcoin/bitcoin/pull/19460) also adds a new `bitcoin-node` `-ipcbind` option and an `bitcoind-wallet` `-ipcconnect` option to allow new wallet processes to connect to an existing node process.
-And [#19461](https://github.com/bitcoin/bitcoin/pull/19461) adds a new `bitcoin-gui` `-ipcconnect` option to allow new GUI processes to connect to an existing node process.
+`BGL-node` is a drop-in replacement for `BGLd`, and `BGL-gui` is a drop-in replacement for `BGL-qt`, and there are no differences in use or external behavior between the new and old executables. But internally after [#10102](https://github.com/bitcoin/bitcoin/pull/10102), `BGL-gui` will spawn a `BGL-node` process to run P2P and RPC code, communicating with it across a socket pair, and `BGL-node` will spawn `BGL-wallet` to run wallet code, also communicating over a socket pair. This will let node, wallet, and GUI code run in separate address spaces for better isolation, and allow future improvements like being able to start and stop components independently on different machines and environments.
+[#19460](https://github.com/bitcoin/bitcoin/pull/19460) also adds a new `BGL-node` `-ipcbind` option and a `BGL-wallet` `-ipcconnect` option to allow new wallet processes to connect to an existing node process.
+And [#19461](https://github.com/bitcoin/bitcoin/pull/19461) adds a new `BGL-gui` `-ipcconnect` option to allow new GUI processes to connect to an existing node process.


### PR DESCRIPTION
Summary:
- Update multiprocess usage and design docs to use the Bitgesell executable names: BGLd, BGL-qt, BGL-node, BGL-wallet, and BGL-gui.
- Align the libraries design doc with the repository's libBGL_* and BGLconsensus naming, including the dependency diagram.
- Keep upstream Bitcoin links only where they point to historical design references.

Validation:
- rg -n 'bitcoin-node|bitcoin-wallet|bitcoin-gui|bitcoin-cli|bitcoind|bitcoin-qt|libbitcoin|Bitcoin Core|Multiprocess Bitcoin|BITCOIN_SOURCE_DIRECTORY' doc/design/libraries.md doc/design/multiprocess.md doc/multiprocess.md
- python3 test/lint/lint-tests.py
- git diff --check HEAD~1..HEAD

Bounty:
- Refs #39