### PR TITLE
doc: update Bitgesell issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,10 +5,10 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## This issue tracker is only for technical issues related to Bitcoin Core.
+        ## This issue tracker is only for technical issues related to BGL Core.
 
-        * General bitcoin questions and/or support requests should use Bitcoin StackExchange at https://bitcoin.stackexchange.com.
-        * For reporting security issues, please read instructions at https://bitcoincore.org/en/contact/.
+        * General Bitgesell questions and/or support requests should use the project website or community channels linked from https://bitgesell.ca/.
+        * For reporting security issues, please read the instructions in SECURITY.md.
         * If the node is "stuck" during sync or giving "block checksum mismatch" errors, please ensure your hardware is stable by running `memtest` and observe CPU temperature with a load-test tool such as `linpack` before creating an issue.
 
         ----
@@ -50,14 +50,14 @@ body:
       description: |
         Please copy and paste any relevant log output or attach a debug log file.
 
-        You can find the debug.log in your [data dir.](https://github.com/bitcoin/bitcoin/blob/master/doc/files.md#data-directory-location)
+        You can find the debug.log in your [data dir.](../../doc/files.md#data-directory-location)
 
         Please be aware that the debug log might contain personally identifying information.
     validations:
       required: false
   - type: dropdown
     attributes:
-      label: How did you obtain Bitcoin Core
+      label: How did you obtain BGL Core
       multiple: false
       options:
         - Compiled from source
@@ -69,8 +69,8 @@ body:
   - type: input
     id: core-version
     attributes:
-      label: What version of Bitcoin Core are you using?
-      description: Run `bitcoind --version` or in Bitcoin-QT use `Help > About Bitcoin Core`
+      label: What version of BGL Core are you using?
+      description: Run `BGLd --version` or in BGL-qt use `Help > About BGL Core`
       placeholder: e.g. v24.0.1 or master@e1bf547
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -5,11 +5,12 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please add the label "good first issue" manually before or after opening
+        Please add the label "good first issue" manually before or after opening.
 
-        A good first issue is an uncontroversial issue, that has a relatively unique and obvious solution
+        A good first issue is an uncontroversial issue with a relatively unique
+        and obvious solution.
 
-        Motivate the issue and explain the solution briefly
+        Motivate the issue and explain the solution briefly.
   - type: textarea
     id: motivation
     attributes:
@@ -28,9 +29,9 @@ body:
     id: useful-skills
     attributes:
       label: Useful Skills
-      description: For example, “`std::thread`”, “Qt5 GUI and async GUI design” or “basic understanding of Bitcoin mining and the Bitcoin Core RPC interface”.
+      description: For example, "`std::thread`", "Qt5 GUI and async GUI design", or "basic understanding of Bitgesell mining and the BGL Core RPC interface".
       value: |
-        * Compiling Bitcoin Core from source
+        * Compiling BGL Core from source
         * Running the C++ unit tests and the Python functional tests
         * ...
   - type: textarea
@@ -40,5 +41,4 @@ body:
       value: |
         Want to work on this issue?
 
-        For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md) before opening your pull request.
-
+        For guidance on contributing, please read [CONTRIBUTING.md](../../CONTRIBUTING.md) before opening your pull request.

--- a/.github/ISSUE_TEMPLATE/gui_issue.yml
+++ b/.github/ISSUE_TEMPLATE/gui_issue.yml
@@ -5,8 +5,8 @@ body:
 - type: checkboxes
   id: acknowledgement
   attributes:
-    label: Issues, reports or feature requests related to the GUI should be opened directly on the GUI repo
-    description: https://github.com/bitcoin-core/gui/issues/
+    label: Issues, reports or feature requests related to the BGL GUI
+    description: Use this template for BGL-qt reports that belong in the Bitgesell repository.
     options:
       - label: I still think this issue should be opened here
         required: true


### PR DESCRIPTION
### Description

Updates the GitHub issue templates so new reports point to Bitgesell/BGL Core resources instead of inherited Bitcoin Core locations.

This keeps the change limited to `.github/ISSUE_TEMPLATE` files and avoids touching runtime or consensus code.

### Notes

- Replaces Bitcoin Core wording in the bug report template with BGL Core wording.
- Points bug reporters to the local `SECURITY.md` and local `doc/files.md` instead of external Bitcoin Core pages.
- Updates the good-first-issue template to remove mojibake in the useful-skills examples and link to this repository's `CONTRIBUTING.md`.
- Updates the GUI issue template so BGL-qt reports stay in the Bitgesell repository instead of being redirected to the Bitcoin Core GUI tracker.

Validation:
- `git diff --check`
- Checked the edited templates for required issue-template keys (`name`, `description`, `labels`, `body`) and tab-free indentation.
- Confirmed the edited templates no longer contain Bitcoin Core/bitcoin-core issue tracker links.

### BTC/BGL PR reward address

Bounty issue: #39

Preferred payout: USDT ERC20 or BEP20/BSC to `0x185e250a54ced0d999cbc3280ca8481b35aa2ce0`