### PR TITLE
rpc: raise default HTTP threads to 16

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -35,7 +35,7 @@ threads take up 8MiB for the thread stack on a 64-bit system, and 4MiB in a
 32-bit system.
 
 - `-par=<n>` - the number of script verification threads, defaults to the number of cores in the system minus one.
-- `-rpcthreads=<n>` - the number of threads used for processing RPC requests, defaults to `4`.
+- `-rpcthreads=<n>` - the number of threads used for processing RPC requests, defaults to `16`.
 
 ## Linux specific
 

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -14,7 +14,7 @@ namespace util {
 class SignalInterrupt;
 } // namespace util
 
-static const int DEFAULT_HTTP_THREADS=4;
+static const int DEFAULT_HTTP_THREADS=16;
 static const int DEFAULT_HTTP_WORKQUEUE=16;
 static const int DEFAULT_HTTP_SERVER_TIMEOUT=30;
 


### PR DESCRIPTION
Raise the default RPC thread count from 4 to 16 and align the reduce-memory docs with the new default.\n\nThis keeps the change small and reviewable while matching the documented intent of the lane.