### PR TITLE
doc: refresh support and testing references

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
         <li><a href="#installation">Installation</a></li>
       </ul> -->
     </li>
+    <li><a href="#testing-and-qa">Testing and QA</a></li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>
@@ -189,6 +190,14 @@ Benchmark
 ------------
 If configured with `--enable-benchmark` (which is the default), binaries for benchmarking the libsecp256k1 functions will be present in the root directory after the build.
 
+Testing and QA
+------------
+The repository includes unit, functional, fuzz, lint, and benchmark tooling.
+Start with [test/README.md](test/README.md) for the functional test runner and
+[test/lint/README.md](test/lint/README.md) for the lint suite. Additional
+developer notes are available in [doc/benchmarking.md](doc/benchmarking.md) and
+[doc/fuzzing.md](doc/fuzzing.md).
+
 Facebook: [Bitgesell](https://www.facebook.com/Bitgesell)
 
 
@@ -196,7 +205,7 @@ Facebook: [Bitgesell](https://www.facebook.com/Bitgesell)
 ## Translations
 
 Changes to translations as well as new translations can be submitted to
-[BGL Core's Transifex page](https://www.transifex.com/bitcoin/bitcoin/).
+[BGL Core's Transifex page](https://www.transifex.com/BGL/BGL/).
 
 Translations are periodically pulled from Transifex and merged into the git repository. See the
 [translation process](doc/translation_process.md) for details on how this works.

--- a/doc/README.md
+++ b/doc/README.md
@@ -28,11 +28,13 @@ Drag BGL Core to your applications folder, and then run BGL Core.
 
 ### Need Help?
 
-* See the documentation at the [BGL Wiki](https://en.bitcoin.it/wiki/Main_Page)
-for help and more information.
-* Ask for help on [BGL StackExchange](https://bitcoin.stackexchange.com).
-* Ask for help on #BGL on Libera Chat. If you don't have an IRC client, you can use [web.libera.chat](https://web.libera.chat/#bitcoin).
-* Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
+* Start with the BGL documentation in this directory and the project website at
+  [bitgesell.ca](https://bitgesell.ca/).
+* For reproducible wallet, node, build, or RPC problems, search existing
+  [GitHub issues](https://github.com/BitgesellOfficial/bitgesell/issues) before
+  opening a new issue.
+* Security reports should follow the repository's
+  [security policy](/SECURITY.md) instead of being posted publicly.
 
 Building
 ---------------------
@@ -65,8 +67,9 @@ The BGL repo's [root README](/README.md) contains relevant information on the de
 - [Internal Design Docs](design/)
 
 ### Resources
-* Discuss on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Development & Technical Discussion board](https://bitcointalk.org/index.php?board=6.0).
-* Discuss project-specific development on #bitcoin-core-dev on Libera Chat. If you don't have an IRC client, you can use [web.libera.chat](https://web.libera.chat/#bitcoin-core-dev).
+* Discuss project-specific development in GitHub issues and pull requests.
+* Use narrowly scoped issues with clear reproduction steps for bugs, build
+  failures, or documentation gaps.
 
 ### Miscellaneous
 - [Assets Attribution](assets-attribution.md)

--- a/test/README.md
+++ b/test/README.md
@@ -31,7 +31,7 @@ See [/doc/fuzzing.md](/doc/fuzzing.md)
 The ZMQ functional test requires a python ZMQ library. To install it:
 
 - on Unix, run `sudo apt-get install python3-zmq`
-- on mac OS, run `pip3 install pyzmq`
+- on macOS, run `pip3 install pyzmq`
 
 
 On Windows the `PYTHONUTF8` environment variable must be set to 1:


### PR DESCRIPTION
### Description

Refresh several contributor-facing docs so they point to Bitgesell/BGL resources instead of inherited Bitcoin channels.

This adds a short Testing and QA entry point in the root README, updates the root Transifex link to the BGL project referenced by `doc/translation_process.md`, and replaces Bitcoin wiki/StackExchange/IRC/forum references in `doc/README.md` with BGL documentation, GitHub issues, and the repository security policy.

Submitted for the standing PR bounty in #32.

### Notes

Validation:
- `git diff --check HEAD~1..HEAD`
- manual review of the changed documentation diff

### BTC/BGL PR reward address

USDT public payout address if this documentation PR is eligible: `0x90bf39fc58cddb45d2935204727ef8555c7f27f1` (please confirm network before sending).
