### PR TITLE
doc: update Tor guide CLI command

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -25,7 +25,7 @@ CLI `-addrinfo` returns the number of addresses known to your node per
 network. This can be useful to see how many onion peers your node knows,
 e.g. for `-onlynet=onion`.
 
-You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run `bitcoin-cli help getnodeaddresses` for details.
+You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run BGL-cli help getnodeaddresses for details.
 
 ## 1. Run BGL Core behind a Tor proxy
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -25,7 +25,7 @@ CLI `-addrinfo` returns the number of addresses known to your node per
 network. This can be useful to see how many onion peers your node knows,
 e.g. for `-onlynet=onion`.
 
-You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run BGL-cli help getnodeaddresses for details.
+You can use the `getnodeaddresses` RPC to fetch a number of onion peers known to your node; run `BGL-cli help getnodeaddresses` for details.
 
 ## 1. Run BGL Core behind a Tor proxy
 


### PR DESCRIPTION
### Description
Updates the Tor guide to use the Bitgesell CLI name when pointing readers to getnodeaddresses help.

This keeps the document consistent with the surrounding BGL Core and BGLd references.

### Notes
Docs-only change.

### BTC/BGL PR reward address
To be provided if applicable.

Validation:
- git diff --check origin/master..fork/doc/fix-tor-cli-name

Refs #32