### PR TITLE
doc: point release process at BGL tooling

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -7,8 +7,8 @@ Regular releases are releases of a new major or minor version as well as patches
 Maintenance releases, on the other hand, are required for patches of older releases.
 
 * Update release candidate version in `configure.ac` (`CLIENT_VERSION_RC`).
-* Update manpages (after rebuilding the binaries), see [gen-manpages.py](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/README.md#gen-manpagespy).
-* Update bitcoin.conf and commit changes if they exist, see [gen-bitcoin-conf.sh](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/README.md#gen-bitcoin-confsh).
+* Update manpages (after rebuilding the binaries), see [gen-manpages.py](../contrib/devtools/README.md#gen-manpagespy).
+* Update BGL.conf and commit changes if they exist, see [gen-BGL-conf.sh](../contrib/devtools/README.md#gen-BGL-confsh).
 
 This process also assumes that there will be no minor releases for old major releases.
 


### PR DESCRIPTION
Summary:
- Point the release-process manpage step at the local devtools README instead of upstream bitcoin/bitcoin.
- Rename the config refresh step from bitcoin.conf/gen-bitcoin-conf.sh to BGL.conf/gen-BGL-conf.sh.

Validation:
- `git diff --check`
- `rg -n gen-BGL-conf\.sh|gen-BGL-confsh|gen-manpagespy contrib\devtools\README.md doc\release-process.md`

Bounty context:
- Submitted under the open Bitgesell PR bounty hunt: https://github.com/BitgesellOfficial/bitgesell/issues/39
- Preferred payout if accepted/approved: USDT ERC20/BEP20 to 0xa3d7745af6E77ce825f0AF6DB94bA8073355E022