### PR TITLE
Fix #291

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,28 @@
-# Contributing to libsecp256k1
+# Contributing to Bitgesell
+
+## BGL PR bounty hunt
+
+Bitgesell welcomes pull requests from the community. Reasonable contributions
+can include refactoring, tests, cleanup, documentation and comment improvements,
+bug fixes, build improvements, and new features.
+
+Approved pull requests may receive a bounty starting at $100 USDT. Larger or
+more impactful contributions may qualify for higher payouts at the maintainers'
+discretion. Bounty eligibility and final payout amounts are confirmed during
+maintainer review and approval.
+
+To contribute:
+
+1. Fork [BitgesellOfficial/bitgesell](https://github.com/BitgesellOfficial/bitgesell).
+2. Create a focused branch for your change.
+3. Open a pull request with a clear explanation of what changed and why.
+4. Respond to maintainer feedback until the pull request is ready for approval.
+
+Keep pull requests focused and reviewable. Separate unrelated changes into
+separate pull requests, and include tests or documentation updates when they are
+relevant to the change.
+
+## libsecp256k1 contribution notes
 
 ## Scope
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,18 @@ Translations are periodically pulled from Transifex and merged into the git repo
 
 See [SECURITY.md](SECURITY.md)
 
-Contributing to libsecp256k1
-------------
+## Contributing
+
+### BGL PR bounty hunt
+
+Bitgesell welcomes community pull requests that improve the project. Reasonable
+contributions can include bug fixes, refactoring, tests, build improvements,
+documentation updates, cleanup, comments, and new features.
+
+Approved pull requests may receive a bounty starting at $100 USDT. Larger or
+more impactful contributions may qualify for higher payouts at the maintainers'
+discretion. To get started, fork
+[github.com/BitgesellOfficial/bitgesell](https://github.com/BitgesellOfficial/bitgesell),
+open a focused pull request, and describe what changed and why.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Fix #291\n\nImplemented the bounty docs.\n\nUpdated:\n- [README.md](/tmp/bounty-bitgesell_291-2jp4flxu/repo/README.md:206) now has a visible  section with  details.\n- [CONTRIBUTING.md](/tmp/bounty-bitgesell_291-2jp4flxu/repo/CONTRIBUTING.md:1) now starts with Bitgesell-specific contribution and bounty guidance before the inherited libsecp256k1 notes.\n\nVerified with ; no whitespace issues found. No test suite was run because this is documentation-only.\n\n---\n*Auto-generated bounty fix*