### PR TITLE
test: normalize previous release binary names

### DIFF
--- a/test/get_previous_releases.py
+++ b/test/get_previous_releases.py
@@ -19,6 +19,13 @@ import subprocess
 import sys
 import hashlib
 
+PREVIOUS_RELEASE_BINARY_RENAMES = {
+    'bitcoind': 'BGLd',
+    'bitcoin-cli': 'BGL-cli',
+    'bitcoin-tx': 'BGL-tx',
+    'bitcoin-wallet': 'BGL-wallet',
+}
+
 SHA256_SUMS = {
     "0e2819135366f150d9906e294b61dff58fd1996ebd26c2f8e979d6c0b7a79580": {"tag": "v0.14.3", "tarball": "bitcoin-0.14.3-aarch64-linux-gnu.tar.gz"},
     "d86fc90824a85c38b25c8488115178d5785dbc975f5ff674f9f5716bc8ad6e65": {"tag": "v0.14.3", "tarball": "bitcoin-0.14.3-arm-linux-gnueabihf.tar.gz"},
@@ -92,6 +99,16 @@ def pushd(new_dir) -> None:
         os.chdir(previous_dir)
 
 
+def normalize_previous_release_binary_names(bin_path) -> None:
+    """Rename upstream Bitcoin binary names to the BGL names used by tests."""
+    bin_path = Path(bin_path)
+    for old_name, new_name in PREVIOUS_RELEASE_BINARY_RENAMES.items():
+        old_path = bin_path / old_name
+        new_path = bin_path / new_name
+        if old_path.exists() and not new_path.exists():
+            old_path.rename(new_path)
+
+
 def download_binary(tag, args) -> int:
     if Path(tag).is_dir():
         if not args.remove_dir:
@@ -150,6 +167,8 @@ def download_binary(tag, args) -> int:
     if ret != 0:
         print(f"Failed to extract the {tag} tarball")
         return ret
+
+    normalize_previous_release_binary_names(Path(tag) / 'bin')
 
     Path(tarball).unlink()
 
@@ -225,9 +244,15 @@ def build_release(tag, args) -> int:
         # Move binaries, so they're in the same place as in the
         # release download
         Path('bin').mkdir(exist_ok=True)
-        files = ['bitcoind', 'bitcoin-cli', 'bitcoin-tx']
+        files = [
+            *PREVIOUS_RELEASE_BINARY_RENAMES.keys(),
+            *PREVIOUS_RELEASE_BINARY_RENAMES.values(),
+        ]
         for f in files:
-            Path('src/'+f).rename('bin/'+f)
+            src_path = Path('src') / f
+            if src_path.exists():
+                src_path.rename(Path('bin') / f)
+        normalize_previous_release_binary_names('bin')
     return 0
 
 

--- a/test/util/get_previous_releases_test.py
+++ b/test/util/get_previous_releases_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026 The Bitgesell Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Unit tests for test/get_previous_releases.py helpers."""
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / 'get_previous_releases.py'
+SPEC = importlib.util.spec_from_file_location('get_previous_releases', SCRIPT_PATH)
+get_previous_releases = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(get_previous_releases)
+
+
+class GetPreviousReleasesTest(unittest.TestCase):
+    def test_normalizes_bitcoin_binary_names_to_bgl_names(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bin_path = Path(tmpdir)
+            for old_name in get_previous_releases.PREVIOUS_RELEASE_BINARY_RENAMES:
+                (bin_path / old_name).write_text('binary placeholder', encoding='utf8')
+
+            get_previous_releases.normalize_previous_release_binary_names(bin_path)
+
+            for old_name, new_name in get_previous_releases.PREVIOUS_RELEASE_BINARY_RENAMES.items():
+                self.assertFalse((bin_path / old_name).exists())
+                self.assertEqual((bin_path / new_name).read_text(encoding='utf8'), 'binary placeholder')
+
+    def test_does_not_overwrite_existing_bgl_binary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            bin_path = Path(tmpdir)
+            (bin_path / 'bitcoind').write_text('old binary', encoding='utf8')
+            (bin_path / 'BGLd').write_text('new binary', encoding='utf8')
+
+            get_previous_releases.normalize_previous_release_binary_names(bin_path)
+
+            self.assertEqual((bin_path / 'BGLd').read_text(encoding='utf8'), 'new binary')
+            self.assertEqual((bin_path / 'bitcoind').read_text(encoding='utf8'), 'old binary')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description
Normalize previous-release binaries extracted or built by `test/get_previous_releases.py` from upstream Bitcoin names to the Bitgesell names used by the functional test framework.

Without this, `--previous-releases` can populate `bin/bitcoind` and `bin/bitcoin-cli`, while the test framework looks for `bin/BGLd` and `bin/BGL-cli` for versioned nodes.

This adds a small helper plus unit coverage for the rename behavior.

### Validation
- `python test\util\get_previous_releases_test.py`
- `python -m py_compile test\get_previous_releases.py test\util\get_previous_releases_test.py`
- `python test\lint\lint-tests.py`
- `git diff --check`

Refs #32