### PR TITLE
build: fix Windows resource metadata names

### DIFF
--- a/src/BGL-cli-res.rc
+++ b/src/BGL-cli-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Bitgesell"
-            VALUE "FileDescription",    "BGL-util (CLI Bitgesell utility)"
+            VALUE "FileDescription",    "BGL-cli (JSON-RPC client for " PACKAGE_NAME ")"
             VALUE "FileVersion",        PACKAGE_VERSION
-            VALUE "InternalName",       "BGL-util"
+            VALUE "InternalName",       "BGL-cli"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "BGL-util.exe"
-            VALUE "ProductName",        "BGL-util"
+            VALUE "OriginalFilename",   "BGL-cli.exe"
+            VALUE "ProductName",        "BGL-cli"
             VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END

--- a/src/BGL-tx-res.rc
+++ b/src/BGL-tx-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Bitgesell"
-            VALUE "FileDescription",    "BGLd (Bitgesell node with a JSON-RPC server)"
+            VALUE "FileDescription",    "BGL-tx (CLI Bitgesell transaction editor utility)"
             VALUE "FileVersion",        PACKAGE_VERSION
-            VALUE "InternalName",       "BGLd"
+            VALUE "InternalName",       "BGL-tx"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "BGLd.exe"
-            VALUE "ProductName",        "BGLd"
+            VALUE "OriginalFilename",   "BGL-tx.exe"
+            VALUE "ProductName",        "BGL-tx"
             VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END

--- a/src/BGL-util-res.rc
+++ b/src/BGL-util-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Bitgesell"
-            VALUE "FileDescription",    "BGL-tx (CLI Bitgesell transaction editor utility)"
+            VALUE "FileDescription",    "BGL-util (CLI Bitgesell utility)"
             VALUE "FileVersion",        PACKAGE_VERSION
-            VALUE "InternalName",       "BGL-tx"
+            VALUE "InternalName",       "BGL-util"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "BGL-tx.exe"
-            VALUE "ProductName",        "BGL-tx"
+            VALUE "OriginalFilename",   "BGL-util.exe"
+            VALUE "ProductName",        "BGL-util"
             VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END

--- a/src/BGL-wallet-res.rc
+++ b/src/BGL-wallet-res.rc
@@ -15,13 +15,13 @@ BEGIN
         BLOCK "040904E4" // U.S. English - multilingual (hex)
         BEGIN
             VALUE "CompanyName",        "Bitgesell"
-            VALUE "FileDescription",    "BGL-cli (JSON-RPC client for " PACKAGE_NAME ")"
+            VALUE "FileDescription",    "BGL-wallet (Bitgesell wallet utility)"
             VALUE "FileVersion",        PACKAGE_VERSION
-            VALUE "InternalName",       "BGL-cli"
+            VALUE "InternalName",       "BGL-wallet"
             VALUE "LegalCopyright",     COPYRIGHT_STR
             VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
-            VALUE "OriginalFilename",   "BGL-cli.exe"
-            VALUE "ProductName",        "BGL-cli"
+            VALUE "OriginalFilename",   "BGL-wallet.exe"
+            VALUE "ProductName",        "BGL-wallet"
             VALUE "ProductVersion",     PACKAGE_VERSION
         END
     END


### PR DESCRIPTION
## Summary

Fixes mismatched Windows version-resource metadata for BGL command-line tools:

- BGL-cli resource now identifies BGL-cli.exe
- BGL-tx resource now identifies BGL-tx.exe
- BGL-util resource now identifies BGL-util.exe
- BGL-wallet resource now identifies BGL-wallet.exe

The resource files were shifted across tools, so Windows file properties could show the wrong executable name/product metadata.

References #32.

## Verification

- Verified each touched resource file has matching InternalName, OriginalFilename, and ProductName values for its executable.
- `git diff --check`