### PR TITLE
doc: update secp256k1 documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ In addition, libsecp256k1 tries to maintain the following coding conventions:
     ```
 * Use `unsigned int` instead of just `unsigned`.
 * Use `void *ptr` instead of `void* ptr`.
-* Arguments of the publicly-facing API must have a specific order defined in [include/secp256k1.h](include/secp256k1.h).
+* Arguments of the publicly-facing API must have a specific order defined in [src/secp256k1/include/secp256k1.h](src/secp256k1/include/secp256k1.h).
 * User-facing comment lines in headers should be limited to 80 chars if possible.
 * All identifiers in file scope should start with `secp256k1_`.
 * Avoid trailing whitespace.
@@ -100,7 +100,7 @@ To create a HTML report with coloured and annotated source code:
 #### Exhaustive tests
 
 There are tests of several functions in which a small group replaces secp256k1.
-These tests are *exhaustive* since they provide all elements and scalars of the small group as input arguments (see [src/tests_exhaustive.c](src/tests_exhaustive.c)).
+These tests are *exhaustive* since they provide all elements and scalars of the small group as input arguments (see [src/secp256k1/src/tests_exhaustive.c](src/secp256k1/src/tests_exhaustive.c)).
 
 ### Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ In "Developer Command Prompt for VS 2022":
 
 Usage examples
 -----------
-Usage examples can be found in the [examples](examples) directory. To compile them you need to configure with `--enable-examples`.
-  * [ECDSA example](examples/ecdsa.c)
-  * [Schnorr signatures example](examples/schnorr.c)
-  * [Deriving a shared secret (ECDH) example](examples/ecdh.c)
+Usage examples can be found in the [examples](src/secp256k1/examples) directory. To compile them you need to configure with `--enable-examples`.
+  * [ECDSA example](src/secp256k1/examples/ecdsa.c)
+  * [Schnorr signatures example](src/secp256k1/examples/schnorr.c)
+  * [Deriving a shared secret (ECDH) example](src/secp256k1/examples/ecdh.c)
 
 To compile the Schnorr signature and ECDH examples, you also need to configure with `--enable-module-schnorrsig` and `--enable-module-ecdh`.
 


### PR DESCRIPTION
### Description
Updates stale secp256k1 documentation links.

The project already vendors secp256k1 under `src/secp256k1`; this points contributors and readers to the in-tree documentation instead of the old external Bitcoin Core path.

### Notes
Docs-only change.

### BTC/BGL PR reward address
To be provided if applicable.

Validation:
- git diff --check origin/master..doc/fix-secp256k1-doc-links
- rg -n "bitcoin-core/secp256k1|bitcoin-core/secp256k1/blob/master" README.md CONTRIBUTING.md

Refs #32
