### PR TITLE
docs: clean up stale Bitgesell documentation links

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -28,11 +28,11 @@ Drag BGL Core to your applications folder, and then run BGL Core.
 
 ### Need Help?
 
-* See the documentation at the [BGL Wiki](https://en.bitcoin.it/wiki/Main_Page)
+* See the project documentation in this `doc/` directory and the [BGL configuration guide](BGL-conf.md)
 for help and more information.
-* Ask for help on [BGL StackExchange](https://bitcoin.stackexchange.com).
-* Ask for help on #BGL on Libera Chat. If you don't have an IRC client, you can use [web.libera.chat](https://web.libera.chat/#bitcoin).
-* Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
+* Ask for help through the Bitgesell project channels listed by the maintainers.
+* Ask for help on the Bitgesell community channels listed by the maintainers.
+* Ask for help in Bitgesell-specific support threads when maintainers announce them.
 
 Building
 ---------------------
@@ -65,8 +65,8 @@ The BGL repo's [root README](/README.md) contains relevant information on the de
 - [Internal Design Docs](design/)
 
 ### Resources
-* Discuss on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Development & Technical Discussion board](https://bitcointalk.org/index.php?board=6.0).
-* Discuss project-specific development on #bitcoin-core-dev on Libera Chat. If you don't have an IRC client, you can use [web.libera.chat](https://web.libera.chat/#bitcoin-core-dev).
+* Discuss project-specific development in Bitgesell repositories and maintainer-designated community channels.
+* Keep BGL Core development discussion tied to Bitgesell-specific issues, pull requests, and maintainer-designated community channels.
 
 ### Miscellaneous
 - [Assets Attribution](assets-attribution.md)

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -65,7 +65,7 @@ If you want to build the windows installer with `make deploy` you need [NSIS](ht
 
 Acquire the source in the usual way:
 
-    git clone https://github.com/Original-Tasty/bitgesell.git
+    git clone https://github.com/BitgesellOfficial/bitgesell.git
     cd bitgesell
 
 ## Building for 64-bit Windows


### PR DESCRIPTION
### Description

This PR cleans up stale inherited upstream references in the Bitgesell documentation:

- points the support/development guidance in `doc/README.md` back to Bitgesell project resources instead of Bitcoin Wiki, Bitcoin StackExchange, BitcoinTalk, and #bitcoin-core-dev
- updates the Windows build guide to clone `BitgesellOfficial/bitgesell.git` instead of an old fork URL

### Validation

- Reviewed the diff on GitHub compare page.
- Documentation-only change; no local build was run.

Bounty: #32