### PR TITLE
build: relax Debian runtime dependencies

### DIFF
--- a/debian.minimal/control
+++ b/debian.minimal/control
@@ -2,14 +2,14 @@ Source: bitgesell
 Section: misc
 Priority: optional
 Maintainer: Emma Wu <wuemma@protonmail.com>
-Build-Depends: debhelper (>=11~), g++-11, pkg-config, dh-autoreconf, libevent-dev, libssl-dev, fakeroot, wget
+Build-Depends: debhelper (>=11~), g++-11, pkg-config, dh-autoreconf, libevent-dev, libssl-dev, libsqlite3-dev, fakeroot, wget
 Standards-Version: 4.1.4
 Homepage: https://github.com/wu-emma/bitgesell
 
 Package: bitgesell
 Architecture: any
-Depends: libc6 (>= 2.27), libstdc++6 (>= 8.4.0), libbz2-1.0 (>= 1.0.6), liblzma5 (>= 5.2.2), zlib1g (>= 1:1.1.4), libsqlite3-dev,
- openssl, perl-modules-5.34, ${misc:Depends}
+Depends: libc6 (>= 2.27), libstdc++6 (>= 8.4.0), libbz2-1.0 (>= 1.0.6), liblzma5 (>= 5.2.2), zlib1g (>= 1:1.1.4), libsqlite3-0,
+ openssl, ${misc:Depends}
 Description: BGL is an experimental digital currency that enables instant payments to anyone, anywhere in the world
  BGL is an experimental digital currency that enables instant payments to anyone,
  anywhere in the world. BGL uses peer-to-peer technology to operate with no central authority:

--- a/debian.qt/control
+++ b/debian.qt/control
@@ -2,15 +2,15 @@ Source: bitgesell-qt
 Section: misc
 Priority: optional
 Maintainer: Mathias van Orton <it@bitgesell.ca>
-Build-Depends: debhelper (>=11~), g++-11, pkg-config, dh-autoreconf, libevent-dev, libssl-dev, fakeroot, wget
+Build-Depends: debhelper (>=11~), g++-11, pkg-config, dh-autoreconf, libevent-dev, libssl-dev, libsqlite3-dev, libqrencode-dev, fakeroot, wget
 Standards-Version: 4.1.4
 Homepage: https://github.com/wu-emma/bitgesell
 
 Package: bitgesell-qt
 Architecture: any
 Depends: libc6 (>= 2.27), libstdc++6 (>= 8.4.0), libbz2-1.0 (>= 1.0.6), liblzma5 (>= 5.2.2), zlib1g (>= 1:1.1.4),
- libqt5core5a (>= 5.9.5), libqt5dbus5 (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5gui5 (>= 5.9.5), libqrencode-dev, libsqlite3-dev,
- openssl, perl-modules-5.34, ${misc:Depends}
+ libqt5core5a (>= 5.9.5), libqt5dbus5 (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5gui5 (>= 5.9.5), libqrencode4, libsqlite3-0,
+ openssl, ${misc:Depends}
 Description: BGL is an experimental digital currency that enables instant payments to anyone, anywhere in the world
  BGL is an experimental digital currency that enables instant payments to anyone,
  anywhere in the world. BGL uses peer-to-peer technology to operate with no central authority:
@@ -20,7 +20,7 @@ Description: BGL is an experimental digital currency that enables instant paymen
 Package: bitgesell-qt-dbg
 Architecture: any
 Depends: libc6 (>= 2.27), libstdc++6 (>= 8.4.0), libbz2-1.0 (>= 1.0.6), liblzma5 (>= 5.2.2), zlib1g (>= 1:1.1.4),
- libqt5core5a (>= 5.9.5), libqt5dbus5 (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5gui5 (>= 5.9.5), libqrencode-dev, libsqlite3-dev,
+ libqt5core5a (>= 5.9.5), libqt5dbus5 (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5gui5 (>= 5.9.5), libqrencode4, libsqlite3-0,
  openssl, ${misc:Depends}
 Description: BGL is an experimental digital currency that enables instant payments to anyone, anywhere in the world
  BGL is an experimental digital currency that enables instant payments to anyone,


### PR DESCRIPTION
## Summary
- Move `libsqlite3-dev` out of runtime `Depends` and into `Build-Depends`; runtime packages now depend on `libsqlite3-0`.
- Remove the version-pinned `perl-modules-5.34` runtime dependency that blocks installation on newer Ubuntu releases.
- Use the runtime `libqrencode4` package for Qt binaries while keeping `libqrencode-dev` as a build dependency.

Fixes #357.

Bounty submission for the Bitgesell improvement/PR bounty program (#39 / #81). Payment details can be provided after maintainer review/approval.

## Validation
- Parsed `debian.minimal/control` and `debian.qt/control` to confirm binary `Depends` no longer include `perl-modules-5.34`, `libsqlite3-dev`, or `libqrencode-dev`.
- Parsed source `Build-Depends` to confirm the moved development packages remain available for package builds.
- `git diff --check`