### PR TITLE
doc: fix broken internal documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ In addition, libsecp256k1 tries to maintain the following coding conventions:
     ```
 * Use `unsigned int` instead of just `unsigned`.
 * Use `void *ptr` instead of `void* ptr`.
-* Arguments of the publicly-facing API must have a specific order defined in [include/secp256k1.h](include/secp256k1.h).
+* Arguments of the publicly-facing API must have a specific order defined in [include/secp256k1.h](src/secp256k1/include/secp256k1.h).
 * User-facing comment lines in headers should be limited to 80 chars if possible.
 * All identifiers in file scope should start with `secp256k1_`.
 * Avoid trailing whitespace.
@@ -100,7 +100,7 @@ To create a HTML report with coloured and annotated source code:
 #### Exhaustive tests
 
 There are tests of several functions in which a small group replaces secp256k1.
-These tests are *exhaustive* since they provide all elements and scalars of the small group as input arguments (see [src/tests_exhaustive.c](src/tests_exhaustive.c)).
+These tests are *exhaustive* since they provide all elements and scalars of the small group as input arguments (see [src/tests_exhaustive.c](src/secp256k1/src/tests_exhaustive.c)).
 
 ### Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ In "Developer Command Prompt for VS 2022":
 
 Usage examples
 -----------
-Usage examples can be found in the [examples](examples) directory. To compile them you need to configure with `--enable-examples`.
-  * [ECDSA example](examples/ecdsa.c)
-  * [Schnorr signatures example](examples/schnorr.c)
-  * [Deriving a shared secret (ECDH) example](examples/ecdh.c)
+Usage examples can be found in the [examples](src/secp256k1/examples) directory. To compile them you need to configure with `--enable-examples`.
+  * [ECDSA example](src/secp256k1/examples/ecdsa.c)
+  * [Schnorr signatures example](src/secp256k1/examples/schnorr.c)
+  * [Deriving a shared secret (ECDH) example](src/secp256k1/examples/ecdh.c)
 
 To compile the Schnorr signature and ECDH examples, you also need to configure with `--enable-module-schnorrsig` and `--enable-module-ecdh`.
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -70,7 +70,7 @@ The BGL repo's [root README](/README.md) contains relevant information on the de
 
 ### Miscellaneous
 - [Assets Attribution](assets-attribution.md)
-- [Assumeutxo design](assumeutxo.md)
+- [Assumeutxo design](design/assumeutxo.md)
 - [BGL.conf Configuration File](BGL-conf.md)
 - [CJDNS Support](cjdns.md)
 - [Files](files.md)


### PR DESCRIPTION
### Description
Fix broken internal Markdown links in the documentation.

### Notes
- `doc/README.md`: point the Assumeutxo design link at `doc/design/assumeutxo.md`.
- `README.md`: point secp256k1 usage example links at `src/secp256k1/examples`.

### Validation
- Checked the touched Markdown links resolve to files/directories in the repository.
- Ran `git diff --check` on the local patch.

Related to #32.