### PR TITLE
doc: use BGL names in init interface comments

### DIFF
--- a/src/init/BGL-node.cpp
+++ b/src/init/BGL-node.cpp
@@ -47,7 +47,7 @@ namespace interfaces {
 std::unique_ptr<Init> MakeNodeInit(node::NodeContext& node, int argc, char* argv[], int& exit_status)
 {
     auto init = std::make_unique<init::BGLNodeInit>(node, argc > 0 ? argv[0] : "");
-    // Check if bitcoin-node is being invoked as an IPC server. If so, then
+    // Check if BGL-node is being invoked as an IPC server. If so, then
     // bypass normal execution and just respond to requests over the IPC
     // channel and return null.
     if (init->m_ipc->startSpawnedProcess(argc, argv, exit_status)) {

--- a/src/init/common.h
+++ b/src/init/common.h
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 //! @file
-//! @brief Common init functions shared by bitcoin-node, bitcoin-wallet, etc.
+//! @brief Common init functions shared by BGL-node, BGL-wallet, etc.
 
 #ifndef BGL_INIT_COMMON_H
 #define BGL_INIT_COMMON_H

--- a/src/interfaces/README.md
+++ b/src/interfaces/README.md
@@ -16,4 +16,4 @@ The following interfaces are defined here:
 
 * [`Ipc`](ipc.h) — used by multiprocess code to access `Init` interface across processes. Added in [#19160](https://github.com/bitcoin/bitcoin/pull/19160).
 
-The interfaces above define boundaries between major components of bitcoin code (node, wallet, and gui), making it possible for them to run in [different processes](../../doc/multiprocess.md), and be tested, developed, and understood independently. These interfaces are not currently designed to be stable or to be used externally.
+The interfaces above define boundaries between major components of BGL code (node, wallet, and gui), making it possible for them to run in [different processes](../../doc/multiprocess.md), and be tested, developed, and understood independently. These interfaces are not currently designed to be stable or to be used externally.

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -101,7 +101,7 @@ struct BlockInfo {
 //! estimate fees, and submit transactions.
 //!
 //! TODO: Current chain methods are too low level, exposing too much of the
-//! internal workings of the bitcoin node, and not being very convenient to use.
+//! internal workings of the BGL node, and not being very convenient to use.
 //! Chain methods should be cleaned up and simplified over time. Examples:
 //!
 //! * The initMessages() and showProgress() methods which the wallet uses to send

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -24,7 +24,7 @@ class Ipc;
 //! and get access to other interfaces (Node, Chain, Wallet, etc).
 //!
 //! There is a different Init interface implementation for each process
-//! (bitcoin-gui, bitcoin-node, bitcoin-wallet, bitcoind, bitcoin-qt) and each
+//! (BGL-gui, BGL-node, BGL-wallet, BGLd, BGL-qt) and each
 //! implementation can implement the make methods for interfaces it supports.
 //! The default make methods all return null.
 class Init

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -65,7 +65,7 @@ public:
     virtual std::string getName() = 0;
 };
 
-//! Top-level interface for a bitcoin node (bitcoind process).
+//! Top-level interface for a BGL node (BGLd process).
 class Node
 {
 public:
@@ -105,7 +105,7 @@ public:
     //! would be ignored because it is also specified in the command line.
     virtual bool isSettingIgnored(const std::string& name) = 0;
 
-    //! Return setting value from <datadir>/settings.json or bitcoin.conf.
+    //! Return setting value from <datadir>/settings.json or BGL.conf.
     virtual common::SettingsValue getPersistentSetting(const std::string& name) = 0;
 
     //! Update a setting in <datadir>/settings.json.


### PR DESCRIPTION
Refs #39 and #81.

This is a focused cleanup for the init/interface documentation comments that still used inherited Bitcoin process and config names. It updates those comments to use the Bitgesell names already defined in the tree: `BGL-node`, `BGL-wallet`, `BGL-gui`, `BGLd`, `BGL-qt`, and `BGL.conf`.

Scope:
- `src/interfaces/README.md`
- `src/interfaces/init.h`
- `src/interfaces/node.h`
- `src/interfaces/chain.h`
- `src/init/common.h`
- `src/init/BGL-node.cpp`

Validation:
- `git diff --check HEAD~1..HEAD`
- `rg -n "bitcoin code|bitcoin node|bitcoin\.conf|bitcoin-node|bitcoin-wallet|bitcoin-gui|bitcoind process|bitcoin-qt" src/interfaces/README.md src/interfaces/init.h src/interfaces/node.h src/interfaces/chain.h src/init/common.h src/init/BGL-node.cpp` returned no matches after the patch.

I did not run a full build because this change is limited to comments and one Markdown line; it does not alter code behavior, APIs, or build files.