### PR TITLE
test: use BGL unit test binary names

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -487,7 +487,7 @@ To enable LCOV report generation during test runs:
 make
 make cov
 
-# A coverage report will now be accessible at `./test_bitcoin.coverage/index.html`,
+# A coverage report will now be accessible at `./test_BGL.coverage/index.html`,
 # which covers unit tests, and `./total.coverage/index.html`, which covers
 # unit and functional tests.
 ```

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -61,7 +61,7 @@ if USE_NATPMP
 FUZZ_SUITE_LD_COMMON += $(NATPMP_LIBS)
 endif
 
-# test_bitcoin binary #
+# test_BGL binary #
 BGL_TESTS =\
   test/addrman_tests.cpp \
   test/allocator_tests.cpp \

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -58,7 +58,7 @@ standard terminal output.
 ... or to run just the doubledash test:
 
 ```bash
-test_ --run_test=getarg_tests/doubledash
+test_BGL --run_test=getarg_tests/doubledash
 ```
 
 `test_BGL` creates a temporary working (data) directory with a randomly
@@ -72,7 +72,7 @@ have a `debug.log` file, for example.
 The location of the temporary data directory can be specified with the
 `-testdatadir` option. This can make debugging easier. The directory
 path used is the argument path appended with
-`/test_common_Bitcoin Core/<test-name>/datadir`.
+`/test_common_BGL Core/<test-name>/datadir`.
 The directory path is created if necessary.
 Specifying this argument also causes the data directory
 not to be removed after the last test. This is useful for looking at
@@ -81,12 +81,12 @@ what the test wrote to `debug.log` after it completes, for example.
 so no leftover state is used.)
 
 ```bash
-$ test_bitcoin --run_test=getarg_tests/doubledash -- -testdatadir=/somewhere/mydatadir
+$ test_BGL --run_test=getarg_tests/doubledash -- -testdatadir=/somewhere/mydatadir
 Test directory (will not be deleted): "/somewhere/mydatadir/test_common_BGL Core/getarg_tests/doubledash/datadir
 Running 1 test case...
 
 *** No errors detected
-$ ls -l '/somewhere/mydatadir/test_common_Bitcoin Core/getarg_tests/doubledash/datadir'
+$ ls -l '/somewhere/mydatadir/test_common_BGL Core/getarg_tests/doubledash/datadir'
 total 8
 drwxrwxr-x 2 admin admin 4096 Nov 27 22:45 blocks
 -rw-rw-r-- 1 admin admin 1003 Nov 27 22:45 debug.log
@@ -96,7 +96,7 @@ If you run an entire test suite, such as `--run_test=getarg_tests`, or all the t
 (by not specifying `--run_test`), a separate directory
 will be created for each individual test.
 
-Run `test_bitcoin --help` for the full list of tests.
+Run `test_BGL --help` for the full list of tests.
 
 ### Adding test cases
 

--- a/src/test/argsman_tests.cpp
+++ b/src/test/argsman_tests.cpp
@@ -906,7 +906,7 @@ BOOST_FIXTURE_TEST_CASE(util_ArgsMerge, ArgsMergeTestingSetup)
 
     // If check below fails, should manually dump the results with:
     //
-    //   ARGS_MERGE_TEST_OUT=results.txt ./test_bitcoin --run_test=argsman_tests/util_ArgsMerge
+    //   ARGS_MERGE_TEST_OUT=results.txt ./test_BGL --run_test=argsman_tests/util_ArgsMerge
     //
     // And verify diff against previous results to make sure the changes are expected.
     //
@@ -1009,7 +1009,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
 
     // If check below fails, should manually dump the results with:
     //
-    //   CHAIN_MERGE_TEST_OUT=results.txt ./test_bitcoin --run_test=argsman_tests/util_ChainMerge
+    //   CHAIN_MERGE_TEST_OUT=results.txt ./test_BGL --run_test=argsman_tests/util_ChainMerge
     //
     // And verify diff against previous results to make sure the changes are expected.
     //

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -29,7 +29,7 @@ const std::function<void(const std::string&)> G_TEST_LOG_FUN = [](const std::str
 /**
  * Retrieve the command line arguments from boost.
  * Allows usage like:
- * `test_bitcoin --run_test="net_tests/cnode_listen_port" -- -checkaddrman=1 -printtoconsole=1`
+ * `test_BGL --run_test="net_tests/cnode_listen_port" -- -checkaddrman=1 -printtoconsole=1`
  * which would return `["-checkaddrman=1", "-printtoconsole=1"]`.
  */
 const std::function<std::vector<const char*>()> G_TEST_COMMAND_LINE_ARGUMENTS = []() {

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -256,7 +256,7 @@ BOOST_FIXTURE_TEST_CASE(Merge, MergeTestingSetup)
 
     // If check below fails, should manually dump the results with:
     //
-    //   SETTINGS_MERGE_TEST_OUT=results.txt ./test_bitcoin --run_test=settings_tests/Merge
+    //   SETTINGS_MERGE_TEST_OUT=results.txt ./test_BGL --run_test=settings_tests/Merge
     //
     // And verify diff against previous results to make sure the changes are expected.
     //


### PR DESCRIPTION
## Summary

This is a small test/documentation consistency cleanup for the Bitgesell tree:

- Replace leftover `test_bitcoin` examples with the actual Bitgesell unit test binary name, `test_BGL`.
- Fix the malformed `test_ --run_test=...` example in `src/test/README.md`.
- Align the documented unit-test LCOV output path with the existing `Makefile.am` target, `test_BGL.coverage`.
- Update a Makefile comment and unit-test helper comments to match the current Bitgesell binary names.

This is intentionally scoped to docs/comments only; it does not change runtime behavior.

## Validation

```bash
grep -RIn "test_bitcoin\|test_common_Bitcoin Core\|test_ --run_test" src/test src/Makefile.test.include doc/developer-notes.md 2>/dev/null || true
python3 - <<'PY'
from pathlib import Path
makefile = Path('Makefile.am').read_text()
docs = Path('doc/developer-notes.md').read_text()
assert 'test_BGL.coverage/.dirstamp' in makefile
assert './test_BGL.coverage/index.html' in docs
print('coverage doc matches Makefile target')
PY
git diff --check
```

Result: no stale `test_bitcoin` / `test_common_Bitcoin Core` / malformed `test_ --run_test` references remain in the touched test-doc scope; coverage doc matches the Makefile target; diff check passes.

## Bounty note

If this small cleanup qualifies under the Bitgesell PR/improvement bounty program (#39 / #81), public payout addresses are:

- USDT TRC20: `TU3WsDnY9RbwGFEHx6WoF1C7J592SGrS8F`
- USDT/ERC20-compatible EVM: `0xc580927355132643ad82b4c12ba94a7a93e63ba2`
