### PR TITLE
test: remove outdated gettime check

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -520,14 +520,6 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 #undef B
 #undef E
 
-/* Check for mingw/wine issue #3494
- * Remove this test before time.ctime(0xffffffff) == 'Sun Feb  7 07:28:15 2106'
- */
-BOOST_AUTO_TEST_CASE(gettime)
-{
-    BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
-}
-
 BOOST_AUTO_TEST_CASE(util_time_GetTime)
 {
     SetMockTime(111);


### PR DESCRIPTION
Issue #143 says the old gettime test is outdated and can be removed. This patch deletes that legacy check from util_tests while leaving the modern util_time_GetTime coverage in place.

Verification:
- git diff --check
- inspected the surrounding util_tests cases to ensure only the obsolete test case was removed.

This is a narrow cleanup and should be easy to review.