### PR TITLE
build: move minisketch self-tests to check

### DIFF
--- a/src/minisketch/Makefile.am
+++ b/src/minisketch/Makefile.am
@@ -57,8 +57,9 @@ noinst_PROGRAMS =
 if USE_BENCHMARK
 noinst_PROGRAMS += bench
 endif
+check_PROGRAMS =
 if USE_TESTS
-noinst_PROGRAMS += test test-verify
+check_PROGRAMS += test test-verify
 TESTS = test test-verify
 endif
 


### PR DESCRIPTION
Issue #139 indicates the build currently trips over minisketch test compilation during make. This small build-system change moves the minisketch self-tests out of noinst_PROGRAMS and into check_PROGRAMS so they run under make check instead of the default make path, while keeping TESTS registered for the test runner.

Verification:
- git diff --check
- inspected src/minisketch/Makefile.am

This is a narrow build fix only; it does not touch runtime logic.