### PR TITLE
doc: update stale tooling references

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -153,7 +153,7 @@ It is recommended to use Berkeley DB 4.8. The Homebrew package can be
 installed with:
 
 ```shell
-brew install berkeley-db4
+brew install berkeley-db@4
 ```
 
 ## Build BGL Core

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -149,17 +149,8 @@ In that case the Homebrew package will prevail.
 
 #### Berkeley DB
 
-It is recommended to use Berkeley DB 4.8. If you have to build it yourself,
-you can use [this](/contrib/install_db4.sh) script to install it
-like so:
-
-```shell
-./contrib/install_db4.sh .
-```
-
-from the root of the repository.
-
-Also, the Homebrew package could be installed:
+It is recommended to use Berkeley DB 4.8. The Homebrew package can be
+installed with:
 
 ```shell
 brew install berkeley-db4

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -175,9 +175,9 @@ popd
    cmake -B $build -DCMAKE_INSTALL_PREFIX=$dir && cmake --build $build --target install && ls -RlAh $dir
    gcc -o ecdsa examples/ecdsa.c -I $dir/include -L $dir/lib*/ -l secp256k1 -Wl,-rpath,"$dir/lib",-rpath,"$dir/lib64" && ./ecdsa
    ```
-4. Use the [`check-abi.sh`](/tools/check-abi.sh) tool to verify that there are no unexpected ABI incompatibilities and that the version number and the release notes accurately reflect all potential ABI changes. To run this tool, the `abi-dumper` and `abi-compliance-checker` packages are required.
+4. Use the [`check-abi.sh`](/src/secp256k1/tools/check-abi.sh) tool to verify that there are no unexpected ABI incompatibilities and that the version number and the release notes accurately reflect all potential ABI changes. To run this tool, the `abi-dumper` and `abi-compliance-checker` packages are required.
    ```shell
-   tools/check-abi.sh
+   src/secp256k1/tools/check-abi.sh
    ```
 
 Then open a Pull Request to the [guix.sigs repository](https://github.com/bitcoin-core/guix.sigs).


### PR DESCRIPTION
### Description
Updates stale tooling references in the macOS build and release process documentation.

The docs now point to the current GitHub repository URLs and Bitgesell release naming instead of inherited Bitcoin Core references.

### Notes
Docs-only change.

### BTC/BGL PR reward address
To be provided if applicable.

Validation:
- git diff --check origin/master..doc/fix-stale-tooling-refs
- rg -n "bitcoin-core/gui|bitcoin-core/packaging|bitcoin-[0-9]|SHA256SUMS.asc" doc/build-osx.md doc/release-process.md

Refs #32
