### PR TITLE
build: use generated Debian runtime dependencies

### DIFF
--- a/debian.minimal/control
+++ b/debian.minimal/control
@@ -8,8 +8,7 @@ Homepage: https://github.com/wu-emma/bitgesell
 
 Package: bitgesell
 Architecture: any
-Depends: libc6 (>= 2.27), libstdc++6 (>= 8.4.0), libbz2-1.0 (>= 1.0.6), liblzma5 (>= 5.2.2), zlib1g (>= 1:1.1.4), libsqlite3-dev,
- openssl, perl-modules-5.34, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: BGL is an experimental digital currency that enables instant payments to anyone, anywhere in the world
  BGL is an experimental digital currency that enables instant payments to anyone,
  anywhere in the world. BGL uses peer-to-peer technology to operate with no central authority:

--- a/debian.qt/control
+++ b/debian.qt/control
@@ -8,9 +8,7 @@ Homepage: https://github.com/wu-emma/bitgesell
 
 Package: bitgesell-qt
 Architecture: any
-Depends: libc6 (>= 2.27), libstdc++6 (>= 8.4.0), libbz2-1.0 (>= 1.0.6), liblzma5 (>= 5.2.2), zlib1g (>= 1:1.1.4),
- libqt5core5a (>= 5.9.5), libqt5dbus5 (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5gui5 (>= 5.9.5), libqrencode-dev, libsqlite3-dev,
- openssl, perl-modules-5.34, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: BGL is an experimental digital currency that enables instant payments to anyone, anywhere in the world
  BGL is an experimental digital currency that enables instant payments to anyone,
  anywhere in the world. BGL uses peer-to-peer technology to operate with no central authority:
@@ -19,9 +17,7 @@ Description: BGL is an experimental digital currency that enables instant paymen
 
 Package: bitgesell-qt-dbg
 Architecture: any
-Depends: libc6 (>= 2.27), libstdc++6 (>= 8.4.0), libbz2-1.0 (>= 1.0.6), liblzma5 (>= 5.2.2), zlib1g (>= 1:1.1.4),
- libqt5core5a (>= 5.9.5), libqt5dbus5 (>= 5.9.5), libqt5network5 (>= 5.9.5), libqt5gui5 (>= 5.9.5), libqrencode-dev, libsqlite3-dev,
- openssl, ${misc:Depends}
+Depends: bitgesell-qt (= ${binary:Version}), ${misc:Depends}
 Description: BGL is an experimental digital currency that enables instant payments to anyone, anywhere in the world
  BGL is an experimental digital currency that enables instant payments to anyone,
  anywhere in the world. BGL uses peer-to-peer technology to operate with no central authority:


### PR DESCRIPTION
### Description
Fixes #357 by removing version-locked and development package dependencies from the Debian runtime package metadata.

The Debian package rules already run `dh_shlibdeps`, so the binary packages should rely on generated runtime dependencies instead of hard-coding old Ubuntu-era package names.

Changes:
- `bitgesell` now uses `${shlibs:Depends}, ${misc:Depends}`.
- `bitgesell-qt` now uses `${shlibs:Depends}, ${misc:Depends}`.
- `bitgesell-qt-dbg` now depends on the matching `bitgesell-qt` binary package version.

This avoids install blockers such as `perl-modules-5.34` on newer Ubuntu releases and avoids pulling development packages such as `libsqlite3-dev` as runtime dependencies.

### Validation
- `git diff --check`
- Confirmed `debian.minimal/control` and `debian.qt/control` no longer contain `perl-modules-*` or `libsqlite3-dev` in `Depends`.
- Full Debian package build was not run in this Windows environment.

### Bounty payout
Related bounty program: #32

Preferred payout: USDT on ERC20 or BEP20/BSC to `0x185e250a54ced0d999cbc3280ca8481b35aa2ce0`.