### PR TITLE
doc: align network docs with BGL names

### DIFF
--- a/doc/p2p-bad-ports.md
+++ b/doc/p2p-bad-ports.md
@@ -1,22 +1,22 @@
-When Bitcoin Core automatically opens outgoing P2P connections, it chooses
+When BGL Core automatically opens outgoing P2P connections, it chooses
 a peer (address and port) from its list of potential peers. This list is
 populated with unchecked data gossiped over the P2P network by other peers.
 
-A malicious actor may gossip an address:port where no Bitcoin node is listening,
-or one where a service is listening that is not related to the Bitcoin network.
-As a result, this service may occasionally get connection attempts from Bitcoin
+A malicious actor may gossip an address:port where no BGL node is listening,
+or one where a service is listening that is not related to the BGL network.
+As a result, this service may occasionally get connection attempts from BGL
 nodes.
 
 "Bad" ports are ones used by services which are usually not open to the public
-and usually require authentication. A connection attempt (by Bitcoin Core,
-trying to connect because it thinks there is a Bitcoin node on that
+and usually require authentication. A connection attempt (by BGL Core,
+trying to connect because it thinks there is a BGL node on that
 address:port) to such service may be considered a malicious action by an
 ultra-paranoid administrator. An example for such a port is 22 (ssh). On the
 other hand, connection attempts to public services that usually do not require
 authentication are unlikely to be considered a malicious action,
 e.g. port 80 (http).
 
-Below is a list of "bad" ports which Bitcoin Core avoids when choosing a peer to
+Below is a list of "bad" ports which BGL Core avoids when choosing a peer to
 connect to. If a node is listening on such a port, it will likely receive fewer
 incoming connections.
 

--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -3,7 +3,7 @@ Reduce Traffic
 
 Some node operators need to deal with bandwidth caps imposed by their ISPs.
 
-By default, Bitcoin Core allows up to 125 connections to different peers, 11 of
+By default, BGL Core allows up to 125 connections to different peers, 11 of
 which are outbound. You can therefore, have at most 114 inbound connections.
 Of the 11 outbound peers, there can be 8 full-relay connections, 2
 block-relay-only ones and occasionally 1 short-lived feeler or an extra block-relay-only connection.

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -25,7 +25,7 @@ CLI `-addrinfo` returns the number of addresses known to your node per
 network. This can be useful to see how many onion peers your node knows,
 e.g. for `-onlynet=onion`.
 
-You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run `bitcoin-cli help getnodeaddresses` for details.
+You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run `BGL-cli help getnodeaddresses` for details.
 
 ## 1. Run BGL Core behind a Tor proxy
 

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -91,7 +91,7 @@ For instance:
 Each PUB notification has a topic and body, where the header
 corresponds to the notification type. For instance, for the
 notification `-zmqpubhashtx` the topic is `hashtx` (no null
-terminator). These options can also be provided in bitcoin.conf.
+terminator). These options can also be provided in BGL.conf.
 
 The topics are:
 


### PR DESCRIPTION
Refs #39, #81.

Summary:
- replace stale Bitcoin Core naming in the bad-port and traffic docs with BGL Core terminology
- use BGL-cli in the Tor getnodeaddresses example
- refer to BGL.conf in the ZeroMQ configuration note

Validation:
- git diff --check
- grep check for the replaced stale Bitcoin command/config/product strings in the touched docs

Docs-only change; no runtime tests were run.