### PR TITLE
test: fix format string lint runner

### DIFF
--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -40,6 +40,11 @@ FUNCTION_NAMES_AND_NUMBER_OF_LEADING_ARGUMENTS = [
     'WalletLogPrintf,0',
 ]
 RUN_LINT_FILE = 'test/lint/run-lint-format-strings.py'
+EXCLUDED_FILES_PATTERN = (
+    r'^src/(leveldb|secp256k1|minisketch|tinyformat|test/fuzz/strprintf\.cpp)'
+    r'|^src/precompute_ecmult_gen\.c$'
+    r'|^contrib/devtools/(bitcoin|BGL)-tidy/example_logprintf\.cpp$'
+)
 
 def check_doctest():
     command = [
@@ -82,15 +87,16 @@ def main():
 
         matching_files_filtered = []
         for matching_file in matching_files:
-            if not re.search('^src/(leveldb|secp256k1|minisketch|tinyformat|test/fuzz/strprintf.cpp)|contrib/devtools/bitcoin-tidy/example_logprintf.cpp', matching_file):
+            if not re.search(EXCLUDED_FILES_PATTERN, matching_file):
                 matching_files_filtered.append(matching_file)
         matching_files_filtered.sort()
 
         run_lint_args = [
-                    RUN_LINT_FILE,
-                    '--skip-arguments',
-                    skip_arguments,
-                    function_name,
+            sys.executable,
+            RUN_LINT_FILE,
+            '--skip-arguments',
+            skip_arguments,
+            function_name,
         ]
         run_lint_args.extend(matching_files_filtered)
 


### PR DESCRIPTION
Bounty submission for #32.

This makes `test/lint/lint-format-strings.py` runnable and green in this repository.

Changes:
- Invoke `run-lint-format-strings.py` through the active Python interpreter so the lint works on Windows as well as Unix-like shells.
- Move the excluded-file regex into a named pattern.
- Update the tidy example exclusion for Bitgesell's `contrib/devtools/BGL-tidy/example_logprintf.cpp` path.
- Exclude `src/precompute_ecmult_gen.c`, whose generated secp precompute formatter uses `PRIx32` literal concatenation plus macro-expanded comma-separated arguments that this static checker cannot model.

Verification:
- `python test\lint\lint-format-strings.py`
- `python -m py_compile test\lint\lint-format-strings.py test\lint\run-lint-format-strings.py`
- `git diff --check`

Payment details can be provided after maintainer approval.