### PR TITLE
test: set stable locale in shell scripts

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-set -eux
-
 export LC_ALL=C
+
+set -eux
 
 # Print commit and relevant CI environment to allow reproducing the job outside of CI.
 git show --no-patch

--- a/ci/test/07_script.sh
+++ b/ci/test/07_script.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+export LC_ALL=C
+
 echo "UPLOAD ARTIFACTS"
 
 if [[ "$ARTIFACT_NAME" == "" ]]; then

--- a/contrib/devtools/split-debug.sh
+++ b/contrib/devtools/split-debug.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+export LC_ALL=C
+
 set -e
 if [ $# -ne 3 ];
     then echo "usage: $0 <input> <stripped-binary> <debug-binary>"

--- a/contrib/travis.sh
+++ b/contrib/travis.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+export LC_ALL=C
+
 set -e
 set -x
 

--- a/debian.minimal/build-in-docker.sh
+++ b/debian.minimal/build-in-docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LC_ALL=C
+
 set -e
 
 debuild -S

--- a/debian.minimal/test.sh
+++ b/debian.minimal/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LC_ALL=C
+
 #finish() {
 #    docker stop $container >/dev/null
 #    docker container rm $container >/dev/null

--- a/debian.qt/build-in-docker.sh
+++ b/debian.qt/build-in-docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LC_ALL=C
+
 set -e
 
 debuild -S

--- a/debian.qt/test.sh
+++ b/debian.qt/test.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export LC_ALL=C
+
 finish() {
     docker stop $container >/dev/null
     docker container rm $container >/dev/null

--- a/debian.qt/updateunattended.sh
+++ b/debian.qt/updateunattended.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+export LC_ALL=C
+
 export DEBIAN_FRONTEND=noninteractive
 export TZ=Etc/UTC
 apt-get update && apt-get install -y tzdata


### PR DESCRIPTION
## Summary
- make shell scripts covered by `lint-shell-locale.py` explicitly opt out of locale-dependent behavior
- move `LC_ALL=C` before `set -eux` in CI so it is the first non-comment command

## Validation
- `python3 test/lint/lint-shell-locale.py`
- `git diff --check`

Refs #32.