### PR TITLE
doc: add contributor quickstart and improve README contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,11 @@ Translations are periodically pulled from Transifex and merged into the git repo
 
 See [SECURITY.md](SECURITY.md)
 
-Contributing to libsecp256k1
+Contributing
 ------------
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+Quick onboarding guide for small PRs:
+
+See [doc/contributor_quickstart.md](doc/contributor_quickstart.md)

--- a/doc/contributor_quickstart.md
+++ b/doc/contributor_quickstart.md
@@ -44,3 +44,16 @@ Use this shape:
 
 Small, well-justified PRs generally review faster than broad refactors.
 
+## 6) Common pitfalls to avoid
+
+- Do not combine unrelated fixes in one PR.
+- Do not include generated or local-environment files by accident.
+- Do not force-push repeatedly after review starts unless strictly necessary.
+- Do not leave validation claims without exact command output.
+
+## 7) Final pre-push checklist
+
+1. Re-read changed files once for clarity and typos.
+2. Re-run the smallest relevant validation command.
+3. Confirm `git status` only shows intended files.
+4. Ensure PR description includes validation and rollback note.

--- a/doc/contributor_quickstart.md
+++ b/doc/contributor_quickstart.md
@@ -1,0 +1,46 @@
+# Contributor Quickstart
+
+This quickstart is for small, review-friendly pull requests, especially doc and test fixes.
+
+## 1) Set up a branch
+
+```bash
+git checkout -b docs/contributor-quickstart
+```
+
+## 2) Keep changes scoped
+
+- One topic per PR (docs-only, test-only, or one bug fix).
+- Avoid mixing formatting churn with functional changes.
+- Keep filenames and commit message clear and searchable.
+
+## 3) Minimal validation before opening PR
+
+For docs-only PRs:
+
+- Verify links and paths resolve.
+- Verify Markdown renders correctly.
+- Run a spelling/typo pass on changed sections.
+
+For code/test PRs:
+
+- Run the smallest relevant local test target first.
+- Include exact commands and results in PR description.
+
+## 4) PR description template
+
+Use this shape:
+
+1. **What changed**
+2. **Why this change is needed**
+3. **How it was validated**
+4. **Risk / rollback notes** (if any)
+
+## 5) Good first PR candidates
+
+- Clarify outdated docs and onboarding instructions.
+- Fix dead links or path typos.
+- Improve test/docs comments that reduce reviewer ambiguity.
+
+Small, well-justified PRs generally review faster than broad refactors.
+


### PR DESCRIPTION
### Description
This PR improves contributor onboarding docs with a concise quickstart focused on small, review-friendly documentation pull requests.

Changes:
- Added a dedicated quickstart guide for contributors.
- Improved README contributing section wording.
- Linked README contributing section to the new quickstart for easier navigation.

This is docs-only and scoped to be simple to review.

### Notes
- No code/runtime changes.
- No dependency changes.
- Intended to reduce onboarding friction for first-time contributors.

### BTC/BGL PR reward address
(leave blank if not required by maintainers)