### PR TITLE
Expand installation guide links

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,2 +1,28 @@
+# Installation
 
-See [doc/build-\*.md](/doc)
+Bitgesell Core can be built from source on Linux, macOS, Windows, and BSD systems. The platform-specific build guides in [`doc/`](doc) contain the required dependencies and detailed instructions.
+
+## Platform build guides
+
+- [Unix/Linux](doc/build-unix.md)
+- [macOS](doc/build-osx.md)
+- [Windows](doc/build-windows.md)
+- [FreeBSD](doc/build-freebsd.md)
+- [OpenBSD](doc/build-openbsd.md)
+- [NetBSD](doc/build-netbsd.md)
+
+## Quick source build
+
+On supported Unix-like systems, the usual autotools flow is:
+
+```sh
+./autogen.sh
+./configure
+make
+make check
+sudo make install
+```
+
+Run `./configure --help` to review optional build flags before compiling.
+
+For deterministic release builds and platform-specific dependency notes, use the relevant guide linked above.


### PR DESCRIPTION
## Summary
- Replace the placeholder INSTALL.md with a concise installation overview
- Link each platform-specific build guide from doc/
- Include the common autotools source build flow

## Testing
- Documentation-only change; no code tests run.

Refs #32